### PR TITLE
chore(flake/nur): `22f05c84` -> `de302604`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755722870,
-        "narHash": "sha256-MUyrAjWpGEdOMcuyLv+c467VqJGf6TC/ZYoMZRV8wto=",
+        "lastModified": 1755747053,
+        "narHash": "sha256-v7Sw52iQdA86c49lWfSXsD4fC2mtI0R8l/U0ueZZveg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "22f05c844cd7f8d08063c6dc89448343171ad323",
+        "rev": "de3026043743970a2aa625922307a7f2655a26c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`de302604`](https://github.com/nix-community/NUR/commit/de3026043743970a2aa625922307a7f2655a26c2) | `` automatic update `` |
| [`c6508c49`](https://github.com/nix-community/NUR/commit/c6508c49a36f20ea2d28920d1b5d55a48d072a4a) | `` automatic update `` |
| [`4a013d0e`](https://github.com/nix-community/NUR/commit/4a013d0ea53aff0c936d90a68cd134390305b66e) | `` automatic update `` |