### PR TITLE
chore(flake/nur): `278516db` -> `c8346270`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1755615617,
-        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "lastModified": 1756125398,
+        "narHash": "sha256-XexyKZpf46cMiO5Vbj+dWSAXOnr285GHsMch8FBoHbc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "rev": "3b9f00d7a7bf68acd4c4abb9d43695afb04e03a5",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756179127,
-        "narHash": "sha256-X3V3G2GhSms2QT45olNd2hcU8MqlTdMxDSty+iWV1D0=",
+        "lastModified": 1756189723,
+        "narHash": "sha256-KwW0i9R401Fl/+qaDgFlHWxSiX40SnLbZz2cw09HuQQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "278516dbc557696d283514f8c33a054dcace4ace",
+        "rev": "c83462704b8ccf212d7da8d6756861757ed5cd83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c8346270`](https://github.com/nix-community/NUR/commit/c83462704b8ccf212d7da8d6756861757ed5cd83) | `` automatic update `` |
| [`6e20ce5e`](https://github.com/nix-community/NUR/commit/6e20ce5e131fa16eea2784d1c35abebb1439d8fa) | `` automatic update `` |
| [`a07e9342`](https://github.com/nix-community/NUR/commit/a07e934226e4a8dea0a931e93d100eb5c5ce9404) | `` automatic update `` |
| [`88aa59a3`](https://github.com/nix-community/NUR/commit/88aa59a3d2cbc037699d533bb0fe958ba1d4371d) | `` automatic update `` |
| [`cb3ac54b`](https://github.com/nix-community/NUR/commit/cb3ac54bb0e710029890de14eb24926a0205d5af) | `` automatic update `` |
| [`5418a240`](https://github.com/nix-community/NUR/commit/5418a24093aaa78c9e877b0e6254c462c7f1b60a) | `` automatic update `` |