### PR TITLE
chore(flake/nur): `12e8be26` -> `f6233aca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756011632,
-        "narHash": "sha256-FTEAUDUYH/7uHBkEq4V5+9JJHH7alvDmeS6YDJIpDxE=",
+        "lastModified": 1756039442,
+        "narHash": "sha256-9b+H0ffms/voyIPeVZ12rTgKKGZGluGyix0FN8gyKns=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "12e8be26cf39b4e3a3a303a3c3b8034667f4c1f8",
+        "rev": "f6233aca7cff49a707f0ba551ccf460abbf4c902",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f6233aca`](https://github.com/nix-community/NUR/commit/f6233aca7cff49a707f0ba551ccf460abbf4c902) | `` automatic update `` |
| [`5ab0fe21`](https://github.com/nix-community/NUR/commit/5ab0fe2197dd07b82a11d01197d01656f6a1ff93) | `` automatic update `` |
| [`5bfb3e83`](https://github.com/nix-community/NUR/commit/5bfb3e837f6126c6aec3fc8d533525bbcf7e6577) | `` automatic update `` |