### PR TITLE
chore(flake/nur): `25a49240` -> `cd7b4898`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755938926,
-        "narHash": "sha256-KNLwcrzQvGsI4CuI6DDry1P5WqZlAxrWCU+UTIATdXg=",
+        "lastModified": 1755954273,
+        "narHash": "sha256-h4eW3OcDBzOD3OfrxSkPdfj/qII+HI/UbDemjbWTZxk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25a49240b3eb5d2206dc4e03242dda9640f34773",
+        "rev": "cd7b489898d6928e73bbf0a7e374d58f6ee7b4c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cd7b4898`](https://github.com/nix-community/NUR/commit/cd7b489898d6928e73bbf0a7e374d58f6ee7b4c6) | `` automatic update `` |
| [`ffaf7fa0`](https://github.com/nix-community/NUR/commit/ffaf7fa085f6da161289e4223651872f57be9683) | `` automatic update `` |
| [`67508e51`](https://github.com/nix-community/NUR/commit/67508e513c893c7572d27964f85f83306fc92b21) | `` automatic update `` |
| [`ab6dfe65`](https://github.com/nix-community/NUR/commit/ab6dfe65180e9ba167b18f0a6ff55df87ed87a04) | `` automatic update `` |