### PR TITLE
chore(flake/nixpkgs): `9cb344e9` -> `b1b32914`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1755704039,
-        "narHash": "sha256-gKlP0LbyJ3qX0KObfIWcp5nbuHSb5EHwIvU6UcNBg2A=",
+        "lastModified": 1755922037,
+        "narHash": "sha256-wY1+2JPH0ZZC4BQefoZw/k+3+DowFyfOxv17CN/idKs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9cb344e96d5b6918e94e1bca2d9f3ea1e9615545",
+        "rev": "b1b3291469652d5a2edb0becc4ef0246fff97a7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`c552d68f`](https://github.com/NixOS/nixpkgs/commit/c552d68f510a569699f36b3b081baa62add3c033) | `` ejabberd: 25.07 -> 25.08 ``                                            |
| [`6f999f45`](https://github.com/NixOS/nixpkgs/commit/6f999f457b0f57bdbb636ae09c0ebdfcab59c499) | `` ejabberd: add toastal to maintainers ``                                |
| [`8389303c`](https://github.com/NixOS/nixpkgs/commit/8389303cb6b2e8b3e51c9f1b1e6594d37bbc9dc2) | `` ejabberd: 25.04 → 25.07 ``                                             |
| [`005d02e8`](https://github.com/NixOS/nixpkgs/commit/005d02e8209b803612e624cbc1d845c95b9e5be8) | `` weechat-unwrapped: 4.7.0 -> 4.7.1 ``                                   |
| [`336086ca`](https://github.com/NixOS/nixpkgs/commit/336086ca1b1b33dbee6a0d17bb7627504c0615c3) | `` findup: 1.1.2 -> 1.1.3 ``                                              |
| [`135ab63e`](https://github.com/NixOS/nixpkgs/commit/135ab63e1422fba4af1d33d227af1f216aaba9e0) | `` actions/checkout: update input descriptions ``                         |
| [`a387b2ed`](https://github.com/NixOS/nixpkgs/commit/a387b2ed61fc227d525aadfe658a21377cf2e2ce) | `` ci: remove python-updates from development branches ``                 |
| [`413daa84`](https://github.com/NixOS/nixpkgs/commit/413daa84dd16bb6ee08fc59c052a2376ef780ebe) | `` lighttpd: 1.4.80 -> 1.4.81 ``                                          |
| [`828a1b9c`](https://github.com/NixOS/nixpkgs/commit/828a1b9ce46ad450b884ab9a05ecfbf5025a2f82) | `` envoy-bin: 1.34.4 -> 1.34.5 ``                                         |
| [`1646453f`](https://github.com/NixOS/nixpkgs/commit/1646453f34812059aa625e0ddc1e0b8ff5b0fe1a) | `` workflows/eval: pass outpaths via cachix instead of artifacts ``       |
| [`08072590`](https://github.com/NixOS/nixpkgs/commit/08072590751ec047c5e4eaba93645517a7011fa1) | `` actions/checkout: always checkout pinned commits ``                    |
| [`1ca85055`](https://github.com/NixOS/nixpkgs/commit/1ca85055787cbf5fff7ecf2ed5e98208157ba2e6) | `` actions/checkout: use single tmpfs with subfolders ``                  |
| [`4f6f5acd`](https://github.com/NixOS/nixpkgs/commit/4f6f5acdc5ad3f84795898f8ce087a4cf0f6bff9) | `` qdigidoc: 4.8.0 -> 4.8.2 ``                                            |
| [`b0e0a560`](https://github.com/NixOS/nixpkgs/commit/b0e0a560da1cb3b945e8c0fd36715b88cbb95e37) | `` ci/github-script/commits: fix logging no-cherry-pick message ``        |
| [`cafd0bbe`](https://github.com/NixOS/nixpkgs/commit/cafd0bbe8a3ec134643bba857a2f8a20f6360ade) | `` ci/github-script/commits: fix not-cherry-picked-because regex ``       |
| [`04bd7046`](https://github.com/NixOS/nixpkgs/commit/04bd70460a061d4b85251c298bf255e183592aa8) | `` radicle-tui: use fetchFromRadicle ``                                   |
| [`8ebf0ecc`](https://github.com/NixOS/nixpkgs/commit/8ebf0ecc5319de54412242fe346b5f729ecc6409) | `` radicle-httpd: use fetchFromRadicle ``                                 |
| [`c1806c3f`](https://github.com/NixOS/nixpkgs/commit/c1806c3f8826fd5b70dde733a34ee236c5b9c7f9) | `` radicle-node: use fetchFromRadicle ``                                  |
| [`68893088`](https://github.com/NixOS/nixpkgs/commit/688930885e430739290930f13c4198b033806d46) | `` fetchFromRadicle: init ``                                              |
| [`6e3f4fa9`](https://github.com/NixOS/nixpkgs/commit/6e3f4fa9be56355d4a2ca885dd969faa4f41392c) | `` radicle-explorer: fix src hash ``                                      |
| [`ef7d4c27`](https://github.com/NixOS/nixpkgs/commit/ef7d4c27387fe5d8860f60b91720f974a74b99ea) | `` radicle-tui: init at 0.6.0 ``                                          |
| [`b9331e12`](https://github.com/NixOS/nixpkgs/commit/b9331e1289895f0a4e60b26cd4470da51d093600) | `` vivaldi: 7.5.3735.58 -> 7.5.3735.64 ``                                 |
| [`1f6bd8f0`](https://github.com/NixOS/nixpkgs/commit/1f6bd8f0fe4656f619c523873dde7079f3412f5c) | `` claude-code: 1.0.84 -> 1.0.85 ``                                       |
| [`8c36e4d4`](https://github.com/NixOS/nixpkgs/commit/8c36e4d44e3641b1a10fb853cd851d362f7730a9) | `` ncdu: 2.9 -> 2.9.1 ``                                                  |
| [`27ce6ac1`](https://github.com/NixOS/nixpkgs/commit/27ce6ac178982170e855f11dd4554f966c053f67) | `` actions/checkout: parallelize checkout of multiple commits on tmpfs `` |
| [`bfc38e76`](https://github.com/NixOS/nixpkgs/commit/bfc38e76ca7b949d0c457367f2efab5ab452ab12) | `` vimPlugins.commasemi-nvim: init at 2025-03-06 ``                       |
| [`13605ada`](https://github.com/NixOS/nixpkgs/commit/13605ada4d475bd6c100ca2b1a75b1dd2c201ff6) | `` ci: disable aliases in CI's pkgs instance ``                           |
| [`cbb22239`](https://github.com/NixOS/nixpkgs/commit/cbb222390828a56246a002f0b6ee8d6a4121225e) | `` ci: explicitly define `programs.nixfmt.package` ``                     |
| [`2c55a15c`](https://github.com/NixOS/nixpkgs/commit/2c55a15c1e83956d54f0f63c9053b9505f92b1a8) | `` ci: reformat comment ``                                                |
| [`6c4086f5`](https://github.com/NixOS/nixpkgs/commit/6c4086f5dac694239c814b87f86525860e08116f) | `` librewolf-bin-unwrapped: 141.0.3-1 -> 142.0.1 ``                       |
| [`be59626a`](https://github.com/NixOS/nixpkgs/commit/be59626a3a6cbfa89e1a5dad1461148c13a8533d) | `` vrcx: 2025.06.30 -> 2025.08.17 ``                                      |
| [`7267b548`](https://github.com/NixOS/nixpkgs/commit/7267b548ae7aa940afec52c79d393a98cae23475) | `` miniflux: 2.2.11 -> 2.2.12 ``                                          |
| [`2c3773b8`](https://github.com/NixOS/nixpkgs/commit/2c3773b88cc924035d7affcaaa3c9e172bd5d857) | `` p2pool: add jk to maintainers ``                                       |
| [`85baa458`](https://github.com/NixOS/nixpkgs/commit/85baa458e04cfb136adde8b610d8614972ff6189) | `` p2pool: reduce usage of `with lib;` ``                                 |
| [`16b10ccd`](https://github.com/NixOS/nixpkgs/commit/16b10ccd8b0828681215c08803335b50f29fa4b5) | `` p2pool: move to finalAttrs pattern ``                                  |
| [`34dcdeb6`](https://github.com/NixOS/nixpkgs/commit/34dcdeb6b2d34f1e3ddd660c9d65c0012fdc1738) | `` p2pool: 4.9 -> 4.9.1 ``                                                |
| [`9971d819`](https://github.com/NixOS/nixpkgs/commit/9971d819cb5cdf9bbf30cd051909bcd1635337fa) | `` nixosTests.prometheus-exporters.smokeping: fix test after 0.10.0 ``    |
| [`09a3e3cf`](https://github.com/NixOS/nixpkgs/commit/09a3e3cf18554bf85e72f78e4a9a42848c90daef) | `` ci/nixpkgs-vet: use Nix 2.30+ inside sandbox ``                        |
| [`45731886`](https://github.com/NixOS/nixpkgs/commit/457318865ad62249d959582e1cee336a89cec00f) | `` ungoogled-chromium: 139.0.7258.127-1 -> 139.0.7258.138-1 ``            |
| [`15bc3339`](https://github.com/NixOS/nixpkgs/commit/15bc3339fe34120a3ba2f5912b8b64865c85d96f) | `` ente-auth: 4.4.3 -> 4.4.4 ``                                           |
| [`02a696bc`](https://github.com/NixOS/nixpkgs/commit/02a696bccd681ae5ea5538f300d6fca493b99d02) | `` ci,modules: Backport additions of #431450 ``                           |
| [`359f951e`](https://github.com/NixOS/nixpkgs/commit/359f951ea7bd8b3f8f207d2ee9bb08113c33c457) | `` ruby_3_2: 3.2.8 -> 3.2.9 ``                                            |
| [`849eb9d0`](https://github.com/NixOS/nixpkgs/commit/849eb9d065a1ec0303df681a4e5867c6f88c83be) | `` flightgear: use forked openscenegraph ``                               |
| [`6e08fa3d`](https://github.com/NixOS/nixpkgs/commit/6e08fa3d0fd6890168de2df364e741267add260b) | `` lock: 1.7.1 -> 1.7.3 ``                                                |
| [`27c7bb1b`](https://github.com/NixOS/nixpkgs/commit/27c7bb1b4530722824216088e2721e8a5b53b4b6) | `` maintainers: add omarjatoi ``                                          |
| [`c5d1bca4`](https://github.com/NixOS/nixpkgs/commit/c5d1bca4c65879075b021bac4b1aa6d67c187554) | `` claude-code: 1.0.83 -> 1.0.84 ``                                       |
| [`9a08507f`](https://github.com/NixOS/nixpkgs/commit/9a08507f38232ce9f7a99e35c73d187291c229d1) | `` claude-code: 1.0.81 -> 1.0.83 ``                                       |
| [`075a240c`](https://github.com/NixOS/nixpkgs/commit/075a240cc4ed317eefe709c9e515e2688cad4198) | `` claude-code: 1.0.80 -> 1.0.81 ``                                       |
| [`2af0d9c0`](https://github.com/NixOS/nixpkgs/commit/2af0d9c000b30cc8f3ea6568bf71debfa730b938) | `` claude-code: 1.0.74 -> 1.0.80 ``                                       |
| [`0f4a82a8`](https://github.com/NixOS/nixpkgs/commit/0f4a82a88a9ee79b19c984ba239ef211fe78afd8) | `` claude-code: 1.0.73 -> 1.0.74 ``                                       |
| [`4cf564a0`](https://github.com/NixOS/nixpkgs/commit/4cf564a0bd912101a433dd5c269c91ce8f462328) | `` claude-code: 1.0.72 -> 1.0.73 ``                                       |
| [`3da5e660`](https://github.com/NixOS/nixpkgs/commit/3da5e6601ad5ed7703519d34e0f6c8e7c31be78f) | `` claude-code: 1.0.71 -> 1.0.72 ``                                       |
| [`3fd94ad0`](https://github.com/NixOS/nixpkgs/commit/3fd94ad0cc920575ac42133068726d0e554b3eff) | `` claude-code: 1.0.70 -> 1.0.71 ``                                       |
| [`a552abb2`](https://github.com/NixOS/nixpkgs/commit/a552abb244eb6ad4d8b8774ccd68a094334e1b27) | `` claude-code: 1.0.69 -> 1.0.70 ``                                       |
| [`8ea86f9c`](https://github.com/NixOS/nixpkgs/commit/8ea86f9cbe19927a9defb72cc45fda0b1686fab3) | `` claude-code: 1.0.67 -> 1.0.69 (#431362) ``                             |
| [`03387cb5`](https://github.com/NixOS/nixpkgs/commit/03387cb547de68b4049505d7f8664e02c092144e) | `` claude-code: 1.0.65 -> 1.0.67 ``                                       |
| [`e9f0fb0d`](https://github.com/NixOS/nixpkgs/commit/e9f0fb0dfc4e90a8d59c4a4db273567eefd0dcb3) | `` claude-code: 1.0.64 -> 1.0.65 ``                                       |
| [`c0ecdfd9`](https://github.com/NixOS/nixpkgs/commit/c0ecdfd9ef6eefc8010565cbcd19cc0bf3a832f8) | `` claude-code: 1.0.62 -> 1.0.64 ``                                       |
| [`e6c60ba1`](https://github.com/NixOS/nixpkgs/commit/e6c60ba199fca81bd9851a8fb87fc164110b237c) | `` claude-code: 1.0.61 -> 1.0.62 ``                                       |
| [`38cac5ca`](https://github.com/NixOS/nixpkgs/commit/38cac5ca3222236cf76f54bbee55bb4b599c591e) | `` claude-code: add markus1189 to maintainers ``                          |
| [`40f12fe2`](https://github.com/NixOS/nixpkgs/commit/40f12fe28e1cc6a3cf3190ef10800729d895a900) | `` claude-code: 1.0.60 -> 1.0.61 ``                                       |
| [`fc373aff`](https://github.com/NixOS/nixpkgs/commit/fc373affaf72534e93e562e4c4f37decb2ccba31) | `` claude-code: 1.0.58 -> 1.0.60 ``                                       |
| [`13a97660`](https://github.com/NixOS/nixpkgs/commit/13a976609ebede54bc3730ab3bc34661192e9c63) | `` claude-code: 1.0.57 -> 1.0.58 ``                                       |
| [`367c84b8`](https://github.com/NixOS/nixpkgs/commit/367c84b85f8d4af05d8877db91c02c2627fbd7f5) | `` claude-code: 1.0.56 -> 1.0.57 ``                                       |
| [`aaf310a7`](https://github.com/NixOS/nixpkgs/commit/aaf310a74bb38f0759d40605c01853b3da75c8bc) | `` claude-code: 1.0.55 -> 1.0.56 ``                                       |
| [`d50381bb`](https://github.com/NixOS/nixpkgs/commit/d50381bb0843f2ae00a64c55662a76675327927f) | `` claude-code: 1.0.54 -> 1.0.55 ``                                       |
| [`493ec9b6`](https://github.com/NixOS/nixpkgs/commit/493ec9b6c27bc6322ffd5362f51026dcc68f03b5) | `` claude-code: 1.0.53 -> 1.0.54 ``                                       |
| [`f23cfc13`](https://github.com/NixOS/nixpkgs/commit/f23cfc1338c8bd3dd57cd4012da97f4511c528ff) | `` claude-code: 1.0.51 -> 1.0.53 ``                                       |
| [`8afaee98`](https://github.com/NixOS/nixpkgs/commit/8afaee98613bad06e7b2185f8ef62df16a51d06f) | `` claude-code: 1.0.48 -> 1.0.51 ``                                       |
| [`96798132`](https://github.com/NixOS/nixpkgs/commit/967981326d0995efedde3e5ae1f3a2aacf60b246) | `` claude-code: 1.0.44 -> 1.0.48 ``                                       |
| [`24a7f0eb`](https://github.com/NixOS/nixpkgs/commit/24a7f0eb89567d663025b53afb863602a85a658e) | `` claude-code: fix issue with DEV=true ``                                |
| [`c4257ec9`](https://github.com/NixOS/nixpkgs/commit/c4257ec9e59ca8e804253d1e929d25711969261b) | `` claude-code: 1.0.43 -> 1.0.44 ``                                       |
| [`575530c8`](https://github.com/NixOS/nixpkgs/commit/575530c8c4e0e1a484d5fa10e91c3b89a1d46a6f) | `` claude-code: 1.0.41 -> 1.0.43 ``                                       |
| [`9b2586e3`](https://github.com/NixOS/nixpkgs/commit/9b2586e361eb49e160b32a3cd6caef74ea662952) | `` claude-code: 1.0.38 -> 1.0.41 ``                                       |
| [`9376fe68`](https://github.com/NixOS/nixpkgs/commit/9376fe68081b3f9963a116c4adfc2dc9ca886ec3) | `` claude-code: 1.0.35 -> 1.0.38 ``                                       |
| [`c30799a7`](https://github.com/NixOS/nixpkgs/commit/c30799a79ba1ff2e0bd72320b0fc1e4c6b0ed4fd) | `` claude-code: 1.0.33 -> 1.0.35 ``                                       |
| [`c99ab8c3`](https://github.com/NixOS/nixpkgs/commit/c99ab8c3d57dd1a3e6818ff3291d2417dbc9874b) | `` claude-code: 1.0.30 -> 1.0.33 (#419510) ``                             |
| [`dac415dc`](https://github.com/NixOS/nixpkgs/commit/dac415dc75ed51f56abddf4761e86e0d9c610d6d) | `` claude-code: 1.0.29 -> 1.0.30 ``                                       |
| [`03f518f2`](https://github.com/NixOS/nixpkgs/commit/03f518f28e77d686f6ead565f1a3dcee32b04a4f) | `` claude-code: 1.0.24 -> 1.0.29 ``                                       |
| [`a7ccbba7`](https://github.com/NixOS/nixpkgs/commit/a7ccbba71d7649d1826eff6b596a7804613463cb) | `` claude-code: add omarjatoi to maintainers ``                           |
| [`31f1bca5`](https://github.com/NixOS/nixpkgs/commit/31f1bca5af2fa224025e0c9109cc383ffde7539c) | `` claude-code: 1.0.21 -> 1.0.24 ``                                       |
| [`8419d07b`](https://github.com/NixOS/nixpkgs/commit/8419d07be27c69c93c679b35779a15d8abf304ba) | `` claude-code: 1.0.17 -> 1.0.21 ``                                       |
| [`059b3cac`](https://github.com/NixOS/nixpkgs/commit/059b3cacd3ea26babe80191265e96e48744f3b7a) | `` claude-code: 1.0.11 -> 1.0.17 ``                                       |
| [`05c46561`](https://github.com/NixOS/nixpkgs/commit/05c4656185a02688a8ab104f69ab73704cc89d5e) | `` claude-code: 1.0.6 -> 1.0.11 (#413858) ``                              |
| [`b1efba88`](https://github.com/NixOS/nixpkgs/commit/b1efba8836715210ef26d77ad83bb67c9cc122a8) | `` claude-code: 1.0.5 -> 1.0.6 ``                                         |
| [`083f1de9`](https://github.com/NixOS/nixpkgs/commit/083f1de91e41ff363de8f8bc81612dbba0b915f6) | `` claude-code: 1.0.3 -> 1.0.5 ``                                         |
| [`13f1f46b`](https://github.com/NixOS/nixpkgs/commit/13f1f46b48ef7cbeb6bbd3370f3c77f80fd17a0a) | `` claude-code: 1.0.2 -> 1.0.3 ``                                         |
| [`8fc6025d`](https://github.com/NixOS/nixpkgs/commit/8fc6025da07dc34d2e13b8b4ac2fe720f01592bd) | `` claude-code: 1.0.0 -> 1.0.2 ``                                         |
| [`1d573602`](https://github.com/NixOS/nixpkgs/commit/1d5736028e3a26143f8025511b48b85a76d7f2b2) | `` claude-code: 0.2.122 -> 1.0.0 ``                                       |
| [`17424b11`](https://github.com/NixOS/nixpkgs/commit/17424b113500efad8686ae094cf97392de2201bf) | `` claude-code: 0.2.109 -> 0.2.122 ``                                     |
| [`fb0f8d87`](https://github.com/NixOS/nixpkgs/commit/fb0f8d873944462c0c3edb5254b4c52bf11be484) | `` brave: 1.81.135 -> 1.81.136 ``                                         |
| [`fec9d062`](https://github.com/NixOS/nixpkgs/commit/fec9d0622968da0ab1b8988ccb4ca047198b86d7) | `` geph: 0.2.72 -> 0.2.77 ``                                              |
| [`fc3ea869`](https://github.com/NixOS/nixpkgs/commit/fc3ea8697bf4186055ef3c5e1a03c9a61a943ffc) | `` buildstream: 2.4.1 -> 2.5.0 ``                                         |
| [`83f65557`](https://github.com/NixOS/nixpkgs/commit/83f65557e69aeea4f60df641b83a7829f945d043) | `` matrix-alertmanager-receiver: 2025.8.6 -> 2025.8.20 ``                 |
| [`efc86c05`](https://github.com/NixOS/nixpkgs/commit/efc86c058ce9e67c8c639814afc5faeac6d694f2) | `` matrix-alertmanager-receiver: 2025.7.30 -> 2025.8.6 ``                 |
| [`494c83bf`](https://github.com/NixOS/nixpkgs/commit/494c83bf05ad4245fccf88bc561b39446c6af035) | `` garnet: 1.0.81 -> 1.0.82 ``                                            |
| [`ef795d58`](https://github.com/NixOS/nixpkgs/commit/ef795d583cd6845a0e39e3f0afa0e2ae70f3b643) | `` garnet: 1.0.80 -> 1.0.81 ``                                            |
| [`0775958f`](https://github.com/NixOS/nixpkgs/commit/0775958f96c1706c61928f322434d9efed5166d5) | `` tauno-monitor: 0.2.11 -> 0.2.15 ``                                     |
| [`6cc8a229`](https://github.com/NixOS/nixpkgs/commit/6cc8a229ba0029e6ebdafc1e26e51790deed10d2) | `` open62541: 1.4.12 -> 1.4.13 ``                                         |
| [`c966bf5f`](https://github.com/NixOS/nixpkgs/commit/c966bf5fd4f17eed5448846ad056527c980ea780) | `` mautrix-slack: 0.2.2 -> 0.2.3 ``                                       |
| [`045ef578`](https://github.com/NixOS/nixpkgs/commit/045ef5783370c7a7dd87e49d428bb25e91b08ef9) | `` mautrix-slack: 0.2.1 -> 0.2.2 ``                                       |
| [`9b25c330`](https://github.com/NixOS/nixpkgs/commit/9b25c330be40afe4b8be9a493439f81aaae27d5f) | `` tor-browser: added maintainer @c4patino ``                             |
| [`3ec0718b`](https://github.com/NixOS/nixpkgs/commit/3ec0718b0504e081e28c9c6961cdf504934729b1) | `` tor-browser: 14.5.5 -> 14.5.6 ``                                       |
| [`ac552186`](https://github.com/NixOS/nixpkgs/commit/ac552186464c77a9783556bfc4229a0c7b5e7616) | `` chromium,chromedriver: 139.0.7258.127 -> 139.0.7258.138 ``             |
| [`f1f40958`](https://github.com/NixOS/nixpkgs/commit/f1f409581a4bdaba49a8fb162337e1b1bcdc2ec3) | `` linux_6_12: 6.12.42 -> 6.12.43 ``                                      |
| [`7881bf6f`](https://github.com/NixOS/nixpkgs/commit/7881bf6f00ea6298901bb31e3544fc664ccbf403) | `` linux_6_15: 6.15.10 -> 6.15.11 ``                                      |
| [`dd859314`](https://github.com/NixOS/nixpkgs/commit/dd859314e92ce5546b8aa6441d276f6db3e2f1ed) | `` linux_6_16: 6.16.1 -> 6.16.2 ``                                        |
| [`6e36853a`](https://github.com/NixOS/nixpkgs/commit/6e36853a915e20acd89f006dd455072353f05367) | `` linux_testing: 6.17-rc1 -> 6.17-rc2 ``                                 |
| [`9268ef3c`](https://github.com/NixOS/nixpkgs/commit/9268ef3c0301f446ecf242fc9107861369c98887) | `` sydbox: 3.37.6 -> 3.37.8 ``                                            |
| [`8622d9ff`](https://github.com/NixOS/nixpkgs/commit/8622d9ff885f5f660830c606a5b7372c04945ea4) | `` xwayland-satellite: 0.6 -> 0.7 ``                                      |
| [`35b71aac`](https://github.com/NixOS/nixpkgs/commit/35b71aacc498f9f4d64ecd5a7595824aabcd6a42) | `` riffdiff: 3.4.0 -> 3.4.1 ``                                            |
| [`3d11e6cd`](https://github.com/NixOS/nixpkgs/commit/3d11e6cda5b0501f6b8eb1306ed97bfe5a799d44) | `` treewide: `donteatoreo` -> `FlameFlag` ``                              |
| [`62239bc1`](https://github.com/NixOS/nixpkgs/commit/62239bc159bb03b91e6bff11bb3a44a39f2c56fc) | `` floorp: 11.29.0 -> 11.30.0 ``                                          |
| [`99fac9c2`](https://github.com/NixOS/nixpkgs/commit/99fac9c2b31b23284ea04e4c6ede90f8d9c13ae3) | `` maintainers: `donteatoreo` -> `FlameFlag` ``                           |
| [`e0654c9c`](https://github.com/NixOS/nixpkgs/commit/e0654c9c9af9c73a4beb5b548aaf83357fbca43d) | `` flyctl: 0.3.169 -> 0.3.171 ``                                          |
| [`6c3e70f0`](https://github.com/NixOS/nixpkgs/commit/6c3e70f0b5fe8563843bd65e0c0ce5dc1b37e2a2) | `` maintainers: update c4thebomb -> c4patino and add gpg key ``           |
| [`1d5b0b9e`](https://github.com/NixOS/nixpkgs/commit/1d5b0b9e95539ec5af44def19c215f4a99850f52) | `` actions/checkout: remove unused input types ``                         |
| [`599c6c4e`](https://github.com/NixOS/nixpkgs/commit/599c6c4e7fde7a0d2d2dca8f4250f326b3ff6cd2) | `` workflows/pr.prepare: specify cone mode explicitly ``                  |
| [`1e8419b5`](https://github.com/NixOS/nixpkgs/commit/1e8419b52e69ca0189a41e83f71329ccaaabe1f1) | `` ci/github-script/prepare: fix logging of branch classification ``      |
| [`9b0135b3`](https://github.com/NixOS/nixpkgs/commit/9b0135b3477b07c53dcf0c58dfe0963e5e2e96e4) | `` ci/github-script/prepare: determine changed files ``                   |
| [`5b613376`](https://github.com/NixOS/nixpkgs/commit/5b6133762099874b2a9b2bc354c538b969aa1012) | `` ci/github-script/prepare: classify branches ``                         |
| [`51298d2e`](https://github.com/NixOS/nixpkgs/commit/51298d2e28f9b1e790fb7297926b552a839a3f0d) | `` ci/github-script/prepare: load systems ``                              |
| [`70fc919b`](https://github.com/NixOS/nixpkgs/commit/70fc919bde014d1b33fa341abd594e40e0ea77f8) | `` actions/checkout: rename inconsistent pinned-from input ``             |
| [`7d405339`](https://github.com/NixOS/nixpkgs/commit/7d405339b3c59d0162d329aeb91ca3cd21a69ec9) | `` actions/checkout: rename from actions/get-merge-commit ``              |
| [`4c5bae6e`](https://github.com/NixOS/nixpkgs/commit/4c5bae6e3f9af502f499e958abb9502a24566eec) | `` workflows/build: prevent pushing tarball to cachix ``                  |
| [`0c354911`](https://github.com/NixOS/nixpkgs/commit/0c3549113bee761508b921036dbee8d474268dce) | `` workflows/eval: add cachix ``                                          |
| [`16321a25`](https://github.com/NixOS/nixpkgs/commit/16321a259b90d812c0394320e860c6afcd8a45f6) | `` ci/nixpkgs-vet: ignore .github/ and ci/ folders ``                     |
| [`053b8e38`](https://github.com/NixOS/nixpkgs/commit/053b8e38d659af9dc7f6a352a2e1c69cc417c27e) | `` ci/nixpkgs-vet: memoize filesets ``                                    |
| [`b431f97a`](https://github.com/NixOS/nixpkgs/commit/b431f97a1c6b4f446bf0ea68796e890d305e6341) | `` workflows/lint: add cachix ``                                          |
| [`e3ff0fab`](https://github.com/NixOS/nixpkgs/commit/e3ff0fab42ed01dc1f45ab538f957d68fcfa7c6c) | `` workflows: never push source to cachix ``                              |
| [`28c86b23`](https://github.com/NixOS/nixpkgs/commit/28c86b235961ea7312523111cb2e8669df183d7e) | `` workflows: support cachix in forks ``                                  |
| [`2f045526`](https://github.com/NixOS/nixpkgs/commit/2f045526231fbb2a2adb672e461464cc2174c747) | `` firefox-esr-140-unwrapped: 140.1.0esr -> 140.2.0esr ``                 |
| [`e6303e72`](https://github.com/NixOS/nixpkgs/commit/e6303e7245d55dd8f3096007d72efe47d70115a0) | `` firefox-bin-unwrapped: 141.0.3 -> 142.0 ``                             |
| [`b5e579aa`](https://github.com/NixOS/nixpkgs/commit/b5e579aa9f2a84a3ecaeb90d624ff07ac7d192c8) | `` firefox-unwrapped: 141.0.3 -> 142.0 ``                                 |
| [`efc27cc6`](https://github.com/NixOS/nixpkgs/commit/efc27cc653c764e40d1bd1c2f57c05d14623222f) | `` librewolf-unwrapped: 141.0.3-1 -> 142.0.1 ``                           |
| [`5bd96697`](https://github.com/NixOS/nixpkgs/commit/5bd96697ac7ee12d7f43454b1bf3d594d4e0d9d1) | `` raycast: 1.102.4 -> 1.102.5 ``                                         |
| [`f51b3124`](https://github.com/NixOS/nixpkgs/commit/f51b31241fc522b28f3a2606721795387a4a6f63) | `` yt-dlp: 2025.08.11 -> 2025.08.20 ``                                    |
| [`31e468da`](https://github.com/NixOS/nixpkgs/commit/31e468da7f9e5b98b585879a166b5cfe17de1a4b) | `` monero-{cli,gui}: 0.18.4.0 -> 0.18.4.1 ``                              |
| [`f86d2faf`](https://github.com/NixOS/nixpkgs/commit/f86d2fafa7bbe6b4a24ae7400fedf46b96c64c10) | `` qq: 3.2.18-2025-07-24 -> 3.2.19-2025-08-20 ``                          |
| [`c1b3d7d4`](https://github.com/NixOS/nixpkgs/commit/c1b3d7d4eb4617d13d48b15f481e8f916af13e9c) | `` matrix-authentication-service: 0.20.0 -> 1.0.0 ``                      |
| [`10df93eb`](https://github.com/NixOS/nixpkgs/commit/10df93eb75c949c12ec2c46c453ec1b3fc0b0bbd) | `` kubernix: 0.2.0 -> 0.2.0-unstable-2021-11-16 ``                        |
| [`8435e8ba`](https://github.com/NixOS/nixpkgs/commit/8435e8bacba852c11ee413548c36fa1f173fb1e1) | `` nix-fast-build: 1.2.0 -> 1.3.0 ``                                      |
| [`1042f441`](https://github.com/NixOS/nixpkgs/commit/1042f441a0bcae7495fcc22edc054dde018bc3ac) | `` github-runner: 2.326.0 -> 2.327.1 ``                                   |
| [`11f226d1`](https://github.com/NixOS/nixpkgs/commit/11f226d19dd1524fa4a4c16c8075c69889b05875) | `` nixos/vector: add option to disable the configuration validation ``    |
| [`e6279c5e`](https://github.com/NixOS/nixpkgs/commit/e6279c5e3533dad588a123d0b5fa5075181edcc4) | `` nixos/vector: add graceful shutdown limit option ``                    |