### PR TITLE
chore(flake/nur): `1272a2e3` -> `9b93cfba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756219674,
-        "narHash": "sha256-AA9e6etDZwGCnkn3VTVwCjyfB3CcGZDbwVbZpKzeVOo=",
+        "lastModified": 1756233021,
+        "narHash": "sha256-Ry3XHRvu+nyIMHmq2pmxz/Y6E56yGpbnANe/efMXzzs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1272a2e336db343cff24461505375891f31e786e",
+        "rev": "9b93cfba00d9bce6022fba9a30cd63f3dc7c86bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9b93cfba`](https://github.com/nix-community/NUR/commit/9b93cfba00d9bce6022fba9a30cd63f3dc7c86bc) | `` automatic update `` |
| [`4ab446f4`](https://github.com/nix-community/NUR/commit/4ab446f4dca26b2f3d549a0fec85dbf99d12c251) | `` automatic update `` |
| [`f294db93`](https://github.com/nix-community/NUR/commit/f294db93bf5709df481b9d12ad9bb9ba1ec081fa) | `` automatic update `` |