### PR TITLE
chore(flake/nur): `dd2d02cb` -> `10df67c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756112112,
-        "narHash": "sha256-sZNmd0w8aH3/DCBDq8xbmHVDp90KhLCSf6bGFiMWfC4=",
+        "lastModified": 1756119064,
+        "narHash": "sha256-icuxHZS74KdqeX3uYdaC65XZ4tJDkqPk/3z6sr+A2AY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd2d02cb1c8f6f14d83d223963bb7c51b8ccf865",
+        "rev": "10df67c5ae01fa7bcd18467c0415f4b00754e6fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`10df67c5`](https://github.com/nix-community/NUR/commit/10df67c5ae01fa7bcd18467c0415f4b00754e6fc) | `` automatic update `` |