### PR TITLE
chore(flake/nur): `b60e9210` -> `5e37e460`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756252473,
-        "narHash": "sha256-uqVN0Mvs6FlKd93GPibttpukt8mKRTB/rlWN3PmSeW8=",
+        "lastModified": 1756265421,
+        "narHash": "sha256-Z/QkAExN1/zuqUGCgHmkAyIGgsiwFXeCnPNX3viUFmI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b60e92106e48214f51e91eadbc099f2717af7167",
+        "rev": "5e37e460711df07217ab247f3fec3d8e1ecc0c3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5e37e460`](https://github.com/nix-community/NUR/commit/5e37e460711df07217ab247f3fec3d8e1ecc0c3b) | `` automatic update `` |
| [`d540f21a`](https://github.com/nix-community/NUR/commit/d540f21ac38e2339ccfef0552dc497204281a502) | `` automatic update `` |
| [`11f099c5`](https://github.com/nix-community/NUR/commit/11f099c5fd0cddb14352dfee7d56b54f3c6c6f91) | `` automatic update `` |
| [`147fbfd0`](https://github.com/nix-community/NUR/commit/147fbfd0361367d402111cc6abdcdb832bab9a17) | `` automatic update `` |