### PR TITLE
chore(flake/nur): `dc884c08` -> `c9c985b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756133362,
-        "narHash": "sha256-Jl8qjtiZqBOD37LKtzu/IUflkJ1JLy0z255p83NXOZQ=",
+        "lastModified": 1756145408,
+        "narHash": "sha256-ltkbs5Watrq+V2l9hWefSdM7cfvxLkabtMJeZn0MiCo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dc884c082a0d84b774f78ffa9c715692dbff6862",
+        "rev": "c9c985b60eb46d97370f7d3fefdc300b953c044d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c9c985b6`](https://github.com/nix-community/NUR/commit/c9c985b60eb46d97370f7d3fefdc300b953c044d) | `` automatic update `` |
| [`3aada358`](https://github.com/nix-community/NUR/commit/3aada358b8b7fa629fa8ab3561286779e99f62fd) | `` automatic update `` |
| [`d17df02a`](https://github.com/nix-community/NUR/commit/d17df02acd4ed103147d6393a8162604065ab82b) | `` automatic update `` |