### PR TITLE
chore(flake/nixpkgs): `a58390ab` -> `9cb344e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1755593991,
-        "narHash": "sha256-BA9MuPjBDx/WnpTJ0EGhStyfE7hug8g85Y3Ju9oTsM4=",
+        "lastModified": 1755704039,
+        "narHash": "sha256-gKlP0LbyJ3qX0KObfIWcp5nbuHSb5EHwIvU6UcNBg2A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a58390ab6f1aa810eb8e0f0fc74230e7cc06de03",
+        "rev": "9cb344e96d5b6918e94e1bca2d9f3ea1e9615545",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`2c86ed70`](https://github.com/NixOS/nixpkgs/commit/2c86ed707c80b0606d0466b3e452fe2b746bd6e0) | `` workflows/reviewers: integrate codeowner reviews ``                      |
| [`2746652f`](https://github.com/NixOS/nixpkgs/commit/2746652fdcd9ca034c827b4c682619989a84a6de) | `` workflows/reviewers: remove pull_request trigger ``                      |
| [`aefe360c`](https://github.com/NixOS/nixpkgs/commit/aefe360c78b744a3f3d1c3596a70efb750c4e6d3) | `` workflows/check: move owners check job from codeowners ``                |
| [`f27f6819`](https://github.com/NixOS/nixpkgs/commit/f27f68194ac7e70bd21ecc2799a82feeb1d6dbc6) | `` workflows/codeowners: split comment for each job ``                      |
| [`4daef5d8`](https://github.com/NixOS/nixpkgs/commit/4daef5d84736b9e7bc4399e138fd18c093b22f8e) | `` workflows/codeowners: move global env into jobs ``                       |
| [`a0c25004`](https://github.com/NixOS/nixpkgs/commit/a0c2500457d3626a067700df1777ab0c41134d49) | `` nixos/invoiceplane: Update patch ``                                      |
| [`7f6e2a1c`](https://github.com/NixOS/nixpkgs/commit/7f6e2a1c01672c917fa5186877eaaa07771bd0a3) | `` invoiceplane: 1.6.2 -> 1.6.3 ``                                          |
| [`1304c547`](https://github.com/NixOS/nixpkgs/commit/1304c547d8365d89757fbd7e1ead5993e3bc2366) | `` ci/treefmt: enable biome for doc/ ``                                     |
| [`a6e40e9c`](https://github.com/NixOS/nixpkgs/commit/a6e40e9c907885644f5c0de49056eee90f3b6780) | `` doc: fix biome linting errors ``                                         |
| [`4d650d05`](https://github.com/NixOS/nixpkgs/commit/4d650d0530133173f5293dd5e696f3545f8861d4) | `` doc: apply safe formatting with biome ``                                 |
| [`1516b443`](https://github.com/NixOS/nixpkgs/commit/1516b4435df2445f5f98a9b2bb9be733e4df5fe9) | `` .editorconfig: indent css with spaces ``                                 |
| [`4fdb1350`](https://github.com/NixOS/nixpkgs/commit/4fdb135006305b8ec13c4d36376439ef65931008) | `` ci/treefmt: add biome for .js files ``                                   |
| [`27c0126b`](https://github.com/NixOS/nixpkgs/commit/27c0126b67c2360d4a3a5e87ef70ea4c0e84c25c) | `` ci: apply unsafe fixes with biome ``                                     |
| [`e6d63110`](https://github.com/NixOS/nixpkgs/commit/e6d63110df84bc72e094ca2d5df338f2a2fb92cd) | `` ci: apply safe formatting with biome ``                                  |
| [`7511af4f`](https://github.com/NixOS/nixpkgs/commit/7511af4fc54e5dbb9440276fc12449d47fd893aa) | `` .editorconfig: two spaces for .js files ``                               |
| [`64d1d69b`](https://github.com/NixOS/nixpkgs/commit/64d1d69b9f25fb7cbe9e20779e39ba8f5f33e4da) | `` ci/github-script/prepare: refactor ``                                    |
| [`0fa17a8e`](https://github.com/NixOS/nixpkgs/commit/0fa17a8e6c6db2c6f32efa4c24a1d807573989f5) | `` ci/github-script/prepare: run biome ``                                   |
| [`b60acc12`](https://github.com/NixOS/nixpkgs/commit/b60acc12a938718d1a27c00b6d4df699917b2efd) | `` ci/github-script/prepare: init from actions/get-merge-commit ``          |
| [`ea9f6794`](https://github.com/NixOS/nixpkgs/commit/ea9f67944fc7889d6ace5157714a472a7c2807a3) | `` actions/get-merge-commit: remove push branch ``                          |
| [`19d5d69d`](https://github.com/NixOS/nixpkgs/commit/19d5d69dc958bf36661b17f7b31506c6c367bc3e) | `` workflows/eval: run misc job with same merge commit ``                   |
| [`af7981ed`](https://github.com/NixOS/nixpkgs/commit/af7981ed14511a756c236a1f55798fe959a71ac1) | `` vencord: 1.12.10 -> 1.12.12 ``                                           |
| [`ba53a2a4`](https://github.com/NixOS/nixpkgs/commit/ba53a2a477c2c90c15ada7a38e6577c4e723ce12) | `` wechat: 4.0.6.25-29387 -> 4.1.0.19-29668 for darwin ``                   |
| [`ea11a248`](https://github.com/NixOS/nixpkgs/commit/ea11a24887d12799e0de0499aeb9fe40a1a598df) | `` wechat: 4.0.6.19-29383 -> 4.0.6.25-29387 for darwin ``                   |
| [`58f91dd6`](https://github.com/NixOS/nixpkgs/commit/58f91dd673aebc0356b7e6690a67c0aa41a16027) | `` freetube: 0.23.6 -> 0.23.7 ``                                            |
| [`18ec1750`](https://github.com/NixOS/nixpkgs/commit/18ec1750c7d02fe584b658db91f3a1057dab8f2c) | `` freetube: 0.23.5 -> 0.23.6 ``                                            |
| [`b8b29e49`](https://github.com/NixOS/nixpkgs/commit/b8b29e499c5b36b45635286e62070a90cdc904c1) | `` mprisence: 1.2.4 -> 1.2.5 ``                                             |
| [`985c9f9a`](https://github.com/NixOS/nixpkgs/commit/985c9f9a10581c38ba5cc9122e7a8aa0f5c86184) | `` rundeck: 5.13.0 -> 5.14.1 ``                                             |
| [`3802a0c4`](https://github.com/NixOS/nixpkgs/commit/3802a0c44e8d95ba2c641a257e83a99fc8016d08) | `` [Backport release-25.05] Revert serie: 0.4.6 -> 0.4.7 ``                 |
| [`f47bd8c6`](https://github.com/NixOS/nixpkgs/commit/f47bd8c63e9f743f1a6f2572f963a5cd5506c9ee) | `` signal-desktop: 7.64.0 -> 7.66.0 ``                                      |
| [`d5edba18`](https://github.com/NixOS/nixpkgs/commit/d5edba18e838970b9c0b895fdb4c279253728aad) | `` lib/tests/test-with-nix: run lib/tests/fetchers.nix in the derivation `` |
| [`da5d00ad`](https://github.com/NixOS/nixpkgs/commit/da5d00ad9c0b565e0829575460a1720b2eefcfd2) | `` lib/tests/test-with-nix: remove broken import ./check-eval ``            |
| [`16a05de6`](https://github.com/NixOS/nixpkgs/commit/16a05de6380612747163104fd2cd300687d97443) | `` lib/tests/test-with-nix: run misc.nix tests in the derivation ``         |
| [`0e04293d`](https://github.com/NixOS/nixpkgs/commit/0e04293d5926d91ca6d1855446901698fe26891b) | `` lib/tests/misc: don't hardcode store directory ``                        |
| [`e888a099`](https://github.com/NixOS/nixpkgs/commit/e888a099315b233307659bff4c60657445d65db5) | `` lib/tests/misc: don't import nixpkgs ``                                  |