### PR TITLE
chore(flake/nur): `568092d3` -> `17255790`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755524129,
-        "narHash": "sha256-kCFnsO840MXNQDlxieqddiyn0aD17KAEmmOxPQTu+LI=",
+        "lastModified": 1755530503,
+        "narHash": "sha256-iM/uqz3OqmtvZxlfDqvfrBgfHqS44aRTn2QxT1bjAio=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "568092d37c240c999349e497b2320753dadb5ff2",
+        "rev": "17255790e7abaaaa4790d0e594f90f4744082917",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`17255790`](https://github.com/nix-community/NUR/commit/17255790e7abaaaa4790d0e594f90f4744082917) | `` automatic update `` |
| [`cf1a095b`](https://github.com/nix-community/NUR/commit/cf1a095b4791925df774dee91bf9e38d80c98837) | `` automatic update `` |