### PR TITLE
chore(flake/nur): `5e37e460` -> `0768df88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756265421,
-        "narHash": "sha256-Z/QkAExN1/zuqUGCgHmkAyIGgsiwFXeCnPNX3viUFmI=",
+        "lastModified": 1756275235,
+        "narHash": "sha256-YTbfVlVKXkBxgJo+2ra+7yLod/eOWZQzYpEPzEko+/o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e37e460711df07217ab247f3fec3d8e1ecc0c3b",
+        "rev": "0768df88122ee3795d2544aabce4161bb1e6efcd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0768df88`](https://github.com/nix-community/NUR/commit/0768df88122ee3795d2544aabce4161bb1e6efcd) | `` automatic update `` |
| [`9824fee9`](https://github.com/nix-community/NUR/commit/9824fee9eb7676a3624d8dcf8e36879fdbe5ccf6) | `` automatic update `` |
| [`5bfce522`](https://github.com/nix-community/NUR/commit/5bfce5225f9eb659023708c10d16bb0abb56f4b3) | `` automatic update `` |
| [`6f0a647e`](https://github.com/nix-community/NUR/commit/6f0a647e79499984c965866626e6b90716f4d0ed) | `` automatic update `` |