### PR TITLE
chore(flake/nur): `de302604` -> `be0a0bf1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755747053,
-        "narHash": "sha256-v7Sw52iQdA86c49lWfSXsD4fC2mtI0R8l/U0ueZZveg=",
+        "lastModified": 1755757554,
+        "narHash": "sha256-cU/T/9j1fEickuPuvpkadqqRoj79TDdesVNKzlhvbrU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "de3026043743970a2aa625922307a7f2655a26c2",
+        "rev": "be0a0bf16503238a291563ec84ea9eb537f4f03a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`be0a0bf1`](https://github.com/nix-community/NUR/commit/be0a0bf16503238a291563ec84ea9eb537f4f03a) | `` automatic update `` |
| [`ca5f5ac4`](https://github.com/nix-community/NUR/commit/ca5f5ac4f6c8e02a10b3ded1a57f7fc097d7bde9) | `` automatic update `` |
| [`468be9ba`](https://github.com/nix-community/NUR/commit/468be9ba59d7cff1fa9ff4fa2da6e6e9a3f40e96) | `` automatic update `` |
| [`a6b45ca9`](https://github.com/nix-community/NUR/commit/a6b45ca9b75729d3d00e01486fb46ff6d043c36e) | `` automatic update `` |
| [`d6d189b4`](https://github.com/nix-community/NUR/commit/d6d189b40f96738749da8429885247b3421ba4f2) | `` automatic update `` |
| [`1ba19c9d`](https://github.com/nix-community/NUR/commit/1ba19c9dd44b629314534caa8ae07cff86b88174) | `` automatic update `` |
| [`61f635f4`](https://github.com/nix-community/NUR/commit/61f635f438aee43068b02d7c98572d03f79202dd) | `` automatic update `` |