### PR TITLE
chore(flake/catppuccin): `ad015344` -> `d96b7f75`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1756028045,
-        "narHash": "sha256-j6ehEdta7YnXtk42cdYQEElCKfnbe24yfeHJwszgyes=",
+        "lastModified": 1756285318,
+        "narHash": "sha256-GD4YREVbkIpj/+YFatStQCsALkA1w5bYL/+oa8aET90=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "ad015344f592b6ebb82de853b747dd577926ec77",
+        "rev": "d96b7f75d43fb8e6300089f65807a742253bab7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                        |
| ----------------------------------------------------------------------------------------------- | ------------------------------ |
| [`d96b7f75`](https://github.com/catppuccin/nix/commit/d96b7f75d43fb8e6300089f65807a742253bab7f) | `` chore(deps): bump (#709) `` |