### PR TITLE
chore(flake/nur): `bed88eb5` -> `5dee0440`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755766334,
-        "narHash": "sha256-CNRnIgUm+yqWiRQOKqJR73JoGPsOk//H9EzqsigUQz4=",
+        "lastModified": 1755781769,
+        "narHash": "sha256-VvPXGObHT7rH00oqjTKyLXeL9Hr1B9U5WnMEdx8foB4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bed88eb56c4893b400c524619f823a1906cf4140",
+        "rev": "5dee0440f395c68e6dc161a506cde3adf2a55e87",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5dee0440`](https://github.com/nix-community/NUR/commit/5dee0440f395c68e6dc161a506cde3adf2a55e87) | `` automatic update `` |
| [`297fce91`](https://github.com/nix-community/NUR/commit/297fce91176042104c293405e99de188209dcfa3) | `` automatic update `` |
| [`f579dc81`](https://github.com/nix-community/NUR/commit/f579dc81337c902da373b91bf57896d69d6c602a) | `` automatic update `` |
| [`e1cbed66`](https://github.com/nix-community/NUR/commit/e1cbed667dcae06f778c9680522df3ae8c259b62) | `` automatic update `` |