### PR TITLE
chore(flake/chaotic): `fdcdc42e` -> `11e2c380`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1755288426,
-        "narHash": "sha256-Ppsg77kOV4bstSOIw7xt7+pIODfbUH3ud3FNFOjm0xE=",
+        "lastModified": 1755341625,
+        "narHash": "sha256-1M7Ewf416zZ+P2TYDfcZqbeym8qgRWAaWslYDGzVgWI=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "fdcdc42efa880f79839734490f46a9f545ade4e1",
+        "rev": "11e2c38094f84f4ed8193fe68fb0bb37f3158de1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                                         |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`11e2c380`](https://github.com/chaotic-cx/nyx/commit/11e2c38094f84f4ed8193fe68fb0bb37f3158de1) | `` qtile_git: adopt upstream changes ``                                                         |
| [`20cfda0c`](https://github.com/chaotic-cx/nyx/commit/20cfda0c8368bd7e27b4d86a8729b679b540a809) | `` vulkanPackages_latest: adopt known-good glslang and spirv ``                                 |
| [`10ff4293`](https://github.com/chaotic-cx/nyx/commit/10ff429387de2f9b286ec6cc5feba1a9abb12f99) | `` Revert "telegram-desktop-unwrapped_git: 20250809114408-0bc59a8 -> 20250813071938-192a56e" `` |
| [`a934d507`](https://github.com/chaotic-cx/nyx/commit/a934d5079e1edd3ea66c6a32305d61b43bdad32b) | `` Revert "openmohaa_git: 20250803002135-a72bc15 -> 20250813212004-2821102" ``                  |
| [`5ce0ac85`](https://github.com/chaotic-cx/nyx/commit/5ce0ac85d15dc116da402ba063e0f1e7a2f07b54) | `` qtile_git: drop patches ``                                                                   |
| [`c1ce9d66`](https://github.com/chaotic-cx/nyx/commit/c1ce9d668af26d485b096bed3b1ca670eb3cf7a0) | `` mesa_git: fmt ``                                                                             |
| [`827d6c5c`](https://github.com/chaotic-cx/nyx/commit/827d6c5c989427bee18bd3a9bc038e75969ad012) | `` openrgb_git: fix ``                                                                          |
| [`9704092b`](https://github.com/chaotic-cx/nyx/commit/9704092b7d25b14487aa04232f4c88169e764219) | `` openmohaa_git: add new dependencies ``                                                       |
| [`34d3b9c6`](https://github.com/chaotic-cx/nyx/commit/34d3b9c6dfe0c34cbd14fdd59a4409bbc262db79) | `` conduwuit_git: nuke ``                                                                       |
| [`8190e278`](https://github.com/chaotic-cx/nyx/commit/8190e278ff0ab6b46812b3568d476367dcc8d014) | `` mesa_git: new dep ``                                                                         |