### PR TITLE
chore(flake/nur): `9b93cfba` -> `02934957`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756233021,
-        "narHash": "sha256-Ry3XHRvu+nyIMHmq2pmxz/Y6E56yGpbnANe/efMXzzs=",
+        "lastModified": 1756241107,
+        "narHash": "sha256-5BxxnqwYE+9EYaPkV4LgHebleVOsvrvD5Zd+NwUc934=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b93cfba00d9bce6022fba9a30cd63f3dc7c86bc",
+        "rev": "029349570e7e2bd5256014035f9b5e0cfaf7f59b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                              |
| -------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`02934957`](https://github.com/nix-community/NUR/commit/029349570e7e2bd5256014035f9b5e0cfaf7f59b) | `` automatic update ``                               |
| [`980f3afa`](https://github.com/nix-community/NUR/commit/980f3afa0bef2b0c4a07ac2a5ab98bc9ac24aa69) | `` I bet this is more correct too ``                 |
| [`cfb55011`](https://github.com/nix-community/NUR/commit/cfb550112797ec57d97d22a91d05c09e06afa0ca) | `` fix: maybe using shutil.move will work better? `` |
| [`6f7706b1`](https://github.com/nix-community/NUR/commit/6f7706b1347ffc261a2a4f775880666902cef0d6) | `` fix: ci unformatted file ``                       |
| [`d9fa25f6`](https://github.com/nix-community/NUR/commit/d9fa25f61319872a5678595cdd07b4c00f2e7dd8) | `` Oops, missed a dirs_exist_ok ``                   |
| [`335d3c16`](https://github.com/nix-community/NUR/commit/335d3c168e984a2b3caced34f7d13f982e5379cc) | `` automatic update ``                               |
| [`f954417b`](https://github.com/nix-community/NUR/commit/f954417b89e8ff1a3a1674ea7812af63176bfe0c) | `` automatic update ``                               |
| [`d56a42ef`](https://github.com/nix-community/NUR/commit/d56a42ef8831e46cbfea49d8d6ed995397211689) | `` automatic update ``                               |