### PR TITLE
chore(flake/nur): `da309248` -> `bf9b3a8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755543404,
-        "narHash": "sha256-Y93sq71AYo9qM7rs4TAWN/Jpe15EubSOCLdPIMcdNjw=",
+        "lastModified": 1755595965,
+        "narHash": "sha256-EBXB+Up0CL+Twt6gHyrk1x7p3g8AZ6vUExFzJor9D8Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da3092487ba979281b9f4584cfa0dd2b51e5cf97",
+        "rev": "bf9b3a8dd0bb5d78e440cd5b4f0646b581abce79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bf9b3a8d`](https://github.com/nix-community/NUR/commit/bf9b3a8dd0bb5d78e440cd5b4f0646b581abce79) | `` automatic update `` |
| [`d64dd4e7`](https://github.com/nix-community/NUR/commit/d64dd4e7129ff2ef3c935fc069896184d9c85fc9) | `` automatic update `` |
| [`62675ee8`](https://github.com/nix-community/NUR/commit/62675ee82d16e99be9486932fc355f2d12832c38) | `` automatic update `` |
| [`6acb2199`](https://github.com/nix-community/NUR/commit/6acb2199b7f6ce8548fabb53a241378b3ac710f4) | `` automatic update `` |
| [`0ee04ea6`](https://github.com/nix-community/NUR/commit/0ee04ea6138ae9a91b94f38233119aff6ca0c792) | `` automatic update `` |
| [`8f7d4b6a`](https://github.com/nix-community/NUR/commit/8f7d4b6a0f0fad51c296dab34dcfb7570cb2095a) | `` automatic update `` |
| [`a48c8b1c`](https://github.com/nix-community/NUR/commit/a48c8b1c1b234951fc3722f9889c8f7724d6726d) | `` automatic update `` |
| [`ae30793b`](https://github.com/nix-community/NUR/commit/ae30793badc7fe13c526891a0002f859b999b6a2) | `` automatic update `` |
| [`f977b63c`](https://github.com/nix-community/NUR/commit/f977b63cff16e7113c797584b5739951474ddcff) | `` automatic update `` |
| [`1c950e42`](https://github.com/nix-community/NUR/commit/1c950e42310211f62537be4ff725f046f57d313c) | `` automatic update `` |
| [`821c1249`](https://github.com/nix-community/NUR/commit/821c124991c69cb7cbc19a353b44ca3bc9ca8da7) | `` automatic update `` |
| [`72c49026`](https://github.com/nix-community/NUR/commit/72c49026949b72c8de4ae133bc2846de77b7fa20) | `` automatic update `` |
| [`e16e4103`](https://github.com/nix-community/NUR/commit/e16e4103f9d61dabdfebfa067bb4e2f2ed73d9ee) | `` automatic update `` |
| [`b6e1481f`](https://github.com/nix-community/NUR/commit/b6e1481f34aeaa0fa0874c573b8e4f87cde05050) | `` automatic update `` |
| [`0c299326`](https://github.com/nix-community/NUR/commit/0c29932614c802cc26a855833ebdcb67de727322) | `` automatic update `` |
| [`739a8974`](https://github.com/nix-community/NUR/commit/739a897438e40e9b8bcbcf008009276c9253b358) | `` automatic update `` |
| [`f551bb11`](https://github.com/nix-community/NUR/commit/f551bb1174407e2495d96b38272561eadea951fc) | `` automatic update `` |
| [`9066e57a`](https://github.com/nix-community/NUR/commit/9066e57a8aa9d27509d9bc2e44f0cf84e1b4de8f) | `` automatic update `` |
| [`b54ab372`](https://github.com/nix-community/NUR/commit/b54ab372b6c2831be68f7302142bdfae08204756) | `` automatic update `` |
| [`09e5bd58`](https://github.com/nix-community/NUR/commit/09e5bd58c869f1997f40cbdf26d562dd9b3bbb0d) | `` automatic update `` |
| [`18edb344`](https://github.com/nix-community/NUR/commit/18edb344c61aacf9594bae3f0e9ceb32f5d714b7) | `` automatic update `` |
| [`e6c4b06c`](https://github.com/nix-community/NUR/commit/e6c4b06c5a63664fa469a66d32cb617e22a2dcef) | `` automatic update `` |
| [`d57e71d6`](https://github.com/nix-community/NUR/commit/d57e71d6f02cf7614577b1f5e5bff948c48aa361) | `` automatic update `` |
| [`0c3c6c84`](https://github.com/nix-community/NUR/commit/0c3c6c846c52a2ea5e90a6ba1593f86a9d9340b2) | `` automatic update `` |
| [`09f609d8`](https://github.com/nix-community/NUR/commit/09f609d895f79cada25fd739ae209426a31a19c3) | `` automatic update `` |
| [`1fdab7ec`](https://github.com/nix-community/NUR/commit/1fdab7ec2f9d5218c55dec2d230a4613346f2e8b) | `` automatic update `` |
| [`2d0a1e89`](https://github.com/nix-community/NUR/commit/2d0a1e897c3d83fc40ec6b8d308226ad9fd6b0ee) | `` automatic update `` |
| [`15f16ae7`](https://github.com/nix-community/NUR/commit/15f16ae7f5ef63559e65d82e1015e4b3703cd08d) | `` automatic update `` |