### PR TITLE
chore(flake/nur): `b3af752c` -> `25a49240`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755922143,
-        "narHash": "sha256-aLzarOeQ4cFVXrzaGE7khpAPNJD6E3OTNPxRqjFMfmA=",
+        "lastModified": 1755938926,
+        "narHash": "sha256-KNLwcrzQvGsI4CuI6DDry1P5WqZlAxrWCU+UTIATdXg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b3af752c4e2477d8460556c2c992d950930a4a53",
+        "rev": "25a49240b3eb5d2206dc4e03242dda9640f34773",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`25a49240`](https://github.com/nix-community/NUR/commit/25a49240b3eb5d2206dc4e03242dda9640f34773) | `` automatic update `` |
| [`cadc2eaa`](https://github.com/nix-community/NUR/commit/cadc2eaa4c611d8b6bed6ea28992469e7babc88f) | `` automatic update `` |