### PR TITLE
chore(flake/nur): `be0a0bf1` -> `bed88eb5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755757554,
-        "narHash": "sha256-cU/T/9j1fEickuPuvpkadqqRoj79TDdesVNKzlhvbrU=",
+        "lastModified": 1755766334,
+        "narHash": "sha256-CNRnIgUm+yqWiRQOKqJR73JoGPsOk//H9EzqsigUQz4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "be0a0bf16503238a291563ec84ea9eb537f4f03a",
+        "rev": "bed88eb56c4893b400c524619f823a1906cf4140",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bed88eb5`](https://github.com/nix-community/NUR/commit/bed88eb56c4893b400c524619f823a1906cf4140) | `` automatic update `` |
| [`3224e7f5`](https://github.com/nix-community/NUR/commit/3224e7f5637a9a6d2fde71fb9ccb8a7a22bb15b7) | `` automatic update `` |
| [`e1402def`](https://github.com/nix-community/NUR/commit/e1402defda15e34a085a3c4a00ea0b3fec268b87) | `` automatic update `` |
| [`77adb760`](https://github.com/nix-community/NUR/commit/77adb760309293f0fe46a3f5a9f05ab521017037) | `` automatic update `` |