### PR TITLE
chore(flake/nur): `aebf61ca` -> `af2605b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755969836,
-        "narHash": "sha256-knUFbR1djr4ZXSOtRazHhUz9z1/0KOIrZoHs5eRh51I=",
+        "lastModified": 1755981900,
+        "narHash": "sha256-LDuCCE56Qm6m74Wlweo0RIHsZVF6Kj5UN+LLNxSe3Iw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aebf61cab6d272654032867064607279c39d7750",
+        "rev": "af2605b5e79051af019d61c6d5fa180101feb75b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`af2605b5`](https://github.com/nix-community/NUR/commit/af2605b5e79051af019d61c6d5fa180101feb75b) | `` automatic update `` |
| [`39d39de2`](https://github.com/nix-community/NUR/commit/39d39de27089c2c2c44565d12db1f05654f56d68) | `` automatic update `` |
| [`cb6f7bd3`](https://github.com/nix-community/NUR/commit/cb6f7bd38d1198938d5404516484a6b2f3fc0855) | `` automatic update `` |
| [`7c64ee78`](https://github.com/nix-community/NUR/commit/7c64ee78146699a2b899bac16a5623cf674b1d31) | `` automatic update `` |
| [`2a4e354d`](https://github.com/nix-community/NUR/commit/2a4e354d7ebb34c8b88068aaf89b5db6419f1484) | `` automatic update `` |