### PR TITLE
chore(flake/nur): `87da8eac` -> `9e8d3978`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755500531,
-        "narHash": "sha256-Wr+g1k/3O8+aOVf0zT0UnkykpOxiQzM80hAgEm6UNck=",
+        "lastModified": 1755509835,
+        "narHash": "sha256-jzsGYRF9kTvdvPZ6l6iYbvTubx3lpaUfLs9c3AZIehI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "87da8eac6792f86f1e379d8e736cd389ad8c528e",
+        "rev": "9e8d3978cd27d891095096bf73ce6a02a7c77819",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9e8d3978`](https://github.com/nix-community/NUR/commit/9e8d3978cd27d891095096bf73ce6a02a7c77819) | `` automatic update `` |
| [`9d7ed81d`](https://github.com/nix-community/NUR/commit/9d7ed81d81918c3856c9951589692ee6a64a03d8) | `` automatic update `` |
| [`75dc5103`](https://github.com/nix-community/NUR/commit/75dc5103f9b798265c650d0120e0dc0186c25005) | `` automatic update `` |