### PR TITLE
chore(flake/nur): `dd4cad69` -> `4de6ec34`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -225,11 +225,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754132989,
-        "narHash": "sha256-wOCYEwSknCri0+Rp77VNTUqdfiKDO9W6P0iG5vmIB8o=",
+        "lastModified": 1754319480,
+        "narHash": "sha256-Q2sQCiGrQ80bPdD2b8xrjKXEr+frwDP7Oa5LtgRqiy8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd4cad690f1ada34910930d9f8786f67db2d534d",
+        "rev": "4de6ec34385c2fdd449989fc3751586caaf1dc12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4de6ec34`](https://github.com/nix-community/NUR/commit/4de6ec34385c2fdd449989fc3751586caaf1dc12) | `` automatic update `` |
| [`4fd336ea`](https://github.com/nix-community/NUR/commit/4fd336ea2027e65609bbf1f1f960053fdd3d7d6b) | `` automatic update `` |
| [`65583f6d`](https://github.com/nix-community/NUR/commit/65583f6d80b5fa36ce4c36dc1b5d0e87646203d5) | `` automatic update `` |
| [`c6f06c79`](https://github.com/nix-community/NUR/commit/c6f06c7960982b40be721ccad3a4c295fce4d14d) | `` automatic update `` |
| [`9edce8ab`](https://github.com/nix-community/NUR/commit/9edce8ab128c10d6c351e6bdb76c35b45b3da03c) | `` automatic update `` |
| [`629c088c`](https://github.com/nix-community/NUR/commit/629c088cd24558335707f0ffc4445a501860526a) | `` automatic update `` |
| [`8904db8f`](https://github.com/nix-community/NUR/commit/8904db8f3fa90585e30d63438a4761093183def9) | `` automatic update `` |
| [`928298aa`](https://github.com/nix-community/NUR/commit/928298aa0c7f999bfb1b6d9144c3ead9950c2e24) | `` automatic update `` |
| [`21b30ae3`](https://github.com/nix-community/NUR/commit/21b30ae3758c009a38d06cd9a2612f4d0510db3b) | `` automatic update `` |
| [`acb75d1f`](https://github.com/nix-community/NUR/commit/acb75d1ff9859de4c865e5f7d1fe0ce284c146dc) | `` automatic update `` |
| [`51e85207`](https://github.com/nix-community/NUR/commit/51e8520755b0aa19a5087adb4d6f64ac853d58c1) | `` automatic update `` |
| [`c102500b`](https://github.com/nix-community/NUR/commit/c102500b607096d0f6d0f58233f5acede71ef2ad) | `` automatic update `` |
| [`3dc0c2d2`](https://github.com/nix-community/NUR/commit/3dc0c2d2f50ed9bbceae12663cf717fd99302ab5) | `` automatic update `` |
| [`000670bb`](https://github.com/nix-community/NUR/commit/000670bb45791adb06aeebda248d592771db17b7) | `` automatic update `` |
| [`23ddc4fb`](https://github.com/nix-community/NUR/commit/23ddc4fb08730fcf5e3f059bfcc431c2e3bef380) | `` automatic update `` |
| [`17dc92a5`](https://github.com/nix-community/NUR/commit/17dc92a5f1b7c5d00210ba90902f724a257c168d) | `` automatic update `` |
| [`8c427d70`](https://github.com/nix-community/NUR/commit/8c427d70e197cb0cd8399b94be48d3d0de0f29a9) | `` automatic update `` |
| [`85507c59`](https://github.com/nix-community/NUR/commit/85507c596d47bad37cb7a5684d1b4a854eb79e82) | `` automatic update `` |
| [`47eb5ad2`](https://github.com/nix-community/NUR/commit/47eb5ad2bb1b0fa39d6dc9a76d1b65011a361084) | `` automatic update `` |
| [`39c9fa97`](https://github.com/nix-community/NUR/commit/39c9fa97816651dbab8346b9c035eace782ed283) | `` automatic update `` |
| [`9d64b05c`](https://github.com/nix-community/NUR/commit/9d64b05c0c6de5273cb062353eb5c85ee40ef0d2) | `` automatic update `` |
| [`1b6750af`](https://github.com/nix-community/NUR/commit/1b6750af45d6d96ae2ffeb230ec86502ff903ea8) | `` automatic update `` |
| [`6f2328a6`](https://github.com/nix-community/NUR/commit/6f2328a65015c49b8d571f7e64867edd107c854c) | `` automatic update `` |
| [`cad5bfc3`](https://github.com/nix-community/NUR/commit/cad5bfc318415cce7eb14e4894304e876ee1f499) | `` automatic update `` |
| [`12821441`](https://github.com/nix-community/NUR/commit/12821441dfa7ce212b0729f4d28fe4de53cfc8fc) | `` automatic update `` |
| [`cd5404b6`](https://github.com/nix-community/NUR/commit/cd5404b6d5bfdd7681e67f9b6eaf5584df2d8429) | `` automatic update `` |
| [`6b3e77a1`](https://github.com/nix-community/NUR/commit/6b3e77a1939e61dc9367d9d7432806133e511e69) | `` automatic update `` |
| [`f88a0ce8`](https://github.com/nix-community/NUR/commit/f88a0ce823243512ce9566629725ee358742453e) | `` automatic update `` |
| [`7245e4a7`](https://github.com/nix-community/NUR/commit/7245e4a766b4d0145f6f6e39bdcf04ee1e448a44) | `` automatic update `` |
| [`0b5269c5`](https://github.com/nix-community/NUR/commit/0b5269c51fd7390229018b2a8d42cf09239c50e2) | `` automatic update `` |
| [`c9be8e14`](https://github.com/nix-community/NUR/commit/c9be8e142c0f9c8b4b646e680f9b149f712a9c2d) | `` automatic update `` |
| [`285e74e7`](https://github.com/nix-community/NUR/commit/285e74e783265bced277fa3a377240f356b2f921) | `` automatic update `` |
| [`c049dbec`](https://github.com/nix-community/NUR/commit/c049dbec5702da57a2fd3aae2f96b8d886359938) | `` automatic update `` |
| [`d7134c0f`](https://github.com/nix-community/NUR/commit/d7134c0f424be69b011eb26bccf2f575b300c5d1) | `` automatic update `` |
| [`dbd17f07`](https://github.com/nix-community/NUR/commit/dbd17f07b63f5fc630ff9d3b5b832636259ac8e8) | `` automatic update `` |
| [`e5bde1a7`](https://github.com/nix-community/NUR/commit/e5bde1a7291282d444412ac22b4e2f153ce73993) | `` automatic update `` |
| [`eb10594c`](https://github.com/nix-community/NUR/commit/eb10594c0da5cb09f3ad687461d1979e5f054c6c) | `` automatic update `` |
| [`0b030e85`](https://github.com/nix-community/NUR/commit/0b030e85aa15ae9e0236cc1799a0d644ccc14a11) | `` automatic update `` |
| [`c2eb35aa`](https://github.com/nix-community/NUR/commit/c2eb35aafdd6e61f37728bce5f64d76148646f70) | `` automatic update `` |
| [`d0d88edc`](https://github.com/nix-community/NUR/commit/d0d88edcefcb823d4de2343814d6004f428b5db8) | `` automatic update `` |
| [`993ed205`](https://github.com/nix-community/NUR/commit/993ed205326b2180c8d4967018cd0ceed807d372) | `` automatic update `` |
| [`ca0cf0af`](https://github.com/nix-community/NUR/commit/ca0cf0af08e03a609607974e226a36d09d88e299) | `` automatic update `` |
| [`621a7cbd`](https://github.com/nix-community/NUR/commit/621a7cbd7b44f418f539e00d79f7aab91f8e5fdf) | `` automatic update `` |
| [`46103880`](https://github.com/nix-community/NUR/commit/46103880eb8597fc262062e790f6e4959c07f9a5) | `` automatic update `` |
| [`bae772f3`](https://github.com/nix-community/NUR/commit/bae772f319b57b76ca819c4b599cdb4c075466ce) | `` automatic update `` |
| [`28de4c84`](https://github.com/nix-community/NUR/commit/28de4c8457d178e18de85f4b4ba647fbd3fc123d) | `` automatic update `` |