### PR TITLE
chore(flake/nur): `9e8d3978` -> `568092d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755509835,
-        "narHash": "sha256-jzsGYRF9kTvdvPZ6l6iYbvTubx3lpaUfLs9c3AZIehI=",
+        "lastModified": 1755524129,
+        "narHash": "sha256-kCFnsO840MXNQDlxieqddiyn0aD17KAEmmOxPQTu+LI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9e8d3978cd27d891095096bf73ce6a02a7c77819",
+        "rev": "568092d37c240c999349e497b2320753dadb5ff2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`568092d3`](https://github.com/nix-community/NUR/commit/568092d37c240c999349e497b2320753dadb5ff2) | `` automatic update `` |
| [`0dce3df0`](https://github.com/nix-community/NUR/commit/0dce3df0087dc79c3dbe3c5cebd95bf2a801b030) | `` automatic update `` |
| [`7336a17f`](https://github.com/nix-community/NUR/commit/7336a17f80b5f9eca8cae27776eebf7f30e4fe24) | `` automatic update `` |
| [`2b8086c7`](https://github.com/nix-community/NUR/commit/2b8086c757b6ee16eebafd0f18d0a5b2eb07e01f) | `` automatic update `` |
| [`06942a0a`](https://github.com/nix-community/NUR/commit/06942a0a88bfa9b3a6f46dfa82235f8f34fb331f) | `` automatic update `` |
| [`9550069a`](https://github.com/nix-community/NUR/commit/9550069a71fd790f90ed320225a2f1a76a91ee05) | `` automatic update `` |
| [`8ddccab2`](https://github.com/nix-community/NUR/commit/8ddccab2bd2ec5538d75f0a58ca3b1b7a075eef5) | `` automatic update `` |