### PR TITLE
chore(flake/nur): `c9b5183d` -> `87da8eac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755488311,
-        "narHash": "sha256-MMbwPy6KICdO3QZALd0eia7AVWI/fby6Z/8zvo/ziDU=",
+        "lastModified": 1755500531,
+        "narHash": "sha256-Wr+g1k/3O8+aOVf0zT0UnkykpOxiQzM80hAgEm6UNck=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c9b5183d6cdc240ae1be35ff3d663e48e9082c7c",
+        "rev": "87da8eac6792f86f1e379d8e736cd389ad8c528e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`87da8eac`](https://github.com/nix-community/NUR/commit/87da8eac6792f86f1e379d8e736cd389ad8c528e) | `` automatic update `` |
| [`aead3597`](https://github.com/nix-community/NUR/commit/aead3597dc7d5ff31370ed23c9c495f3ad23967b) | `` automatic update `` |
| [`c5558f60`](https://github.com/nix-community/NUR/commit/c5558f60a136c1a8baab803825730395a5bc64d7) | `` automatic update `` |
| [`866180ae`](https://github.com/nix-community/NUR/commit/866180ae918e4a3b571d74365812d04e009ba68b) | `` automatic update `` |
| [`f93211cd`](https://github.com/nix-community/NUR/commit/f93211cdcacac341c4069641946170c07926bed2) | `` automatic update `` |