### PR TITLE
chore(flake/chaotic): `f14fadaa` -> `d9222847`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1755545956,
-        "narHash": "sha256-/dqfdlsu8jonCbwWTlYXC4vVU4/71Yvz/NZMu1NMwos=",
+        "lastModified": 1755785370,
+        "narHash": "sha256-oA3H94jjm+Ju6m2iNv03v6/R42jven8vhIm9heGEGzo=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "f14fadaa130cc0e222271acde3dddc3596b97c69",
+        "rev": "d92228471fabcb46147cdbda83c6476928c4aebd",
         "type": "github"
       },
       "original": {
@@ -382,11 +382,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1755186698,
-        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                  |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`d9222847`](https://github.com/chaotic-cx/nyx/commit/d92228471fabcb46147cdbda83c6476928c4aebd) | `` ci: fix cache checking and pushing `` |
| [`df4622a1`](https://github.com/chaotic-cx/nyx/commit/df4622a127956ab78739ab68ab2e59c2d71d7749) | `` mesa_git: rebase nixpkgs ``           |
| [`5dd42be4`](https://github.com/chaotic-cx/nyx/commit/5dd42be498870e5f9b6ae5673ed8d901abc08bf7) | `` nixpkgs: bump to 20250820 ``          |