### PR TITLE
chore(flake/nur): `02934957` -> `b60e9210`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756241107,
-        "narHash": "sha256-5BxxnqwYE+9EYaPkV4LgHebleVOsvrvD5Zd+NwUc934=",
+        "lastModified": 1756252473,
+        "narHash": "sha256-uqVN0Mvs6FlKd93GPibttpukt8mKRTB/rlWN3PmSeW8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "029349570e7e2bd5256014035f9b5e0cfaf7f59b",
+        "rev": "b60e92106e48214f51e91eadbc099f2717af7167",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                           |
| -------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`b60e9210`](https://github.com/nix-community/NUR/commit/b60e92106e48214f51e91eadbc099f2717af7167) | `` automatic update ``            |
| [`506ce468`](https://github.com/nix-community/NUR/commit/506ce4680a7efe22b4b357ccf749bde6f42fe11d) | `` automatic update ``            |
| [`d972ed4c`](https://github.com/nix-community/NUR/commit/d972ed4c47dcf0406ce582d0f958610d9d6c469d) | `` add Ev357 repository ``        |
| [`14c7fc25`](https://github.com/nix-community/NUR/commit/14c7fc255bf2eb4e44a1892f1ed6fd88bd395cea) | `` fix: incorrect argument ``     |
| [`10cf97de`](https://github.com/nix-community/NUR/commit/10cf97dee46dd9ae6b10b182959d23172915b396) | `` fix: type error in copytree `` |
| [`91ff8049`](https://github.com/nix-community/NUR/commit/91ff8049dea88cecdb80034796c1ce297a6ceba2) | `` automatic update ``            |