### PR TITLE
chore(flake/nur): `544bd042` -> `ffaa7d51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755423035,
-        "narHash": "sha256-oqWm9uPNiBJgO/LfJK7xKKbfSySBq5nwn/WOaXTPimM=",
+        "lastModified": 1755436015,
+        "narHash": "sha256-Y0o6py+h0+5CtWs/fJQOLaIMwCsOjDBZ5SeaE1VJ5N8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "544bd04284061e2f14c6a2f9cb4e22f67ed91727",
+        "rev": "ffaa7d5185910bfaeda1cfed7ad441809f7d890a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                    |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`ffaa7d51`](https://github.com/nix-community/NUR/commit/ffaa7d5185910bfaeda1cfed7ad441809f7d890a) | `` automatic update ``                     |
| [`199390e7`](https://github.com/nix-community/NUR/commit/199390e7082f9307578531d389cccd9f37412156) | `` automatic update ``                     |
| [`18f6b5dd`](https://github.com/nix-community/NUR/commit/18f6b5ddf1bba18d84f94805d9dc9d567fc83ed8) | `` Add `shymega/nixfigs-nur` repository `` |
| [`9cb965e7`](https://github.com/nix-community/NUR/commit/9cb965e70913b9bceeb98bdd4bcac6d5ff8208af) | `` add theutz repo ``                      |
| [`742afc9c`](https://github.com/nix-community/NUR/commit/742afc9cde4ad99575e198d216d87fcb56550e21) | `` automatic update ``                     |
| [`c68bcdd6`](https://github.com/nix-community/NUR/commit/c68bcdd607b76ff3be2d4499fa7cef7ca217c552) | `` automatic update ``                     |
| [`56901ad1`](https://github.com/nix-community/NUR/commit/56901ad16f4ac75c3e6d41b77df7b1f28235d35b) | `` automatic update ``                     |
| [`c4bef509`](https://github.com/nix-community/NUR/commit/c4bef50946bc456245fbeb1775deabbd98f8a538) | `` automatic update ``                     |