### PR TITLE
chore(flake/nur): `787c0d97` -> `278516db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756173341,
-        "narHash": "sha256-w0+5LtgO54TvKGS7f0kVs12zd9PVykMme2+WSqQskfY=",
+        "lastModified": 1756179127,
+        "narHash": "sha256-X3V3G2GhSms2QT45olNd2hcU8MqlTdMxDSty+iWV1D0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "787c0d97fc77abc7507644bf9ef2c0d26464b70a",
+        "rev": "278516dbc557696d283514f8c33a054dcace4ace",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`278516db`](https://github.com/nix-community/NUR/commit/278516dbc557696d283514f8c33a054dcace4ace) | `` automatic update `` |
| [`d4fd8427`](https://github.com/nix-community/NUR/commit/d4fd84272c576f42573e7a76aaf81a41b36d214a) | `` automatic update `` |