### PR TITLE
chore(flake/nixpkgs): `ad7196ae` -> `48f4c982`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1755274400,
-        "narHash": "sha256-rTInmnp/xYrfcMZyFMH3kc8oko5zYfxsowaLv1LVobY=",
+        "lastModified": 1755471983,
+        "narHash": "sha256-axUoWcm4cNQ36jOlnkD9D40LTfSQgk8ExfHSRm3rTtg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ad7196ae55c295f53a7d1ec39e4a06d922f3b899",
+        "rev": "48f4c982de68d966421d2b6f1ddbeb6227cc5ceb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`f27601ae`](https://github.com/NixOS/nixpkgs/commit/f27601ae633100f6885b80a9aaea5178212868c4) | `` dendrite: 0.14.1 -> 0.15.2 ``                                   |
| [`bea14b39`](https://github.com/NixOS/nixpkgs/commit/bea14b398164fe58d56765fb42e2f104545cf79d) | `` oauth2-proxy: add versionCheckHook ``                           |
| [`3bb1a139`](https://github.com/NixOS/nixpkgs/commit/3bb1a139984a5951920e63f3e4c0d9ee12daaea4) | `` oauth2-proxy: 7.9.0 -> 7.11.0 ``                                |
| [`848b832b`](https://github.com/NixOS/nixpkgs/commit/848b832be1421f4fe3a4936fce39655e7c554be3) | `` oauth2-proxy: 7.8.2 -> 7.9.0 ``                                 |
| [`a745a9d0`](https://github.com/NixOS/nixpkgs/commit/a745a9d0a99541dc0417bf53e9bb7a8c214dce11) | `` lighttpd: 1.4.79 -> 1.4.80 ``                                   |
| [`2f8b346d`](https://github.com/NixOS/nixpkgs/commit/2f8b346d472d13e9c2c3de55fd9d5aa9bb79aca5) | `` [release-25.05] gerrit: 3.11.4 -> 3.11.5 ``                     |
| [`c59471e1`](https://github.com/NixOS/nixpkgs/commit/c59471e10c0a212b3e24d7ddc5053a44dd6c719e) | `` microsoft-edge: 139.0.3405.86 -> 139.0.3405.102 ``              |
| [`900b315d`](https://github.com/NixOS/nixpkgs/commit/900b315dc571652d0a58792990fadb7a9b281a05) | `` osu-lazer: 2025.710.0 -> 2025.816.0 ``                          |
| [`ae800631`](https://github.com/NixOS/nixpkgs/commit/ae80063112dafbc2299bf8ef4eab38cf5285eea9) | `` osu-lazer-bin: 2025.710.0 -> 2025.816.0 ``                      |
| [`1223ed42`](https://github.com/NixOS/nixpkgs/commit/1223ed429554273c94da02284c6cb807d903e86a) | `` git-cinnabar: 0.7.2 -> 0.7.3 ``                                 |
| [`f4090e1e`](https://github.com/NixOS/nixpkgs/commit/f4090e1e1783c3cb7aa62367b9e957026903cca9) | `` linuxKernel.kernels.linux_lqx: 6.15.9 -> 6.15.10 ``             |
| [`c7b2b723`](https://github.com/NixOS/nixpkgs/commit/c7b2b72369f07070b6748cea6dac7aaa531bd6f7) | `` jetty_11: 11.0.25 -> 11.0.26 ``                                 |
| [`373b9bb3`](https://github.com/NixOS/nixpkgs/commit/373b9bb3cd59ff43b325c0831e3472fd0a401a58) | `` serie: 0.4.6 -> 0.4.7 ``                                        |
| [`88c9e296`](https://github.com/NixOS/nixpkgs/commit/88c9e2966fbbeaa471d9cb073bc0d76ce4763941) | `` matrix-synapse: 1.135.2 -> 1.136.0 ``                           |
| [`5352a140`](https://github.com/NixOS/nixpkgs/commit/5352a140e57f1f1ee31b6aa781722ba1c2b61ba2) | `` zammad: 6.5.0 -> 6.5.1 ``                                       |
| [`f8aaffa8`](https://github.com/NixOS/nixpkgs/commit/f8aaffa8bccd6d445a673a1c653f3cad4487208e) | `` python3Packages.py-libzfs: fix gcc 14 compilation ``            |
| [`66c8e771`](https://github.com/NixOS/nixpkgs/commit/66c8e771cc2b414473042da8d798bd0a465df13c) | `` ncdu: 2.8.2 -> 2.9 ``                                           |
| [`857e2f31`](https://github.com/NixOS/nixpkgs/commit/857e2f31591f33a0d47460d610e2f34576232e79) | `` chatzone-desktop: 5.3.2 -> 5.4.1 ``                             |
| [`37e5cde4`](https://github.com/NixOS/nixpkgs/commit/37e5cde4a676ae3ec39036da33c195394a1ec1e6) | `` chatzone-desktop: 5.3.0 -> 5.3.2 ``                             |
| [`76b6fd2b`](https://github.com/NixOS/nixpkgs/commit/76b6fd2b3b92107a1f45480beab01eb9119b6b22) | `` google-chrome: 139.0.7258.66 -> 139.0.7258.127 ``               |
| [`8bf7ed0c`](https://github.com/NixOS/nixpkgs/commit/8bf7ed0ce10e4690c71487bef7e1e120b157d2ab) | `` wofi-power-menu: 0.3.0 -> 0.3.1 ``                              |
| [`5590ead4`](https://github.com/NixOS/nixpkgs/commit/5590ead4e6a6839fbeaa3c4831dcfe03037e5882) | `` wofi-power-menu: use makeBinaryWrapper ``                       |
| [`a38e4c82`](https://github.com/NixOS/nixpkgs/commit/a38e4c82ef5a215964903200f12ec4f85e93a8da) | `` rst2pdf: fix build failure ``                                   |
| [`2badaa01`](https://github.com/NixOS/nixpkgs/commit/2badaa0140c05113d6f1605ed38e5318c0701237) | `` firefox-devedition-unwrapped: 142.0b8 -> 142.0b9 ``             |
| [`f799ddc0`](https://github.com/NixOS/nixpkgs/commit/f799ddc07630621157a4b40cffeaad804b287343) | `` firefox-beta-unwrapped: 142.0b8 -> 142.0b9 ``                   |
| [`e4482214`](https://github.com/NixOS/nixpkgs/commit/e4482214ebc8302096e69dd3e509198f3b92a6ff) | `` ed-odyssey-materials-helper: remove sentry ``                   |
| [`bd8683d8`](https://github.com/NixOS/nixpkgs/commit/bd8683d8ebc3b398e9efd7d8f2fd869dfe70556d) | `` incus-lts: 6.0.4 -> 6.0.5 ``                                    |
| [`6afbe0ba`](https://github.com/NixOS/nixpkgs/commit/6afbe0ba328e555be04f449d705505735b2723f9) | `` lxcfs: 6.0.4 -> 6.0.5 ``                                        |
| [`7f82e7f2`](https://github.com/NixOS/nixpkgs/commit/7f82e7f20b954cfd7630b7d3073e4e4f89bab5c9) | `` lxc: 6.0.4 -> 6.0.5 ``                                          |
| [`fce01f7d`](https://github.com/NixOS/nixpkgs/commit/fce01f7d71457982563557b4dac3d24e91ba40eb) | `` lib: fix overflowing `fromHexString` tests and example ``       |
| [`b5910012`](https://github.com/NixOS/nixpkgs/commit/b591001250842aa1ae470523d45274243926a853) | `` lib: add `fromHexString` tests for distressing behaviour ``     |
| [`162d3d95`](https://github.com/NixOS/nixpkgs/commit/162d3d95622ab7e3cbde27b494466e0fa2c2bd7c) | `` Revert "tiled: 1.11.2 -> 1.11.90", disable auto update ``       |
| [`0128aea5`](https://github.com/NixOS/nixpkgs/commit/0128aea5a299c42acb2e4a907281c78525567df6) | `` varnish77: 7.7.1 -> 7.7.2 ``                                    |
| [`cb5634e5`](https://github.com/NixOS/nixpkgs/commit/cb5634e5c0b7cd1dac3196ca69bb2a3658b8e645) | `` varnish60: 6.0.14 -> 6.0.15 ``                                  |
| [`017a9ff0`](https://github.com/NixOS/nixpkgs/commit/017a9ff0a8a512d78c32ee8559fe5493cbcd6589) | `` python314: 3.14.0rc1 -> 3.14.0rc2 ``                            |
| [`361f6a63`](https://github.com/NixOS/nixpkgs/commit/361f6a6354a2da7a331c321cd9beed1a8b02233b) | `` nixos/conman: init module ``                                    |
| [`cc8962e8`](https://github.com/NixOS/nixpkgs/commit/cc8962e8acac6af6f1046aeac23b619c49eb0140) | `` conman: init at 0.3.1 ``                                        |
| [`15158d13`](https://github.com/NixOS/nixpkgs/commit/15158d13d45233205b1e0002d9444d66c79c9b00) | `` maintainers: add frantathefranta ``                             |
| [`e0356428`](https://github.com/NixOS/nixpkgs/commit/e0356428576c99a37d6c1d2748b89515cce516f3) | `` immich-machine-learning: relax numpy ``                         |
| [`8d9fc2cb`](https://github.com/NixOS/nixpkgs/commit/8d9fc2cb6bab55858c02055c6f64307386406316) | `` immich: 1.137.3 -> 1.138.0 ``                                   |
| [`f6149e0d`](https://github.com/NixOS/nixpkgs/commit/f6149e0d7d266ec0ba8467f11049da6f4f4d4965) | `` immich.geodata: fix hash ``                                     |
| [`0542ec13`](https://github.com/NixOS/nixpkgs/commit/0542ec13e27eafcafea9f04198927fe06355a3c8) | `` immich.geodata: fix hash ``                                     |
| [`6851f846`](https://github.com/NixOS/nixpkgs/commit/6851f846dd523cd52ea25f62a4aa60b5ea5809a6) | `` immich: 1.136.0 -> 1.137.3 ``                                   |
| [`a388bc83`](https://github.com/NixOS/nixpkgs/commit/a388bc83ba9dd7080dc1ac071fd180e4152872f1) | `` python3Packages.ansible-core: 2.18.6 -> 2.18.7 ``               |
| [`7c54f28b`](https://github.com/NixOS/nixpkgs/commit/7c54f28bf324a214492642161c916a492749afe4) | `` soundsource: 5.8.3 -> 5.8.5 ``                                  |
| [`57874762`](https://github.com/NixOS/nixpkgs/commit/57874762fc1a3e9e8c49c28ff720b9595f3d9c35) | `` qpwgraph: 0.9.4 -> 0.9.5 ``                                     |
| [`7dc912ba`](https://github.com/NixOS/nixpkgs/commit/7dc912baffb336ee05d510de822f61dec5195f4f) | `` plexRaw: 1.41.9.9961-46083195d -> 1.42.1.10060-4e8b05daf ``     |
| [`b6823b97`](https://github.com/NixOS/nixpkgs/commit/b6823b97bc1439920bc37844b9f4af3f9c718e1c) | `` plexRaw: 1.41.8.9834-071366d65 -> 1.41.9.9961-46083195d ``      |
| [`f015e812`](https://github.com/NixOS/nixpkgs/commit/f015e812ad29bad7d27e82ff0d9e7aba8e7b39ff) | `` plexRaw: 1.41.7.9823-59f304c16 -> 1.41.8.9834-071366d65 ``      |
| [`1d3aca7b`](https://github.com/NixOS/nixpkgs/commit/1d3aca7bae48b8c34f6499e9c05f9fb2d37084a1) | `` plexRaw: 1.41.7.9799-5bce000f7 -> 1.41.7.9823-59f304c16 ``      |
| [`5c2cb296`](https://github.com/NixOS/nixpkgs/commit/5c2cb296fe2c49733c76bf8191401e40c7b4c7aa) | `` plexRaw: 1.41.6.9685-d301f511a -> 1.41.7.9799-5bce000f7 ``      |
| [`39da7ee7`](https://github.com/NixOS/nixpkgs/commit/39da7ee7ab06057ca5b2e13274d9d5285c19d60f) | `` linux/common-config: update for 6.17 ``                         |
| [`cf7d4788`](https://github.com/NixOS/nixpkgs/commit/cf7d47886c3fdd84942be3c9d36ab52c8e7350a9) | `` linux_6_1: 6.1.147 -> 6.1.148 ``                                |
| [`54bc72c3`](https://github.com/NixOS/nixpkgs/commit/54bc72c3313ed523170179b90fdaff8a59e417f2) | `` linux_6_6: 6.6.101 -> 6.6.102 ``                                |
| [`cfe64b11`](https://github.com/NixOS/nixpkgs/commit/cfe64b11b12dc432a1a6789c103c1db68d6fce26) | `` linux_6_12: 6.12.41 -> 6.12.42 ``                               |
| [`93385170`](https://github.com/NixOS/nixpkgs/commit/9338517046dbe09b93db12500941db3da9fe4272) | `` linux_6_15: 6.15.9 -> 6.15.10 ``                                |
| [`a803750c`](https://github.com/NixOS/nixpkgs/commit/a803750ca413f40e91b0cf3acbde2fbab9f4f71c) | `` linux_6_16: 6.16 -> 6.16.1 ``                                   |
| [`6788a5a4`](https://github.com/NixOS/nixpkgs/commit/6788a5a49c55b52a2f7fb28a439aeaf9a05c950c) | `` linux_testing: 6.16-rc7 -> 6.17-rc1 ``                          |
| [`805634fd`](https://github.com/NixOS/nixpkgs/commit/805634fdce081698c69885aee9848121ce1601a7) | `` python3Packages.ansible-core: 2.18.4 -> 2.18.6 ``               |
| [`38da02cf`](https://github.com/NixOS/nixpkgs/commit/38da02cfa03fd4a20d2d5f4a90b750b10f7899c6) | `` matrix-synapse-plugins.synapse-http-antispam: 0.4.0 -> 0.5.0 `` |
| [`7bd099f1`](https://github.com/NixOS/nixpkgs/commit/7bd099f1c3c45f8d30dbbb9ce3009b06584f6ee6) | `` lock: 1.7.0 -> 1.7.1 ``                                         |
| [`4083bdcd`](https://github.com/NixOS/nixpkgs/commit/4083bdcd8ee33ff446bc7f3011d8eeab71f64c19) | `` flexoptix-app: 5.21.2-latest -> 5.48.0-latest ``                |
| [`b73f53d0`](https://github.com/NixOS/nixpkgs/commit/b73f53d0b693e51b980d68d1093d2f19ef384eab) | `` matrix-alertmanager-receiver: 2025.7.23 -> 2025.7.30 ``         |
| [`f1ac10c9`](https://github.com/NixOS/nixpkgs/commit/f1ac10c981c38fb90870689ade3ff5f2ef6be114) | `` matrix-alertmanager-receiver: 2025.7.2 -> 2025.7.23 ``          |
| [`3281ce4c`](https://github.com/NixOS/nixpkgs/commit/3281ce4c62d607c607df8e8bc22e358c1517c349) | ``  matrix-alertmanager-receiver: 2025.5.21 -> 2025.7.2 ``         |
| [`a8617c5c`](https://github.com/NixOS/nixpkgs/commit/a8617c5c483f75cdc8db03fb38eddd85bb3730b5) | `` matrix-alertmanager-receiver: 2025.4.23 -> 2025.5.21 ``         |