### PR TITLE
chore(flake/nur): `f6233aca` -> `a5d85d24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756039442,
-        "narHash": "sha256-9b+H0ffms/voyIPeVZ12rTgKKGZGluGyix0FN8gyKns=",
+        "lastModified": 1756049419,
+        "narHash": "sha256-ZH6ZcWBwieWeULOA0S93FAvL6ATKzJ+QLt3qPabSrSI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f6233aca7cff49a707f0ba551ccf460abbf4c902",
+        "rev": "a5d85d24fa84289d3d63e484bac7ccfe4e9182e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a5d85d24`](https://github.com/nix-community/NUR/commit/a5d85d24fa84289d3d63e484bac7ccfe4e9182e5) | `` automatic update `` |
| [`48577555`](https://github.com/nix-community/NUR/commit/485775552c60d1392244d9736b4a37f6ff121213) | `` automatic update `` |