### PR TITLE
chore(flake/catppuccin): `bd14b474` -> `a2ef20ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1755247639,
-        "narHash": "sha256-YBjSqGgNAejwIIqUv+NTYpm+peXLro79qNBi0SF1JqM=",
+        "lastModified": 1755334713,
+        "narHash": "sha256-Nxq+mi6aqEbJA4R7i4TLr68ANuIgnEo2aKzJKRYd11s=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "bd14b47481c996e2a5d5e5704d55092edf18e892",
+        "rev": "a2ef20ed6fb921073c2d1b1929447c3bd88f595e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                               |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`a2ef20ed`](https://github.com/catppuccin/nix/commit/a2ef20ed6fb921073c2d1b1929447c3bd88f595e) | `` fix(home-manager/freetube): fix theme setting formatting (#693) `` |