### PR TITLE
chore(flake/nixpkgs-unstable): `5b09dc45` -> `c2ae88e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1754214453,
-        "narHash": "sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY=",
+        "lastModified": 1754498491,
+        "narHash": "sha256-erbiH2agUTD0Z30xcVSFcDHzkRvkRXOQ3lb887bcVrs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b09dc45f24cf32316283e62aec81ffee3c3e376",
+        "rev": "c2ae88e026f9525daf89587f3cbee584b92b6134",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`326f3fbd`](https://github.com/NixOS/nixpkgs/commit/326f3fbdea986e53bef7b1f429eb7f5304f35217) | `` jetbrains.plugins: update ``                                                        |
| [`59d5c3a8`](https://github.com/NixOS/nixpkgs/commit/59d5c3a830b592763720e1f70d98aafd1af30dd1) | `` jetbrains: 2025.1.4 -> 2025.2.1 ``                                                  |
| [`7e8ec0b2`](https://github.com/NixOS/nixpkgs/commit/7e8ec0b2ec8e8c616d508018340524480e4a3e89) | `` gate: 0.51.0 -> 0.52.0 ``                                                           |
| [`af749a3a`](https://github.com/NixOS/nixpkgs/commit/af749a3a10ae188cc37debe4ece84cdf9ee1a6a7) | `` nixos/open-webui: try to fix the database readonly issue ``                         |
| [`8a030400`](https://github.com/NixOS/nixpkgs/commit/8a030400a22cc6fcde5b54af148d0d3b688b9449) | `` python3Packages.snakemake-interface-report-plugins: 1.1.1 -> 1.2.0 ``               |
| [`f2648b26`](https://github.com/NixOS/nixpkgs/commit/f2648b263b69aecca529c14fd5441503850a7c0d) | `` workflows/eval: disable swap ``                                                     |
| [`77aebee8`](https://github.com/NixOS/nixpkgs/commit/77aebee8aca22eb9ce0992a875cfe36dbdcbf23b) | `` nixos/repart-verity-store: fix cross ``                                             |
| [`20d5adac`](https://github.com/NixOS/nixpkgs/commit/20d5adacc79bb83c2a17c80855aa970d218e84c1) | `` vimPlugins.demicolon-nvim: init at 2025-04-25 ``                                    |
| [`a07a5df7`](https://github.com/NixOS/nixpkgs/commit/a07a5df79564534831e8f94ab0c875f2a91004f1) | `` nest-cli: 11.0.8 -> 11.0.10 ``                                                      |
| [`51345f34`](https://github.com/NixOS/nixpkgs/commit/51345f343a93f16b0a752ab07030859a10af3541) | `` open-policy-agent: fix opa 1.6.0 build on darwin (#423747) ``                       |
| [`ffb03c81`](https://github.com/NixOS/nixpkgs/commit/ffb03c81d204c090768024f76424d7bb05113577) | `` cargo-tauri: unbreak test app ``                                                    |
| [`76fcdf42`](https://github.com/NixOS/nixpkgs/commit/76fcdf42745b4034eae512a5f61e6389160dd96a) | `` claude-code: 1.0.67 -> 1.0.69 (#431362) ``                                          |
| [`68fe4744`](https://github.com/NixOS/nixpkgs/commit/68fe474447444aee679af03a63435f7390abdaf2) | `` magma: cleanup ``                                                                   |
| [`0aac58e8`](https://github.com/NixOS/nixpkgs/commit/0aac58e8d28a1e67f5451ab2038cbfb7f68fb947) | `` magma: move to by-name ``                                                           |
| [`dbb02214`](https://github.com/NixOS/nixpkgs/commit/dbb02214c92e61783940e3de2dd2ad76d9466d0c) | `` apache-jena: widened linux to unix compatability ``                                 |
| [`6c5f7adf`](https://github.com/NixOS/nixpkgs/commit/6c5f7adf5360eacb5320b5763d2996400d843880) | `` ollama: 0.11.0 -> 0.11.3 ``                                                         |
| [`1648103c`](https://github.com/NixOS/nixpkgs/commit/1648103cba75ac083f1e63376684f9b668c1d927) | `` hyprls: 0.7.0 -> 0.8.0 ``                                                           |
| [`1026b0d5`](https://github.com/NixOS/nixpkgs/commit/1026b0d5fb73139d9239b07d3dcd12365f38d9ea) | `` namespace-cli: 0.0.433 -> 0.0.434 ``                                                |
| [`c3a108d3`](https://github.com/NixOS/nixpkgs/commit/c3a108d3cddfac32eedbc3c1d707ce1f38a927fd) | `` sgt-puzzles: 20250722.dbe6378 -> 20250730.a7c7826 ``                                |
| [`8ee7cb99`](https://github.com/NixOS/nixpkgs/commit/8ee7cb99fb78981733c64e2e0c60b957261843f0) | `` ocamlPackages.ppx_deriving: propagate `ppxlib` dependency ``                        |
| [`11ef0d0e`](https://github.com/NixOS/nixpkgs/commit/11ef0d0e5e6f9bbb40cda8728aeaea744169cfc2) | `` linuxPackages.perf: remove perl dependency ``                                       |
| [`6b31fb00`](https://github.com/NixOS/nixpkgs/commit/6b31fb007c01b8c2a37e08ce929f896630b51d89) | `` python3Packages.knx-frontend: 2025.7.23.50952 -> 2025.8.6.52906 ``                  |
| [`b0075b9e`](https://github.com/NixOS/nixpkgs/commit/b0075b9ee1e8ab9fbfc91ec0f7b5f07dae814673) | `` gitlab-triage: move to by-name ``                                                   |
| [`88bb828a`](https://github.com/NixOS/nixpkgs/commit/88bb828acff512233085baf9159e19cf9c84cc97) | `` home-assistant: update component packages ``                                        |
| [`84ceb1eb`](https://github.com/NixOS/nixpkgs/commit/84ceb1eb71bb70eca7822682c2305d1fa1912d80) | `` python313Packages.london-tube-status: init at 0.6.1 ``                              |
| [`174bac31`](https://github.com/NixOS/nixpkgs/commit/174bac31abd00b2575111387247b2a652a5a4a3c) | `` inspec: move to by-name ``                                                          |
| [`630305f8`](https://github.com/NixOS/nixpkgs/commit/630305f8532a742638b0b0e0aee79f1052c7f073) | `` inspec: remove with lib ``                                                          |
| [`a4eecb09`](https://github.com/NixOS/nixpkgs/commit/a4eecb097601b1ad337ec540fefbf6d67a911970) | `` wayland-bongocat: add versionCheckHook ``                                           |
| [`a8e01cd2`](https://github.com/NixOS/nixpkgs/commit/a8e01cd2c530acfdc23d1baf6a7b3f3e56388c96) | `` fzf: 0.65.0 -> 0.65.1 ``                                                            |
| [`cb66c5af`](https://github.com/NixOS/nixpkgs/commit/cb66c5af0d35563d917776d88efe7b830233c212) | `` vimPlugins.avante-nvim: 0.0.27-unstable-2025-07-28 -> 0.0.27-unstable-2025-08-06 `` |
| [`5b52e5e0`](https://github.com/NixOS/nixpkgs/commit/5b52e5e0a807182c33ca84f558f56beacd33f975) | `` wdt: 1.27.1612021-unstable-2025-07-23 -> 1.27.1612021-unstable-2025-08-01 ``        |
| [`1801d091`](https://github.com/NixOS/nixpkgs/commit/1801d091567773478c4cdfa96f19faeb788464ba) | `` _1password-gui: 8.11.2 -> 8.11.4 ``                                                 |
| [`15676a82`](https://github.com/NixOS/nixpkgs/commit/15676a826be0e836a008bb7982b1eda8d815d743) | `` python3Packages.subliminal: add meta.mainProgram ``                                 |
| [`74587eb6`](https://github.com/NixOS/nixpkgs/commit/74587eb6453c97874c32a5407415200895a441c7) | `` buildMozillaMach: adjust macos sdk patch range ``                                   |
| [`6fe8527c`](https://github.com/NixOS/nixpkgs/commit/6fe8527c2c8c4a776d92e2bc1d4fa9119fe93025) | `` renode-dts2repl: 0-unstable-2025-07-24 -> 0-unstable-2025-08-01 ``                  |
| [`467bcafe`](https://github.com/NixOS/nixpkgs/commit/467bcafe13e422eea20aaa39d263d5847dd5d027) | `` zed-editor: 0.197.5 -> 0.197.6 ``                                                   |
| [`c206e6c1`](https://github.com/NixOS/nixpkgs/commit/c206e6c1b19118f0695b5ed488582728ccf40e7b) | `` libretro.flycast: 0-unstable-2025-07-11 -> 0-unstable-2025-08-01 ``                 |
| [`cb87b383`](https://github.com/NixOS/nixpkgs/commit/cb87b383763150caa2669edcb497059aea21dd1e) | `` blackfire: 2.28.29 -> 2.28.31 ``                                                    |
| [`75b93d13`](https://github.com/NixOS/nixpkgs/commit/75b93d13c1622e4af6c896b510f98b97a2c4deb7) | `` containerlab: 0.69.1 -> 0.69.2 ``                                                   |
| [`093d9ba2`](https://github.com/NixOS/nixpkgs/commit/093d9ba28cdcde43d760df1d5e8ea581f5e64a08) | `` nvidia-container-toolkit: add meta.mainProgram ``                                   |
| [`483efb8d`](https://github.com/NixOS/nixpkgs/commit/483efb8d130f4a3c016efed33f2221aff24f95c4) | `` nvidia-container-toolkit: remove unused arguments ``                                |
| [`dd202c00`](https://github.com/NixOS/nixpkgs/commit/dd202c0000adc766df73a41ca01473fa7326c8af) | `` github-mcp-server: 0.9.0 -> 0.10.0 ``                                               |
| [`11c885dc`](https://github.com/NixOS/nixpkgs/commit/11c885dcfe58162e688d72c2c59e94adab24ad6f) | `` firefox-bin-unwrapped: 141.0 -> 141.0.2 ``                                          |
| [`7b133bd3`](https://github.com/NixOS/nixpkgs/commit/7b133bd32c56beaa26e8851b37c3846e37aebb6e) | `` firefox-unwrapped: 141.0 -> 141.0.2 ``                                              |
| [`5dd1a9f8`](https://github.com/NixOS/nixpkgs/commit/5dd1a9f85d71cd8f074e06e3f36894c7d7487a5c) | `` xdg-desktop-portal-termfilechooser: 1.1.1 -> 1.2.0 ``                               |
| [`40df29bd`](https://github.com/NixOS/nixpkgs/commit/40df29bdec83a4bd02e99f33b1a8b780ebfe5e7b) | `` emmylua-check: init at 0.10.0 ``                                                    |
| [`4161d870`](https://github.com/NixOS/nixpkgs/commit/4161d8709a432b0c1a197974298470945e1daf7d) | `` emmylua-ls: init at 0.10.0 ``                                                       |
| [`baf11af5`](https://github.com/NixOS/nixpkgs/commit/baf11af5712566cf9266df4c372469cd74fbb981) | `` python3Packages.transformers: 4.54.1 -> 4.55.0 ``                                   |
| [`0707e2bc`](https://github.com/NixOS/nixpkgs/commit/0707e2bc3f5ad7aa6d28607fa397042600beab8d) | `` emmylua-doc-cli: init at 0.10.0 ``                                                  |
| [`7c5249c0`](https://github.com/NixOS/nixpkgs/commit/7c5249c0f4174e7425f5068f2c334ba05db44ca7) | `` audacity: 3.7.4 -> 3.7.5 ``                                                         |
| [`1c3b10e0`](https://github.com/NixOS/nixpkgs/commit/1c3b10e04b7ff1948b5a3eda3d33547506fb8fee) | `` blockbench: 4.12.5 -> 4.12.6 ``                                                     |
| [`59c5ecb3`](https://github.com/NixOS/nixpkgs/commit/59c5ecb3137311049fa6021bbb8675111bcc15f8) | `` tmuxPlugins.tokyo-night-tmux: update to 1.6.6 ``                                    |
| [`f55bd281`](https://github.com/NixOS/nixpkgs/commit/f55bd2818a02778e7b6469f8c432c64da6d01f0f) | `` esphome: 2025.7.4 -> 2025.7.5 ``                                                    |
| [`0eaa94fe`](https://github.com/NixOS/nixpkgs/commit/0eaa94fe18f74f4841bd1169c14dccabfc837d6b) | `` vimPlugins.sonarlint-nvim: 0-unstable-2025-05-30 -> 0-unstable-2025-08-02 ``        |
| [`1870d825`](https://github.com/NixOS/nixpkgs/commit/1870d82500150236626b2ebfebeffa85361a789a) | `` Simplify definitions of libcs ``                                                    |
| [`aad64d42`](https://github.com/NixOS/nixpkgs/commit/aad64d42397fe135bec8e9caf6005c2e05dd6863) | `` chromium,chromedriver: 138.0.7204.183 -> 139.0.7258.66 ``                           |
| [`ba4e30cb`](https://github.com/NixOS/nixpkgs/commit/ba4e30cb287ec51ef130a113219d137fc7f64566) | `` squid: Include missing file in installPhase, log_file_daemon ``                     |
| [`ee9c359b`](https://github.com/NixOS/nixpkgs/commit/ee9c359b5aae154fbdbda28e243e51ca170f2bb3) | `` kdePackages: Plasma 6.4.3 -> 6.4.4 ``                                               |
| [`93a72b31`](https://github.com/NixOS/nixpkgs/commit/93a72b31a24253b2a2615038a183ee0c2a82acdb) | `` lunatask: 2.1.3 -> 2.1.5 ``                                                         |
| [`41fc0bab`](https://github.com/NixOS/nixpkgs/commit/41fc0babd1368111d083282c0026b13d5d13e766) | `` tinymist: 0.13.18 -> 0.13.20 ``                                                     |
| [`7181b4fc`](https://github.com/NixOS/nixpkgs/commit/7181b4fc2c9fb5d305f86f3b04de062105eb6c4d) | `` vscode-extensions.vscode-icons-team.vscode-icons: 12.13.0 -> 12.14.0 ``             |
| [`77dd5cfe`](https://github.com/NixOS/nixpkgs/commit/77dd5cfe73bb0c41ad618dfbbe52b08315cb65d8) | `` python3Packages.libuuu: 1.5.202 -> 1.5.220 ``                                       |
| [`49a95e44`](https://github.com/NixOS/nixpkgs/commit/49a95e445e8f29b6f60cfca13b7d86d809b71264) | `` ollama: fix source hash for version 0.11.0 ``                                       |
| [`deef2074`](https://github.com/NixOS/nixpkgs/commit/deef2074f14559dd1ac62d57347ea7a047efac19) | `` gleam: 1.11.1 -> 1.12.0 ``                                                          |
| [`55fda3e3`](https://github.com/NixOS/nixpkgs/commit/55fda3e3db3c9a0c2d16ba77ca75eaf2d7e3519a) | `` python3Packages.openai: 1.97.1 -> 1.99.0 ``                                         |
| [`abe860e8`](https://github.com/NixOS/nixpkgs/commit/abe860e8d220dbe92b11ce6334571d1a147ff050) | `` ollama: 0.10.0 -> 0.11.0 ``                                                         |
| [`38e72a1c`](https://github.com/NixOS/nixpkgs/commit/38e72a1ce2b4b6f2ac860a6c946070dcbf252cfe) | `` android-studio: 2025.1.1.14 -> 2025.1.2.11 ``                                       |
| [`4f2ad9dc`](https://github.com/NixOS/nixpkgs/commit/4f2ad9dcdaa60d1354af8e7a73e6c86fe90b45d3) | `` grimblast: 0.1-unstable-2025-07-18 -> 0.1-unstable-2025-07-23 ``                    |
| [`ddaa16d8`](https://github.com/NixOS/nixpkgs/commit/ddaa16d8249cdd8ef1b6e6800ee792fd3ae878d9) | `` magma: cleanup package ``                                                           |
| [`2e17dc78`](https://github.com/NixOS/nixpkgs/commit/2e17dc7815f5b2e07a39654b0c1d34152fa8e980) | `` tiddit: avoid conflicts between different python version. ``                        |
| [`47b39dc9`](https://github.com/NixOS/nixpkgs/commit/47b39dc9dc6207a71bda81381828f3cf63d58565) | `` lux-cli: 0.11.1 -> 0.13.0 ``                                                        |
| [`a15b5632`](https://github.com/NixOS/nixpkgs/commit/a15b56326474d2359a89d0904f356fdaa9d694a8) | `` files-cli: 2.15.61 -> 2.15.70 ``                                                    |
| [`fd01b94c`](https://github.com/NixOS/nixpkgs/commit/fd01b94c9457740b5601bc92666d820635c61ced) | `` phoenixd: 0.6.1 -> 0.6.2 ``                                                         |
| [`a7b3b258`](https://github.com/NixOS/nixpkgs/commit/a7b3b2584a7b9f204f634714fe9fbe3a3965b06c) | `` ci/treefmt: add markdown-code-runner ``                                             |
| [`bc5fb869`](https://github.com/NixOS/nixpkgs/commit/bc5fb869bb6d461d31d346e69c3c42fbe4d24375) | `` python3Packages.sipsimple: init at 5.3.3.2 ``                                       |
| [`fed181fa`](https://github.com/NixOS/nixpkgs/commit/fed181fac11b376fc242c4805b91d852902fbc35) | `` nixos/doc/modular-services: run nixfmt on code blocks ``                            |
| [`76e70e84`](https://github.com/NixOS/nixpkgs/commit/76e70e845b0281005675e3ae7be5666a08e06468) | `` tigerbeetle: 0.16.51 -> 0.16.53 ``                                                  |
| [`d3caafc3`](https://github.com/NixOS/nixpkgs/commit/d3caafc32f68040ba90848d73555c8ed304af02d) | `` nixos/doc/mailman: fix syntax in code block ``                                      |
| [`a1496641`](https://github.com/NixOS/nixpkgs/commit/a14966419ea624c53bff9386099995e1d590bdbd) | `` ladybird: 0-unstable-2025-06-27 -> 0-unstable-2025-08-04 ``                         |
| [`368351fc`](https://github.com/NixOS/nixpkgs/commit/368351fc7485bce9153555e49f871df2c26a7090) | `` ladybird: add jk as a maintainer ``                                                 |
| [`f0f66a31`](https://github.com/NixOS/nixpkgs/commit/f0f66a31130a510c7886472e8ab39e58d939316b) | `` ladybird: reduce use of with lib ``                                                 |
| [`24d85e24`](https://github.com/NixOS/nixpkgs/commit/24d85e24db23bd1b4797f63a64b8dea3dbd2aca1) | `` lagrange: 1.18.5 -> 1.18.6 ``                                                       |
| [`9afb2f32`](https://github.com/NixOS/nixpkgs/commit/9afb2f32447b14a3d462a58a90899b7effa4d064) | `` kid3-{cli-kde-qt}: move to by-name to reduce evaluation overhead ``                 |
| [`441d3336`](https://github.com/NixOS/nixpkgs/commit/441d33367b3d813ea5c24dedbc9de44862843f39) | `` clouddrive2: 0.9.1 -> 0.9.4 ``                                                      |
| [`22ae0b20`](https://github.com/NixOS/nixpkgs/commit/22ae0b20d009c3228d863d0c495302e64eabf8e1) | `` ocamlPackages.jsont: flags to turn off optional dependencies ``                     |
| [`3fc72d28`](https://github.com/NixOS/nixpkgs/commit/3fc72d286c51962d0a0deffc29d23bcd9fe30bed) | `` ocamlPackages.elpi: 2.0.7 -> 3.0.1 ``                                               |
| [`f6936f8c`](https://github.com/NixOS/nixpkgs/commit/f6936f8c488515acf371cc482144b412a1f571ba) | `` sketchybar-app-font: 2.0.39 -> 2.0.40 ``                                            |
| [`8e5b9fab`](https://github.com/NixOS/nixpkgs/commit/8e5b9fab8cf69678e849f3d13a94da6150b9635c) | `` python3Packages.librosa: disable failing tests on aarch64-darwin ``                 |
| [`c0b287b2`](https://github.com/NixOS/nixpkgs/commit/c0b287b2ecf47b85dc13d213926cbd75f67acac2) | `` luaPackages: update on 2025-08-05 ``                                                |
| [`0aac3599`](https://github.com/NixOS/nixpkgs/commit/0aac35997c9a51f31a210294117da29d456310b3) | `` python3Packages.vllm: mark as broken ``                                             |