### PR TITLE
chore(flake/nur): `eb48ffa9` -> `22f05c84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755704846,
-        "narHash": "sha256-aaBUXZJPGU1LEVs90BohxsNX8pcHgESYol9krvr8pIA=",
+        "lastModified": 1755722870,
+        "narHash": "sha256-MUyrAjWpGEdOMcuyLv+c467VqJGf6TC/ZYoMZRV8wto=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb48ffa9d2177188e7ed22f850e95e7fabef88a9",
+        "rev": "22f05c844cd7f8d08063c6dc89448343171ad323",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`22f05c84`](https://github.com/nix-community/NUR/commit/22f05c844cd7f8d08063c6dc89448343171ad323) | `` automatic update `` |
| [`a363a91a`](https://github.com/nix-community/NUR/commit/a363a91a8246cfc461b64100a9a30944c3907137) | `` automatic update `` |
| [`46b7cd00`](https://github.com/nix-community/NUR/commit/46b7cd00b85b084dd7ebeb5b2e41c31372736adb) | `` automatic update `` |
| [`84b4210a`](https://github.com/nix-community/NUR/commit/84b4210adcb4080a750c4f7e33f6a93901b8a056) | `` automatic update `` |