### PR TITLE
chore(flake/chaotic): `a12198a1` -> `4a5332e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1756074717,
-        "narHash": "sha256-zWS//20J1wFmKg7C+gZkSkR1DyrnkW0y2B6bgFaQ4cI=",
+        "lastModified": 1756168382,
+        "narHash": "sha256-qHwmBOx6RATjYkdoVzf+LN55DTBCAarTjs2ANNs7yzA=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "a12198a1d1af26d8bb639d8a9742f4a18269e840",
+        "rev": "4a5332e5a4eba9eac822b660c8c6acadc9501b48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                              |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`4a5332e5`](https://github.com/chaotic-cx/nyx/commit/4a5332e5a4eba9eac822b660c8c6acadc9501b48) | `` proton-cachyos: 10.0.20250714 -> 10.0.20250820 `` |
| [`9829be43`](https://github.com/chaotic-cx/nyx/commit/9829be43b30fa9aea5139475100e3489746cd185) | `` proton-cachyos: 10.0.20250714 -> 10.0.20250820 `` |
| [`a925c86e`](https://github.com/chaotic-cx/nyx/commit/a925c86e2ee3d13e39979975c8f8443eda53f6bb) | `` failures: update aarch64-linux ``                 |