### PR TITLE
chore(flake/nur): `b820a5b8` -> `aebf61ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755963829,
-        "narHash": "sha256-2tON0rztjaw0oS8bxrJ/FOgfU9HHYmEK//kkHwl6UIs=",
+        "lastModified": 1755969836,
+        "narHash": "sha256-knUFbR1djr4ZXSOtRazHhUz9z1/0KOIrZoHs5eRh51I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b820a5b8019264f623f3ed36f2153df997020647",
+        "rev": "aebf61cab6d272654032867064607279c39d7750",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aebf61ca`](https://github.com/nix-community/NUR/commit/aebf61cab6d272654032867064607279c39d7750) | `` automatic update `` |
| [`6dda7eba`](https://github.com/nix-community/NUR/commit/6dda7eba089c0721c2235bb48740097051dee507) | `` automatic update `` |
| [`da9b28f6`](https://github.com/nix-community/NUR/commit/da9b28f6f375bce911cb44f70e2d937013d2a50d) | `` automatic update `` |