### PR TITLE
chore(flake/nixpkgs): `13e8d35b` -> `59e69648`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -188,11 +188,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753489912,
-        "narHash": "sha256-uDCFHeXdRIgJpYmtcUxGEsZ+hYlLPBhR83fdU+vbC1s=",
+        "lastModified": 1754028485,
+        "narHash": "sha256-IiiXB3BDTi6UqzAZcf2S797hWEPCRZOwyNThJIYhUfk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13e8d35b7d6028b7198f8186bc0347c6abaa2701",
+        "rev": "59e69648d345d6e8fef86158c555730fa12af9de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`59e69648`](https://github.com/NixOS/nixpkgs/commit/59e69648d345d6e8fef86158c555730fa12af9de) | `` ngrok 3.22.1 -> 3.25.0 ``                                                      |
| [`b1005019`](https://github.com/NixOS/nixpkgs/commit/b10050196b91ca93d859a85c390dc36baf5643c2) | `` ngrok 3.19.1 -> 3.22.1 ``                                                      |
| [`108ee18b`](https://github.com/NixOS/nixpkgs/commit/108ee18be52dc0aa642d6e65b58f0b58e7fb4ab9) | `` dts-lsp: init at 0.1.5 ``                                                      |
| [`63176f93`](https://github.com/NixOS/nixpkgs/commit/63176f93148b17eef5619aeb49e8e6e42e4cb752) | `` prosody: 0.12.4 -> 0.12.5 + community modules ``                               |
| [`0629d0a7`](https://github.com/NixOS/nixpkgs/commit/0629d0a7b5c0f99e83fc92962d95f44d443d409e) | `` filebot: fix mediainfo ``                                                      |
| [`202a4490`](https://github.com/NixOS/nixpkgs/commit/202a4490a1ce6fcdd292abb007696024750a7ff4) | `` vscode: 1.102.2 -> 1.102.3 ``                                                  |
| [`a8fe77ad`](https://github.com/NixOS/nixpkgs/commit/a8fe77ad21ef5481fff48a3505e553bf937dd7d6) | `` vieb: 12.3.0 -> 12.4.0 ``                                                      |
| [`d1c41c17`](https://github.com/NixOS/nixpkgs/commit/d1c41c17c1a94ffd81a79ceccc312f326b62e234) | `` Revert "invidious: 2.20250504.0 -> 2.20250517.0" ``                            |
| [`1e3f344f`](https://github.com/NixOS/nixpkgs/commit/1e3f344fb6d95779dd6ad8ee6d12eb27e6b58fbe) | `` opencode: 0.3.58 -> 0.3.85 ``                                                  |
| [`caae6231`](https://github.com/NixOS/nixpkgs/commit/caae6231d446a9119800f5f2d784692b7f2ebe73) | `` opencode: 3.51 -> 3.58 ``                                                      |
| [`3c82cb55`](https://github.com/NixOS/nixpkgs/commit/3c82cb559e33a8f69cf580646f0600bf76b292cf) | `` opencode: 0.3.43 -> 0.3.51 ``                                                  |
| [`159718da`](https://github.com/NixOS/nixpkgs/commit/159718da794a4840238c30049438240c9cfd7d6e) | `` opencode: 0.3.22 -> 0.3.43 ``                                                  |
| [`bcdd725c`](https://github.com/NixOS/nixpkgs/commit/bcdd725cbce540d4b33ea93d23f353fa9d005c77) | `` opencode: remove "models-dev-data" from updateScript subpackages ``            |
| [`381f7604`](https://github.com/NixOS/nixpkgs/commit/381f7604889d9bf2199fa1f397c93a9c1a7680ff) | `` opencode: 0.2.33 -> 0.3.22 ``                                                  |
| [`32f5e6c8`](https://github.com/NixOS/nixpkgs/commit/32f5e6c87ccf789b80740b0d21fc93a49cbc278e) | `` opencode: use `models-dev` package instead of fetching from online api ``      |
| [`299ae576`](https://github.com/NixOS/nixpkgs/commit/299ae57658dd8c3fe5506a1bc4720860b990e931) | `` models-dev: 0-unstable-2025-07-30 -> 0-unstable-2025-07-31 ``                  |
| [`3edd070f`](https://github.com/NixOS/nixpkgs/commit/3edd070f7c3f1db2edd4860b30e50f1d76e21767) | `` models-dev: move patches to top-level deviration ``                            |
| [`6c57939e`](https://github.com/NixOS/nixpkgs/commit/6c57939efd895e78a7094886cf0e7f6a53a06da3) | `` brave: 1.80.124 -> 1.80.125 ``                                                 |
| [`2ef9d50b`](https://github.com/NixOS/nixpkgs/commit/2ef9d50b8a085a5f8f1bef7f72d27a267615ff22) | `` ungoogled-chromium: 138.0.7204.168-1 -> 138.0.7204.183-1 ``                    |
| [`cbee154d`](https://github.com/NixOS/nixpkgs/commit/cbee154d0127461553531ec10273985671b81c02) | `` models-dev: 0-unstable-2025-07-29 -> 0-unstable-2025-07-30 ``                  |
| [`2743ffc3`](https://github.com/NixOS/nixpkgs/commit/2743ffc346a1c51b66feec0574f1a3f7e8cff76a) | `` models-dev: add patch to rename hashed index file back to index.html ``        |
| [`b9590ac5`](https://github.com/NixOS/nixpkgs/commit/b9590ac5f428add2b8cf21da67714b3732366cc5) | `` veloren: 0.16.0 -> 0.17.0 ``                                                   |
| [`0a674d09`](https://github.com/NixOS/nixpkgs/commit/0a674d09c038daeb76f7c20eb9286854a940696e) | `` models-dev: 0-unstable-2025-07-23 -> 0-unstable-2025-07-29 ``                  |
| [`a5d6022d`](https://github.com/NixOS/nixpkgs/commit/a5d6022d2fdba59870df8f7fae75371bc64d129b) | `` models-dev: 0-unstable-2025-07-16 -> 0-unstable-2025-07-23 ``                  |
| [`3f097b86`](https://github.com/NixOS/nixpkgs/commit/3f097b868cdd0dea04f7b8e48be2287b499af61f) | `` models-dev: 0-unstable-2025-07-14 -> 0-unstable-2025-07-16 ``                  |
| [`4e55890f`](https://github.com/NixOS/nixpkgs/commit/4e55890f2809a9e9d6a93fcc86ee5aaf0b02659f) | `` pnpm.configHook: prevent hard linking on file systems without clone support `` |
| [`7d447ae4`](https://github.com/NixOS/nixpkgs/commit/7d447ae4026643520e0d6eff0fc28f18c2545e93) | `` ci/OWNERS: reduce firefox package ownership ``                                 |
| [`83a09dbc`](https://github.com/NixOS/nixpkgs/commit/83a09dbc0c167f70ae742f02b2e2141a4766a788) | `` buildMozillaMach: restore macos sdk relax for 142 and later ``                 |
| [`5e5ce5fc`](https://github.com/NixOS/nixpkgs/commit/5e5ce5fcc7ab02447d37b4b6ddeb472a18cae5ed) | `` buildMozillaMach: migrate into build-support ``                                |
| [`43f3624b`](https://github.com/NixOS/nixpkgs/commit/43f3624b83fc74dbcececdf9069fa6af8c71be30) | `` servo: 0-unstable-2025-07-21 -> 0-unstable-2025-07-30 ``                       |
| [`a10ae85d`](https://github.com/NixOS/nixpkgs/commit/a10ae85d3a75a3312093f4c0d6481fa20c613eba) | `` nixos/tlsrpt: configure explicit http_script ``                                |
| [`d3709d58`](https://github.com/NixOS/nixpkgs/commit/d3709d58bcbfbe0a7431fd90e9d043f04e635daa) | `` linuxKernel.kernels.linux_lqx: 6.15.7 -> 6.15.8 ``                             |
| [`6ec91287`](https://github.com/NixOS/nixpkgs/commit/6ec9128789f9d87b7eb8bc47f1dfb0f97edc95d0) | `` chromium,chromedriver: 138.0.7204.168 -> 138.0.7204.183 ``                     |
| [`b3e25400`](https://github.com/NixOS/nixpkgs/commit/b3e25400ca539b50caeaef199c8ad5d4a87e04f9) | `` iperf3: 3.19 -> 3.19.1 ``                                                      |
| [`c2d2283f`](https://github.com/NixOS/nixpkgs/commit/c2d2283f414b5f19599a5ccf65d45dad789d3a45) | `` nixos/release-small: fix eval ``                                               |
| [`c7004bfd`](https://github.com/NixOS/nixpkgs/commit/c7004bfd752dbd54d1acd2c23294613925db7040) | `` google-chrome: 138.0.7204.168 -> 138.0.7204.183 ``                             |
| [`b928e7fb`](https://github.com/NixOS/nixpkgs/commit/b928e7fb85decd190c59b628a94e01ffa0156a36) | `` documentation: how to update librewolf-unwrapped ``                            |
| [`9136d60d`](https://github.com/NixOS/nixpkgs/commit/9136d60d02acb7a3173cb235c9a0f92c94edc3d4) | `` librewolf-unwrapped: 140.0.4-1 -> 141.0-1 ``                                   |
| [`a221c91d`](https://github.com/NixOS/nixpkgs/commit/a221c91d445e3424b8d381da8fe929d294384772) | `` dprint-plugins.dprint-plugin-typescript: 0.95.8 -> 0.95.9 ``                   |
| [`118bb7c0`](https://github.com/NixOS/nixpkgs/commit/118bb7c06b85cd13908418428691d976b0a32e4c) | `` dprint-plugins.dprint-plugin-typescript: 0.95.7 -> 0.95.8 ``                   |
| [`33cb0b9a`](https://github.com/NixOS/nixpkgs/commit/33cb0b9a2184fb04c6f251df60d11e5597d32493) | `` sudo: 1.9.17p1 -> 1.9.17p2 ``                                                  |
| [`04e4bcd5`](https://github.com/NixOS/nixpkgs/commit/04e4bcd5da34e8c06abb8912184d3815d20bd990) | `` wofi-power-menu: 0.2.9 -> 0.3.0 ``                                             |
| [`fdfedd21`](https://github.com/NixOS/nixpkgs/commit/fdfedd21bfa00fc1c159b3e8aa807520f5208ada) | `` python3Packages.mechanize: add patch for python 3.13 ``                        |
| [`cfcba627`](https://github.com/NixOS/nixpkgs/commit/cfcba627b6ed82dc8f255292213d2d8dc415decc) | `` tokei: 13.0.0-alpha.8 -> 13.0.0-alpha.9 ``                                     |
| [`350b3744`](https://github.com/NixOS/nixpkgs/commit/350b3744876fa15d5390dcfcebd144a231692b4f) | `` tokei: add defelo as maintainer ``                                             |
| [`f9d9343c`](https://github.com/NixOS/nixpkgs/commit/f9d9343c879f21e5413f593ff4f8059ecc6cafc3) | `` tokei: add nix-update-script ``                                                |
| [`85bb4e93`](https://github.com/NixOS/nixpkgs/commit/85bb4e931f645f611ff27f2ef626af803e357acb) | `` tokei: add versionCheckHook ``                                                 |
| [`92b16a82`](https://github.com/NixOS/nixpkgs/commit/92b16a82c89d1dc979ec801598ac76aff79d4e2c) | `` tokei: add meta.changelog ``                                                   |
| [`80ccef9a`](https://github.com/NixOS/nixpkgs/commit/80ccef9a0d1e42abbba0276a4faa692ea68ebfc8) | `` tokei: improve meta.description ``                                             |
| [`5577c667`](https://github.com/NixOS/nixpkgs/commit/5577c667c7d753cb70bff2540412b219e55a572b) | `` tokei: remove `with lib;` ``                                                   |
| [`00662008`](https://github.com/NixOS/nixpkgs/commit/00662008028b7a1d7a44156296aadeb7f1d01d40) | `` tokei: use tag and hash in fetchFromGitHub ``                                  |
| [`88f42580`](https://github.com/NixOS/nixpkgs/commit/88f425806e71c9f60f021e3be3c33ff89f712433) | `` tokei: use finalAttrs pattern ``                                               |
| [`b3095e2b`](https://github.com/NixOS/nixpkgs/commit/b3095e2b4edbde368b5eb319f11fcbcdf4c19f7f) | `` tokei: don't use pname in src ``                                               |
| [`7e5c9f4f`](https://github.com/NixOS/nixpkgs/commit/7e5c9f4fda4f47daebe0e47c5fca027dd6a90cf9) | `` blanket: 0.7.0 -> 0.8.0 ``                                                     |
| [`b6639d9b`](https://github.com/NixOS/nixpkgs/commit/b6639d9b3ea548d66cc87f5a9dca4fd89f5cfe6f) | `` nixos/tests/go-httpbin: init ``                                                |
| [`17847f67`](https://github.com/NixOS/nixpkgs/commit/17847f675ac0557173b9721ca2576cc1ef7d6e91) | `` nixos/go-httpbin: init module ``                                               |
| [`d1d00364`](https://github.com/NixOS/nixpkgs/commit/d1d0036409429e680772632b1ed3edd7353dfca3) | `` go-httpbin: init at 2.18.3 ``                                                  |
| [`045d4002`](https://github.com/NixOS/nixpkgs/commit/045d4002a8bebb5e728a07780b511db8f48ed0c8) | `` linux_xanmod, linux_xanmod_latest: add update script ``                        |
| [`60a26bb3`](https://github.com/NixOS/nixpkgs/commit/60a26bb3aeb2402f0f9412bac09716bb91853d46) | `` formats.xml: fix cross compilation ``                                          |
| [`13683ca7`](https://github.com/NixOS/nixpkgs/commit/13683ca7e3a3f136fdaacd2c746e81969eb7f611) | `` thunderbird-esr-bin-unwrapped: 140.0.1esr -> 140.1.0esr ``                     |
| [`d5378cec`](https://github.com/NixOS/nixpkgs/commit/d5378cec85f6e7ef3ed4c6db3d678b38f2aaa5f7) | `` nixos/systemd: fix run0 failing to run commands ``                             |
| [`43e3a3e8`](https://github.com/NixOS/nixpkgs/commit/43e3a3e85f81f9374195512955bdc499d3dae805) | `` floorp: 11.28.0 -> 11.29.0 ``                                                  |
| [`dcc19818`](https://github.com/NixOS/nixpkgs/commit/dcc198185311f430de40750c6c35ec8aa8cb1326) | `` python3Packages.buildstream-plugins: init at 2.4.0 ``                          |
| [`007eb35d`](https://github.com/NixOS/nixpkgs/commit/007eb35d91234f06047a627e74025cc93abf12ea) | `` nixos/tlsrpt: fix permissions to execute postdrop ``                           |
| [`c3246b01`](https://github.com/NixOS/nixpkgs/commit/c3246b01ba25b06c94ef946467af2203f59a381b) | `` nixos/tlsrpt: fix restart trigger ``                                           |
| [`6a90d84e`](https://github.com/NixOS/nixpkgs/commit/6a90d84e44cdb24afc7701e5c57fb8284443dae8) | `` nixos/tlsrpt: fix default postfix sendmail path ``                             |
| [`1f8c34b2`](https://github.com/NixOS/nixpkgs/commit/1f8c34b250fadc1c2b45ce38cac367a759f6b9d6) | `` sauerbraten: fix build ``                                                      |
| [`3e25ab90`](https://github.com/NixOS/nixpkgs/commit/3e25ab90e8b12255a3753925c05f39760fc85c79) | `` linux_xanmod_latest: 6.15.7 -> 6.15.8 ``                                       |
| [`f4203b33`](https://github.com/NixOS/nixpkgs/commit/f4203b335b687891f06e99d149ffe41e3c5f1889) | `` linux_xanmod: 6.12.39 -> 6.12.40 ``                                            |
| [`4b6268a3`](https://github.com/NixOS/nixpkgs/commit/4b6268a34bf5466c03900460817206e17b4e9564) | `` llvmPackages_git: 22.0.0-unstable-2025-07-20 -> 22.0.0-unstable-2025-07-28 ``  |
| [`d7d22d94`](https://github.com/NixOS/nixpkgs/commit/d7d22d94832f6334ea499d27d8f189c3c201a29b) | `` linux/common-config: enable new 6.16 features ``                               |
| [`9eca2364`](https://github.com/NixOS/nixpkgs/commit/9eca2364358b84e1098f01057a5a99d08d001c3d) | `` linux_6_16: init at 6.16 ``                                                    |
| [`b210d55d`](https://github.com/NixOS/nixpkgs/commit/b210d55d48bf74ad8a8b8a206fd577c0836658fb) | `` nixos/lib/test-driver: try using XDG_RUNTIME_DIR if available ``               |
| [`a6335244`](https://github.com/NixOS/nixpkgs/commit/a63352447478ae47dc08d46e60cf5a90069605dc) | `` miniflux: 2.2.10 -> 2.2.11 ``                                                  |
| [`161d9aef`](https://github.com/NixOS/nixpkgs/commit/161d9aef5a82d6142423e89aa916d85e3221833d) | `` mmctl: 10.5.8 -> 10.5.9 ``                                                     |
| [`b4718edb`](https://github.com/NixOS/nixpkgs/commit/b4718edb45772f2bbc98fcfe96162f0d7fcd48c5) | `` ustreamer: 6.31 -> 6.39 ``                                                     |
| [`70db00a1`](https://github.com/NixOS/nixpkgs/commit/70db00a101a56b8b4b17d7eb3799054276c487fc) | `` flyctl: 0.3.157 -> 0.3.161 ``                                                  |
| [`50ce7782`](https://github.com/NixOS/nixpkgs/commit/50ce77821aa904620f687d40d3dd483995136af5) | `` buffer: 0.10.0 -> 0.10.1 ``                                                    |
| [`d3c139fb`](https://github.com/NixOS/nixpkgs/commit/d3c139fb56fff091a1670eac7dc495667dcea241) | `` rustfinity: 0.2.13 -> 0.2.14 ``                                                |
| [`7e805bc0`](https://github.com/NixOS/nixpkgs/commit/7e805bc0e2e19d9d0e0f085b78869052a357ebd0) | `` rustfinity: remove useFetchCargoVendor usages ``                               |
| [`f63032fc`](https://github.com/NixOS/nixpkgs/commit/f63032fced3c39803ec18690e759099f1561a3f6) | `` outline: 0.85.0 -> 0.85.1 ``                                                   |
| [`ebb3620e`](https://github.com/NixOS/nixpkgs/commit/ebb3620e761b8cfe59f47f4997326d45ef8a96d5) | `` installer/nixos-generate-config: remove broadcom_sta ``                        |
| [`3fae474b`](https://github.com/NixOS/nixpkgs/commit/3fae474b46b914cd3f5d43e7af0e2e3defda5b90) | `` vscode: 1.102.1 -> 1.102.2 ``                                                  |
| [`3856b699`](https://github.com/NixOS/nixpkgs/commit/3856b699f3221dce6285b6dfe3d49ca7edccaa86) | `` postfix-tlspol: adopt package and module ``                                    |
| [`c50fcdd3`](https://github.com/NixOS/nixpkgs/commit/c50fcdd3131231ee0ba17317a5eb220d6cbef048) | `` nixos/postfix-tlspol: only preset dns resolver with useLocalResolver ``        |
| [`cd303ff4`](https://github.com/NixOS/nixpkgs/commit/cd303ff41b155aaa0b19ac6309e83220b3e01bc0) | `` postfix-tlspol: 1.8.11 -> 1.8.12 ``                                            |
| [`b29b1ffc`](https://github.com/NixOS/nixpkgs/commit/b29b1ffc562000f332ca53d90286a84102acd05d) | `` postfix-tlspol: 1.8.10 -> 1.8.11 ``                                            |
| [`ead9bfd3`](https://github.com/NixOS/nixpkgs/commit/ead9bfd3cf341b1f768e0f44e4cca547c682deb5) | `` postfix-tlspol: 1.8.9 -> 1.8.10 ``                                             |
| [`482dc4fb`](https://github.com/NixOS/nixpkgs/commit/482dc4fbf6ff998c1992c10693100e372598e5c3) | `` mdp: 1.0.17 -> 1.0.18 ``                                                       |
| [`810f9d66`](https://github.com/NixOS/nixpkgs/commit/810f9d6654d1a300ca742b78e77e7a7803bb4394) | `` mdp: 1.0.15 -> 1.0.17 ``                                                       |
| [`9701a002`](https://github.com/NixOS/nixpkgs/commit/9701a002c667f6cb748273fd363ef09c360a384e) | `` rectangle: 0.88 -> 0.89 ``                                                     |
| [`09e53f29`](https://github.com/NixOS/nixpkgs/commit/09e53f298d34219e1a29953a4983e629b32367a6) | `` rectangle: 0.87 -> 0.88 ``                                                     |
| [`1d86f62e`](https://github.com/NixOS/nixpkgs/commit/1d86f62edf801b01f1f2e0d05448ab86058783bc) | `` phel: 0.18.0 -> 0.18.1 ``                                                      |
| [`e7d3191a`](https://github.com/NixOS/nixpkgs/commit/e7d3191a4e6418514699bef71404fecc5cbe7ce8) | `` phel: 0.17.0 -> 0.18.0 ``                                                      |
| [`74a469b1`](https://github.com/NixOS/nixpkgs/commit/74a469b1ddb795f372d4f51438918730f8774680) | `` phel: 0.16.1 -> 0.17.0 ``                                                      |
| [`b734585a`](https://github.com/NixOS/nixpkgs/commit/b734585a64a7948bd5b2375b224557209beb87e5) | `` vivaldi: 7.5.3735.54 -> 7.5.3735.56 ``                                         |
| [`62d10f27`](https://github.com/NixOS/nixpkgs/commit/62d10f27acdea605ce72dedd3fca4326b8bb83ac) | `` wdisplays: 1.1.1 -> 1.1.3 ``                                                   |
| [`ab32e4ae`](https://github.com/NixOS/nixpkgs/commit/ab32e4aeb8ebd7ba2d4b3ff60d333099ed573215) | `` firefox-beta-unwrapped: 141.0b9 -> 142.0b3 ``                                  |
| [`1ca8f91c`](https://github.com/NixOS/nixpkgs/commit/1ca8f91cae9f2306c5a98e7c93d9ff6fdddd116c) | `` firefox-devedition-unwrapped: 141.0b9 -> 142.0b3 ``                            |
| [`cb2ab6ae`](https://github.com/NixOS/nixpkgs/commit/cb2ab6ae46e5d2ca594d203feb551c6bb55cd806) | `` firfox: limit apple sdk patch to versions below 142 ``                         |
| [`77fe0156`](https://github.com/NixOS/nixpkgs/commit/77fe0156510777aea64c4326556a40f78d531a2e) | `` ubootRadxaZero3W: init ``                                                      |
| [`42a17f8a`](https://github.com/NixOS/nixpkgs/commit/42a17f8a4f77ea64e88b350fed39d42875a8b574) | `` immich: 1.135.3 -> 1.136.0 ``                                                  |
| [`ec0f3e3d`](https://github.com/NixOS/nixpkgs/commit/ec0f3e3d93d68ee6a1ad2839121bc3bfa234697f) | `` microsoft-edge: 138.0.3351.95 -> 138.0.3351.109 ``                             |
| [`b5ce7e8b`](https://github.com/NixOS/nixpkgs/commit/b5ce7e8be4312c01e19284eb9fcca7dd7fe8230a) | `` ed-odyssey-materials-helper: 2.178 -> 2.199 and fixes ``                       |
| [`a6dd04d2`](https://github.com/NixOS/nixpkgs/commit/a6dd04d237ac8bf079c86dc4eb02589b8fe02db1) | `` elastic: 0.1.6 -> 0.1.9 ``                                                     |
| [`1f7c3f60`](https://github.com/NixOS/nixpkgs/commit/1f7c3f60c26c62ed70042d32fae49a006d6a84a5) | `` bustle: 0.11.0 -> 0.12.0 ``                                                    |
| [`b7ca8825`](https://github.com/NixOS/nixpkgs/commit/b7ca8825a9dc85008a3e593bc17aa3d24b872154) | `` slack: 4.44.65 -> 4.45.64 ``                                                   |
| [`b59b26cf`](https://github.com/NixOS/nixpkgs/commit/b59b26cfec4f02b768a3b35177110ea91d686c55) | `` thunderbird-latest-bin-unwrapped: 140.0.1 -> 141.0 ``                          |
| [`451ed55d`](https://github.com/NixOS/nixpkgs/commit/451ed55d3a78e9d20b87b91a13c43b6a974dbd55) | `` kubectl: 1.33.2 -> 1.33.3 ``                                                   |
| [`46444338`](https://github.com/NixOS/nixpkgs/commit/46444338ac14ccbace9ec46cdf10b56e19ac0b78) | `` kubectl: 1.33.1 -> 1.33.2 ``                                                   |
| [`625d7a4f`](https://github.com/NixOS/nixpkgs/commit/625d7a4f962e51de684f5362a3c1f6db712912db) | `` kubernetes: 1.33.0 -> 1.33.1 ``                                                |
| [`216496c7`](https://github.com/NixOS/nixpkgs/commit/216496c7b14e0f09d933cebdf301f4693c577f1a) | `` forgejo: 12.0.0 -> 12.0.1 ``                                                   |
| [`58f94672`](https://github.com/NixOS/nixpkgs/commit/58f9467253c9cfd66061bc296a384f2d3b7f0fdd) | `` homepage-dashboard: dashboard-icons: 2025-01-06 -> 2025-07-11 ``               |
| [`abf57e52`](https://github.com/NixOS/nixpkgs/commit/abf57e52904b9323bd9891b6c128e14945e8e844) | `` homepage-dashboard: fix enableLocalIcons = true build ``                       |
| [`da40ac7d`](https://github.com/NixOS/nixpkgs/commit/da40ac7d807ae1b658f6bc545647900f266d9b5a) | `` filebrowser: 2.36.0 -> 2.40.1 ``                                               |
| [`e0adac3c`](https://github.com/NixOS/nixpkgs/commit/e0adac3c5c12a5783cdd2aea3480356b9f1aca2b) | `` ghost-cli: 1.27.0 -> 1.27.1 ``                                                 |
| [`cda6299e`](https://github.com/NixOS/nixpkgs/commit/cda6299e3b7dc710e4abb0ecd202477eea9d5580) | `` pixelflasher: 8.0.1.0 -> 8.0.3.1 ``                                            |
| [`879f518a`](https://github.com/NixOS/nixpkgs/commit/879f518a630e93449007039ea1604eb6cd837580) | `` mesa.disallowedRequisites: avoid `null` values ``                              |
| [`e867ce87`](https://github.com/NixOS/nixpkgs/commit/e867ce876e6f80529ddf1a5dc54dcbd9d0513f6b) | `` nextcloud-spreed-signaling: init at 2.0.3 (#392811) ``                         |
| [`ad280700`](https://github.com/NixOS/nixpkgs/commit/ad2807007b3e2fe58f903d257c18788dc3f1c85b) | `` systemd.disallowedReferences: avoid `null` values, really ``                   |
| [`f432d7fe`](https://github.com/NixOS/nixpkgs/commit/f432d7fea7ecf184c1b0d2152deacf860e1f67c2) | `` rtorrent: fix version hash mismatch and modernize package ``                   |
| [`23c6adf8`](https://github.com/NixOS/nixpkgs/commit/23c6adf8039d90493f39e1755f8c80108f4017b1) | `` weechat-unwrapped: 4.6.3 -> 4.7.0 ``                                           |
| [`04c7347b`](https://github.com/NixOS/nixpkgs/commit/04c7347bf85b3ed6f6e44a3c90d0c7e54b3dcbc1) | `` models-dev: 0-unstable-2025-07-12 -> 0-unstable-2025-07-14 ``                  |
| [`c84f162e`](https://github.com/NixOS/nixpkgs/commit/c84f162e000188a91e32ac0d301c5c33bf1d9fce) | `` models-dev: init at 0-unstable-2025-07-12 ``                                   |
| [`fe05a302`](https://github.com/NixOS/nixpkgs/commit/fe05a30281696db68f12d7f3f500c98f3a4fe893) | `` systemd.disallowedReferences: avoid `null` values ``                           |
| [`ee8333f7`](https://github.com/NixOS/nixpkgs/commit/ee8333f7cbd11697e6ab6d109a4423fb7218887c) | `` gerrit: 3.11.3 -> 3.11.4 ``                                                    |
| [`771fd391`](https://github.com/NixOS/nixpkgs/commit/771fd3915d2015efd4009e21162a76ec4ff8efa1) | `` signal-desktop: 7.61.0 -> 7.62.0 ``                                            |