### PR TITLE
chore(flake/nur): `d16cada7` -> `12e8be26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756006445,
-        "narHash": "sha256-iygY3JmHaR4QNJueohhtEFGWUZv9cKUuO8yBZYvanmc=",
+        "lastModified": 1756011632,
+        "narHash": "sha256-FTEAUDUYH/7uHBkEq4V5+9JJHH7alvDmeS6YDJIpDxE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d16cada7d10863ed3fbfdf42ecd22d2a5866c271",
+        "rev": "12e8be26cf39b4e3a3a303a3c3b8034667f4c1f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`12e8be26`](https://github.com/nix-community/NUR/commit/12e8be26cf39b4e3a3a303a3c3b8034667f4c1f8) | `` automatic update `` |
| [`63954461`](https://github.com/nix-community/NUR/commit/63954461eb7acad315e038a1936acf62c5f8b2a6) | `` automatic update `` |
| [`91b1a7c3`](https://github.com/nix-community/NUR/commit/91b1a7c35515c114697a63f616d0676364b62b7b) | `` automatic update `` |
| [`a8871110`](https://github.com/nix-community/NUR/commit/a887111066805187e95e20c3ca7272639bd61617) | `` automatic update `` |