### PR TITLE
chore(flake/catppuccin): `233b344b` -> `ad015344`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1755850042,
-        "narHash": "sha256-YooO7k/ufm8KGVqSAV9edGkv3Cm07cvINSP478sWppo=",
+        "lastModified": 1756028045,
+        "narHash": "sha256-j6ehEdta7YnXtk42cdYQEElCKfnbe24yfeHJwszgyes=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "233b344b42072b30a00fef1d8bb9ffb73bf1af3d",
+        "rev": "ad015344f592b6ebb82de853b747dd577926ec77",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                            |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`ad015344`](https://github.com/catppuccin/nix/commit/ad015344f592b6ebb82de853b747dd577926ec77) | `` chore(vscode-icons): 1.21.0 -> 1.24.0 (#705) `` |