### PR TITLE
chore(flake/nur): `94c6c5b9` -> `178b145b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1755027561,
-        "narHash": "sha256-IVft239Bc8p8Dtvf7UAACMG5P3ZV+3/aO28gXpGtMXI=",
+        "lastModified": 1755186698,
+        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "005433b926e16227259a1843015b5b2b7f7d1fc3",
+        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755102471,
-        "narHash": "sha256-ecWsZvrU/v7phSRIulxUYoCZ+i8s+mQ0ecmxxcgHUko=",
+        "lastModified": 1755264546,
+        "narHash": "sha256-Wn+dwZGh/IH2PksY0hdGYMim7TX5j7tBpyG79FpmYa8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "94c6c5b9798480dc220ee2cc8b1ce93a472a8d8f",
+        "rev": "178b145b2210ac79b885fb424cc40a4026960bd3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                                  |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`178b145b`](https://github.com/nix-community/NUR/commit/178b145b2210ac79b885fb424cc40a4026960bd3) | `` automatic update ``                                                   |
| [`e14f2525`](https://github.com/nix-community/NUR/commit/e14f2525d5d9babbf4bc502a2d8c8f11e950d887) | `` fix: switch from depricated distutils copy_tree to shutil.copytree `` |
| [`f9405aa9`](https://github.com/nix-community/NUR/commit/f9405aa9ca638b2f404e3858cddc3ac2aba87e8e) | `` fix: add new reqs for buildPythonApplication ``                       |
| [`63ecfbb5`](https://github.com/nix-community/NUR/commit/63ecfbb53d0c5f60d7bddda868c8fa5ce334a056) | `` fix: update flake.lock ``                                             |
| [`5c8a819a`](https://github.com/nix-community/NUR/commit/5c8a819ad59f2be3fa0b84f603e9ce637f836dcf) | `` automatic update ``                                                   |