### PR TITLE
chore(flake/nur): `c9c985b6` -> `d81438d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756145408,
-        "narHash": "sha256-ltkbs5Watrq+V2l9hWefSdM7cfvxLkabtMJeZn0MiCo=",
+        "lastModified": 1756154233,
+        "narHash": "sha256-XKHIJ24aRmlQjqiv56OTvV70/IuK5CFmIP9v+NaBFOM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c9c985b60eb46d97370f7d3fefdc300b953c044d",
+        "rev": "d81438d52a643b84a8bdd7ed0ba39a8e3b97f628",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d81438d5`](https://github.com/nix-community/NUR/commit/d81438d52a643b84a8bdd7ed0ba39a8e3b97f628) | `` automatic update `` |
| [`6e1acb6d`](https://github.com/nix-community/NUR/commit/6e1acb6d05eb49ac32fdaf2ccf2fb50965d3d637) | `` automatic update `` |
| [`9dc277f6`](https://github.com/nix-community/NUR/commit/9dc277f6c14285ae5da982ace53ca208aa9cb253) | `` automatic update `` |
| [`619a7304`](https://github.com/nix-community/NUR/commit/619a7304cdb79098287729421d3efdfdf67f0cd7) | `` automatic update `` |
| [`35fdc605`](https://github.com/nix-community/NUR/commit/35fdc605987124c6ca01feee113fda2ed983d88e) | `` automatic update `` |