### PR TITLE
chore(flake/nur): `a5d85d24` -> `98f1a1dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756049419,
-        "narHash": "sha256-ZH6ZcWBwieWeULOA0S93FAvL6ATKzJ+QLt3qPabSrSI=",
+        "lastModified": 1756054045,
+        "narHash": "sha256-qYT6DOLZwVzqseScLC1Qz3sVsw3zvpIqjL/s7vHEe6k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a5d85d24fa84289d3d63e484bac7ccfe4e9182e5",
+        "rev": "98f1a1dc68d023faa7e0cbcef46a1baa37c41c13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`98f1a1dc`](https://github.com/nix-community/NUR/commit/98f1a1dc68d023faa7e0cbcef46a1baa37c41c13) | `` automatic update `` |