### PR TITLE
chore(flake/nur): `3efcaa18` -> `109080b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755017634,
-        "narHash": "sha256-pgH8wqjXQmIshC7zy5lImEd6tK1cmS/telTW3fXDOdg=",
+        "lastModified": 1755031278,
+        "narHash": "sha256-flnsYgfvL6qeoKZpcB7YIAuWO3HUaXq1bBKN4Mgu+DA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3efcaa18559af47fa3937b8aeee532cd6aebf354",
+        "rev": "109080b61db30927ac762cf1a941a56901cb9362",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`109080b6`](https://github.com/nix-community/NUR/commit/109080b61db30927ac762cf1a941a56901cb9362) | `` automatic update `` |
| [`5605ae42`](https://github.com/nix-community/NUR/commit/5605ae42a0824cde6d03ce8561d9cffcd52c820d) | `` automatic update `` |
| [`363c40d5`](https://github.com/nix-community/NUR/commit/363c40d586969af6f8d3d3dc96d5399f1d6c3039) | `` automatic update `` |
| [`ad765c55`](https://github.com/nix-community/NUR/commit/ad765c55d31435f3c924e6de6e323ed42898d144) | `` automatic update `` |
| [`29c41b16`](https://github.com/nix-community/NUR/commit/29c41b16b571a8136f9698e5a618f274dc5e0d4c) | `` automatic update `` |
| [`4b88d3e2`](https://github.com/nix-community/NUR/commit/4b88d3e2d10698b8b29acc266fdb6c8de1d487d3) | `` automatic update `` |
| [`59d250ea`](https://github.com/nix-community/NUR/commit/59d250ea29e5dad471529df45d442487488fd960) | `` automatic update `` |
| [`07914798`](https://github.com/nix-community/NUR/commit/0791479892a59dfeb999b1ac96d7b0613f6f5495) | `` automatic update `` |