### PR TITLE
chore(flake/nur): `af2605b5` -> `d16cada7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755981900,
-        "narHash": "sha256-LDuCCE56Qm6m74Wlweo0RIHsZVF6Kj5UN+LLNxSe3Iw=",
+        "lastModified": 1756006445,
+        "narHash": "sha256-iygY3JmHaR4QNJueohhtEFGWUZv9cKUuO8yBZYvanmc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af2605b5e79051af019d61c6d5fa180101feb75b",
+        "rev": "d16cada7d10863ed3fbfdf42ecd22d2a5866c271",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d16cada7`](https://github.com/nix-community/NUR/commit/d16cada7d10863ed3fbfdf42ecd22d2a5866c271) | `` automatic update `` |
| [`55d8c47a`](https://github.com/nix-community/NUR/commit/55d8c47a1c60d0280a18c126fc087311327494ce) | `` automatic update `` |
| [`92972b42`](https://github.com/nix-community/NUR/commit/92972b4260142ff0528c34f5740c6c845dbc81ef) | `` automatic update `` |
| [`20caa31d`](https://github.com/nix-community/NUR/commit/20caa31dbef80914895e41b56be4cabc740b2126) | `` automatic update `` |