### PR TITLE
chore(flake/nur): `5e9a8dfd` -> `b3af752c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755895598,
-        "narHash": "sha256-Ag8KwBrC0Y3+gCYGTM7aMHvPPPGW8jKmU7cKPpwphss=",
+        "lastModified": 1755922143,
+        "narHash": "sha256-aLzarOeQ4cFVXrzaGE7khpAPNJD6E3OTNPxRqjFMfmA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e9a8dfd07521eda0e53fd5a75e63f31ef1f3504",
+        "rev": "b3af752c4e2477d8460556c2c992d950930a4a53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b3af752c`](https://github.com/nix-community/NUR/commit/b3af752c4e2477d8460556c2c992d950930a4a53) | `` automatic update `` |
| [`b894e1c6`](https://github.com/nix-community/NUR/commit/b894e1c63dda216bc27b1c45a5b34c9fd04ae7fd) | `` automatic update `` |
| [`1a47d83c`](https://github.com/nix-community/NUR/commit/1a47d83c521c098debd6d1f2c2ae313a5bb729f9) | `` automatic update `` |
| [`38f8d8cf`](https://github.com/nix-community/NUR/commit/38f8d8cfed50ee29f9ef6d9c3b8f0e0179f168ca) | `` automatic update `` |
| [`67055023`](https://github.com/nix-community/NUR/commit/67055023c050c79f95da43d890fac44ebf77c022) | `` automatic update `` |
| [`e702b65a`](https://github.com/nix-community/NUR/commit/e702b65a8488eb50ba706b9f9b0c7fd3a5193781) | `` automatic update `` |
| [`edffca29`](https://github.com/nix-community/NUR/commit/edffca2954feecc63f406d9b16c31f3e47420f8c) | `` automatic update `` |
| [`9a69f0ed`](https://github.com/nix-community/NUR/commit/9a69f0ed994e781be342df887eb85b067fae8210) | `` automatic update `` |