### PR TITLE
chore(flake/nur): `17255790` -> `da309248`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755530503,
-        "narHash": "sha256-iM/uqz3OqmtvZxlfDqvfrBgfHqS44aRTn2QxT1bjAio=",
+        "lastModified": 1755543404,
+        "narHash": "sha256-Y93sq71AYo9qM7rs4TAWN/Jpe15EubSOCLdPIMcdNjw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "17255790e7abaaaa4790d0e594f90f4744082917",
+        "rev": "da3092487ba979281b9f4584cfa0dd2b51e5cf97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`da309248`](https://github.com/nix-community/NUR/commit/da3092487ba979281b9f4584cfa0dd2b51e5cf97) | `` automatic update `` |
| [`55361683`](https://github.com/nix-community/NUR/commit/553616830d127e0e682298080908444efcffaebf) | `` automatic update `` |
| [`ea10c01b`](https://github.com/nix-community/NUR/commit/ea10c01bcdd8ac0b7c15b01fdfde5ca5a3afa186) | `` automatic update `` |
| [`d67e14bb`](https://github.com/nix-community/NUR/commit/d67e14bb1c083969c5a99628150ea2056a3ef5e2) | `` automatic update `` |
| [`aa86fcbc`](https://github.com/nix-community/NUR/commit/aa86fcbc96de9250bd92c3da6bdd90cf1db0ac79) | `` automatic update `` |
| [`74a901e7`](https://github.com/nix-community/NUR/commit/74a901e7f45df791d7df5ffa2b1b5ffb34811906) | `` automatic update `` |