### PR TITLE
chore(flake/nur): `d0e2a11f` -> `a88db488`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756092713,
-        "narHash": "sha256-HMqkuhIdsD0QUu45XsFIWP52rSyCfYSnwPdi69YaxKg=",
+        "lastModified": 1756101399,
+        "narHash": "sha256-LC57KVDiCmPR5nmvnKyIkAU9sSldvpkrngfaOTOSYfw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d0e2a11f41adaff4637c9901467cd16754dedbea",
+        "rev": "a88db4880062222fc64271ddc7fff57467e19f3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a88db488`](https://github.com/nix-community/NUR/commit/a88db4880062222fc64271ddc7fff57467e19f3f) | `` automatic update `` |
| [`e8a74dc6`](https://github.com/nix-community/NUR/commit/e8a74dc621bcb31effe2998d1950f4ebf4d505bd) | `` automatic update `` |
| [`0346d788`](https://github.com/nix-community/NUR/commit/0346d7888363a3c14538c102d899a93592d6cc46) | `` automatic update `` |
| [`f9ae6bb2`](https://github.com/nix-community/NUR/commit/f9ae6bb27ca0f9d4c2c2677dd320805a77178fa5) | `` automatic update `` |
| [`46b91b0e`](https://github.com/nix-community/NUR/commit/46b91b0ecf1276d20bf26549804ad764c3e679dc) | `` automatic update `` |