### PR TITLE
chore(flake/nur): `b12cf912` -> `c9b5183d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755463657,
-        "narHash": "sha256-zlwwq8sVyIs/i3unqtQEqRXFVIxaFzxtjGEAnNQjUsc=",
+        "lastModified": 1755488311,
+        "narHash": "sha256-MMbwPy6KICdO3QZALd0eia7AVWI/fby6Z/8zvo/ziDU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b12cf912ef3f7d899cb78f3865c6f22befaca3ad",
+        "rev": "c9b5183d6cdc240ae1be35ff3d663e48e9082c7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c9b5183d`](https://github.com/nix-community/NUR/commit/c9b5183d6cdc240ae1be35ff3d663e48e9082c7c) | `` automatic update `` |
| [`8066f6e8`](https://github.com/nix-community/NUR/commit/8066f6e84ee60aeafcd065b3985dfba645a37c04) | `` automatic update `` |
| [`c84dc544`](https://github.com/nix-community/NUR/commit/c84dc544a6717d7e1202a343e4d0e141ed41e2b4) | `` automatic update `` |
| [`ba8a68a0`](https://github.com/nix-community/NUR/commit/ba8a68a07b1cca8063b0473db7274c6e88ca5d53) | `` automatic update `` |
| [`baa6cf15`](https://github.com/nix-community/NUR/commit/baa6cf1524463c1178af1e37de51be461c17d7ce) | `` automatic update `` |