### PR TITLE
chore(flake/chaotic): `018c0eea` -> `958ba486`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1755416648,
-        "narHash": "sha256-fOCzR+Ymt7K0N3wExttJAR+cMEWFpda3FscV5gL6DUo=",
+        "lastModified": 1755444192,
+        "narHash": "sha256-9eVUtk3ces32aJpHnsrO49UJNvMKNMxlV7NeNSAADLo=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "018c0eeafe5eb58ed2164f2628d6843b28053a64",
+        "rev": "958ba486ee73019e3820b9ebd97a38660f736f40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message            |
| ----------------------------------------------------------------------------------------------- | ------------------ |
| [`958ba486`](https://github.com/chaotic-cx/nyx/commit/958ba486ee73019e3820b9ebd97a38660f736f40) | `` nix_git: fix `` |