### PR TITLE
chore(flake/nur): `dacefaca` -> `ebb2bbd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754919665,
-        "narHash": "sha256-LiABWkHPyjaLvI82zNB9R9SDnL008MqPdzEms4VDvsU=",
+        "lastModified": 1754931080,
+        "narHash": "sha256-BFozHBLSeTVmOM4HWeFepNtllO9jIRHm3i6HAPjGOtw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dacefaca6d7c2ae8fea96a103705c78bd5919133",
+        "rev": "ebb2bbd65bec6297aab1ddfa171e691a69406530",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ebb2bbd6`](https://github.com/nix-community/NUR/commit/ebb2bbd65bec6297aab1ddfa171e691a69406530) | `` automatic update `` |
| [`d22a1e6f`](https://github.com/nix-community/NUR/commit/d22a1e6fd730b61f083caddc71a3430952117d2e) | `` automatic update `` |
| [`562c625b`](https://github.com/nix-community/NUR/commit/562c625b7d509e75a150849b0e9738d5e7d64aa7) | `` automatic update `` |