### PR TITLE
chore(flake/catppuccin): `eef43ff8` -> `ca11a19d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1755508644,
-        "narHash": "sha256-0Csi3sDOlisRUmjM6fACBthFCe1yX6KlxWVYtTsSy6M=",
+        "lastModified": 1755511413,
+        "narHash": "sha256-cBBF+nwGrSroN6ZewHPFaSThyCvwBxSZMdYEH8DxDx8=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "eef43ff875e3630e8237d1840422053275c71644",
+        "rev": "ca11a19d4e1d2ba5e6162f40cb71288551fd51dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                              |
| ----------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`ca11a19d`](https://github.com/catppuccin/nix/commit/ca11a19d4e1d2ba5e6162f40cb71288551fd51dd) | `` chore: sort module list (#698) `` |