### PR TITLE
chore(flake/nur): `b1950898` -> `a3535b8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756200256,
-        "narHash": "sha256-a3dZU7NAP+eVpctcrL9Pa63lJOe/JBSS2InM1Il9XCU=",
+        "lastModified": 1756211264,
+        "narHash": "sha256-JP8aPndGgr68KTmOGteIGUwsyTv3fr80u3MHBycvP1g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b195089853677d8f5bfef339057736aaca46a222",
+        "rev": "a3535b8d6752d551f3ecfedd6440cf2a7a0ef839",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a3535b8d`](https://github.com/nix-community/NUR/commit/a3535b8d6752d551f3ecfedd6440cf2a7a0ef839) | `` automatic update `` |
| [`5395b789`](https://github.com/nix-community/NUR/commit/5395b789b6ffe8d445f9044825800eedfcc77c1e) | `` automatic update `` |
| [`5703c2e7`](https://github.com/nix-community/NUR/commit/5703c2e786cedb4b939a2acd6717a7f658e03f93) | `` automatic update `` |
| [`320af97c`](https://github.com/nix-community/NUR/commit/320af97cd25b03d8494ee13ce744eb4f030841a8) | `` automatic update `` |
| [`fd3f2c78`](https://github.com/nix-community/NUR/commit/fd3f2c785c408e1828ab7281b0ceb8b46307b545) | `` automatic update `` |
| [`b2cb4218`](https://github.com/nix-community/NUR/commit/b2cb4218df9568b515fef7adaea4bfefcadb4f2d) | `` automatic update `` |