### PR TITLE
chore(flake/nur): `4306d2c0` -> `5e9a8dfd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755888813,
-        "narHash": "sha256-E138YvDtlSuwf+m1Xgh5+yAnS83sl75YCV9+JUjfo6o=",
+        "lastModified": 1755895598,
+        "narHash": "sha256-Ag8KwBrC0Y3+gCYGTM7aMHvPPPGW8jKmU7cKPpwphss=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4306d2c060a176636f132e0db28dbbfc9d46e9eb",
+        "rev": "5e9a8dfd07521eda0e53fd5a75e63f31ef1f3504",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5e9a8dfd`](https://github.com/nix-community/NUR/commit/5e9a8dfd07521eda0e53fd5a75e63f31ef1f3504) | `` automatic update `` |
| [`c602eb40`](https://github.com/nix-community/NUR/commit/c602eb40ea4aa7d484e43d2c39797ed329f2cdd6) | `` automatic update `` |
| [`c8576f7f`](https://github.com/nix-community/NUR/commit/c8576f7fccc2907630353b5458c82228536a3206) | `` automatic update `` |
| [`b4ec260d`](https://github.com/nix-community/NUR/commit/b4ec260de2ebc197aeaa83572fb2eb772123e580) | `` automatic update `` |