### PR TITLE
chore(flake/nur): `c8346270` -> `b1950898`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756189723,
-        "narHash": "sha256-KwW0i9R401Fl/+qaDgFlHWxSiX40SnLbZz2cw09HuQQ=",
+        "lastModified": 1756200256,
+        "narHash": "sha256-a3dZU7NAP+eVpctcrL9Pa63lJOe/JBSS2InM1Il9XCU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c83462704b8ccf212d7da8d6756861757ed5cd83",
+        "rev": "b195089853677d8f5bfef339057736aaca46a222",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b1950898`](https://github.com/nix-community/NUR/commit/b195089853677d8f5bfef339057736aaca46a222) | `` automatic update `` |
| [`26d9af72`](https://github.com/nix-community/NUR/commit/26d9af72ac41eed907f69b05866efee78f870925) | `` automatic update `` |
| [`5093f08b`](https://github.com/nix-community/NUR/commit/5093f08bc48b4aa62d0d55e4bcafc00a2d0f9a50) | `` automatic update `` |
| [`81e3bd13`](https://github.com/nix-community/NUR/commit/81e3bd138df1f68f3a768a6ce66a2bcedda2b149) | `` automatic update `` |
| [`6cd33d55`](https://github.com/nix-community/NUR/commit/6cd33d55c8d5a8b09800a9114e21ce92c60aee1c) | `` automatic update `` |