### PR TITLE
chore(flake/nixpkgs): `b1b32914` -> `4e7667a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1755922037,
-        "narHash": "sha256-wY1+2JPH0ZZC4BQefoZw/k+3+DowFyfOxv17CN/idKs=",
+        "lastModified": 1756217674,
+        "narHash": "sha256-TH1SfSP523QI7kcPiNtMAEuwZR3Jdz0MCDXPs7TS8uo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b1b3291469652d5a2edb0becc4ef0246fff97a7c",
+        "rev": "4e7667a90c167f7a81d906e5a75cba4ad8bee620",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                             |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`2620d9a5`](https://github.com/NixOS/nixpkgs/commit/2620d9a556b669da8cd03aa105f5702ad5f8ecad) | `` buildMozillaMach: restore no-buildconfig patch ``                                                |
| [`150ba26d`](https://github.com/NixOS/nixpkgs/commit/150ba26d2b18f859e75833782bcd0b4db53347fc) | `` build(deps): bump actions/create-github-app-token from 2.1.0 to 2.1.1 ``                         |
| [`9b81db86`](https://github.com/NixOS/nixpkgs/commit/9b81db86e8f728cc16757a1ebece29564306b406) | `` build(deps): bump korthout/backport-action from 3.2.1 to 3.3.0 ``                                |
| [`0ec83b71`](https://github.com/NixOS/nixpkgs/commit/0ec83b71dd60b57e150e4bf036e1c169307180ff) | `` workflows/labels: prevent error on token creation for Test workflow ``                           |
| [`51dee454`](https://github.com/NixOS/nixpkgs/commit/51dee45438dc004f6f347098215635a01e793e2c) | `` ci/github-script: fix run script ``                                                              |
| [`d5041dc6`](https://github.com/NixOS/nixpkgs/commit/d5041dc605c67f34f292963c1d80bb3f41d2741a) | `` mullvad-browser: 14.5.5 -> 14.5.6 ``                                                             |
| [`86ddc0ac`](https://github.com/NixOS/nixpkgs/commit/86ddc0ac36d5f3413a16c1036ab9fc37f45dad26) | `` widevine-cdm: fix build ``                                                                       |
| [`6b7d6074`](https://github.com/NixOS/nixpkgs/commit/6b7d60740bf6f063d7891b982756ac5a3ddb6e06) | `` proton-ge-bin: GE-Proton10-12 -> GE-Proton10-13 ``                                               |
| [`a29ceb59`](https://github.com/NixOS/nixpkgs/commit/a29ceb5962f37dd11147ed50f7d69bff5c747c12) | `` linuxKernel.kernels.linux_lqx: 6.15.10 -> 6.16.3 ``                                              |
| [`c6c8b9fb`](https://github.com/NixOS/nixpkgs/commit/c6c8b9fb0d4d4c6c56669d5fbf88b0e9c4d77da7) | `` nodejs_24: 24.5.0 -> 24.6.0 ``                                                                   |
| [`baf0c3c7`](https://github.com/NixOS/nixpkgs/commit/baf0c3c7ef9b04fafe9274bc4dd5ceb57a29eb1c) | `` vulnix: 1.11.0 -> 1.12.0 ``                                                                      |
| [`006e36e6`](https://github.com/NixOS/nixpkgs/commit/006e36e6876918b8a25a4a65bae316ed228975fa) | `` monado: do not use cudatoolkit, use cuda_nvcc+cuda_cudart ``                                     |
| [`40bcb07c`](https://github.com/NixOS/nixpkgs/commit/40bcb07cd92b96e50a853348d122dbafea47e1da) | `` basalt-monado: do not use cudatoolkit, use cuda_nvcc ``                                          |
| [`f33d889b`](https://github.com/NixOS/nixpkgs/commit/f33d889bd7b7950110da6eb87faea8f1190311a9) | `` buildMozillaMach: prune obsolete patches ``                                                      |
| [`e75aa993`](https://github.com/NixOS/nixpkgs/commit/e75aa99362651e43ea7086a6b6a2bb45ed8fa25b) | `` buildMozillaMach: use cheap tar archive for packaging during profiling ``                        |
| [`dd16501a`](https://github.com/NixOS/nixpkgs/commit/dd16501a1d56e61940d817d0f928f7a480550ba7) | `` buildMozillaMach: use system onnxruntime ``                                                      |
| [`6a2c975c`](https://github.com/NixOS/nixpkgs/commit/6a2c975c57b06426e58dcfae9cf24ed680d9dff7) | `` python3Packages.pyexcel-xls: fix build ``                                                        |
| [`ee1e86a5`](https://github.com/NixOS/nixpkgs/commit/ee1e86a5b4d458791b8aa527b5d8c52992cd440a) | `` ci,workflows: deal with ghost reviews ``                                                         |
| [`a900b9fe`](https://github.com/NixOS/nixpkgs/commit/a900b9fe9ec758b0c68351c9f27a72d6534e6a61) | `` python3Packages.rchitect: 0.4.7 -> 0.4.8 ``                                                      |
| [`91c088d3`](https://github.com/NixOS/nixpkgs/commit/91c088d3b735b25138a903e2585deca14b8cb429) | `` ci/github-script/prepare: identify real base branch ``                                           |
| [`8353c8c1`](https://github.com/NixOS/nixpkgs/commit/8353c8c10eb2c0ef16f94a664dbb7d7b0399f578) | `` ci/github-script/prepare: avoid running CI when targeting channel branches ``                    |
| [`64fbd080`](https://github.com/NixOS/nixpkgs/commit/64fbd08045939cbc5ff08e97e66dea0e7b781643) | `` ci/github-script/commits: split review function into separate file ``                            |
| [`59eb6387`](https://github.com/NixOS/nixpkgs/commit/59eb6387fab108500d90ef0553e83e5cc8e69090) | `` workflows/check: always run commits job ``                                                       |
| [`ce15db64`](https://github.com/NixOS/nixpkgs/commit/ce15db64e647cb08ed0fcda5c08737f3932edabb) | `` fbpanel: correctly apply -Wno-error ``                                                           |
| [`af062b68`](https://github.com/NixOS/nixpkgs/commit/af062b68114d931ee34428f264c9d3c5415ee4f0) | `` thunderbird-128-unwrapped: 128.13.0esr -> 128.14.0esr ``                                         |
| [`32d1a809`](https://github.com/NixOS/nixpkgs/commit/32d1a8095aa2aa0b1ec744b593b270990f35d0b9) | `` python3Packages.pyflakes: disable failing test for PyPy3 ``                                      |
| [`3cbc983b`](https://github.com/NixOS/nixpkgs/commit/3cbc983bef50df92e753ba7742b34e07473b50b2) | `` pnpm_10: 10.14.0 -> 10.15.0 ``                                                                   |
| [`8c37a8ba`](https://github.com/NixOS/nixpkgs/commit/8c37a8ba1c2124883649ee71c59afc6f5c736939) | `` firefly-iii: 6.2.21 -> 6.3.2 ``                                                                  |
| [`64694d3f`](https://github.com/NixOS/nixpkgs/commit/64694d3f2bd727e7e944bc24fa8cc007af23d22e) | `` dotnetCorePackages.dotnet_10.vmr: 10.0.0-preview.6 -> 10.0.0-preview.7 ``                        |
| [`fdcbc89b`](https://github.com/NixOS/nixpkgs/commit/fdcbc89bc2c07017409ce4f5a5d49ef1b081efb7) | `` dotnetCorePackages.sdk_10_0-bin: 10.0.100-preview.6.25358.103 -> 10.0.100-preview.7.25380.108 `` |
| [`1937aaff`](https://github.com/NixOS/nixpkgs/commit/1937aaffb8a632bf7d95c0fc323d8920a871c74b) | `` dotnet/update.nix: read artifact RID from prep script ``                                         |
| [`4ccbd5cc`](https://github.com/NixOS/nixpkgs/commit/4ccbd5ccc56f82328133cf848e1986194d6f3354) | `` arc-browser: 1.106.0-66192 -> 1.109.0-67185 ``                                                   |
| [`78287e87`](https://github.com/NixOS/nixpkgs/commit/78287e87bed9cc3297074a650e0ecf3a6bf25975) | `` workflows/check: allow owners to fail when ci/OWNERS is untouched ``                             |
| [`fc237c6b`](https://github.com/NixOS/nixpkgs/commit/fc237c6b07dff0804a9c2d300b3477f60148c17f) | `` workflows/{merge-group,pr}: avoid posting "no PR failures" for pull_request trigger ``           |
| [`8824c563`](https://github.com/NixOS/nixpkgs/commit/8824c563a706dc743a66511beed58b7f2ecd710b) | `` workflows/{merge-group,pr}: post "no PR failures" status manually ``                             |
| [`18de86f8`](https://github.com/NixOS/nixpkgs/commit/18de86f824bed301ff645142ff5d4c63126f3d50) | `` varnish77: 7.7.2 -> 7.7.3 ``                                                                     |
| [`83ace4da`](https://github.com/NixOS/nixpkgs/commit/83ace4daff8af61aec7791db866623940853de25) | `` psi-plus: 1.5.2072 -> 1.5.2081 ``                                                                |
| [`45330b1a`](https://github.com/NixOS/nixpkgs/commit/45330b1a4d7ffeecc804b8466d91932dd9f98997) | `` postfix-tlspol: 1.8.13 -> 1.8.14 ``                                                              |
| [`a4572ccc`](https://github.com/NixOS/nixpkgs/commit/a4572ccc56c0b5f0d2c0d0756622585b62386eec) | `` ibus-engines.libpinyin: Fix typelib finding ``                                                   |
| [`73644a2c`](https://github.com/NixOS/nixpkgs/commit/73644a2ce81fab506c95f6d225887acdff3a3a7d) | `` workflows/test: test merge-group workflow ``                                                     |
| [`2955bd94`](https://github.com/NixOS/nixpkgs/commit/2955bd942cc5422089d281420a8b613e80ec7b8e) | `` workflows/test: run push job on correct commit ``                                                |
| [`9bea5d38`](https://github.com/NixOS/nixpkgs/commit/9bea5d3844ae5c2b8d2cc88ff1c0fc111ca0ad5d) | `` workflows/test: init ``                                                                          |
| [`fd91d8f5`](https://github.com/NixOS/nixpkgs/commit/fd91d8f556730e383c118e7ec3b6c3efce8e5537) | `` workflows/push: remove unused permissions and secrets ``                                         |
| [`450bb67e`](https://github.com/NixOS/nixpkgs/commit/450bb67e89d0151f617b998c9e91793de89f4a77) | `` workflows/eval.misc: run tasks in parallel ``                                                    |
| [`44d6b48a`](https://github.com/NixOS/nixpkgs/commit/44d6b48a5fe12d0585e931b10b450a38cb1b6fb8) | `` postgresql.tests.postgresql.postgresql-backup-all: fix random dump ``                            |
| [`cf17cded`](https://github.com/NixOS/nixpkgs/commit/cf17cded2f55b746b8c97fbdbbcf4f1c0d64db24) | `` thunderbird-esr-bin-unwrapped: 140.1.1esr -> 140.2.0esr ``                                       |
| [`0f9b573a`](https://github.com/NixOS/nixpkgs/commit/0f9b573a9880150fc1bea55296abc495c569d346) | `` mattermost: 10.5.9 -> 10.5.10 ``                                                                 |
| [`9972f436`](https://github.com/NixOS/nixpkgs/commit/9972f436d9b23cf0ad0102152d9b8a6eb9053c29) | `` waydroid: 1.5.2 -> 1.5.4 ``                                                                      |
| [`a4561655`](https://github.com/NixOS/nixpkgs/commit/a456165572c75e3ad89821ae2a2dd6e3e6455e05) | `` warp-terminal: 0.2025.08.13.08.12.stable_02 -> 0.2025.08.20.08.11.stable_03 ``                   |
| [`16d1e1f4`](https://github.com/NixOS/nixpkgs/commit/16d1e1f40fd6b9198735e16539b83813a8f66b64) | `` warp-terminal: 0.2025.08.06.08.12.stable_02 -> 0.2025.08.13.08.12.stable_02 ``                   |
| [`46b38979`](https://github.com/NixOS/nixpkgs/commit/46b389794077427bdb91b56624571990b5e42bd2) | `` warp-terminal: 0.2025.08.06.08.12.stable_01 -> 0.2025.08.06.08.12.stable_02 ``                   |
| [`deb310ca`](https://github.com/NixOS/nixpkgs/commit/deb310ca46eb3451e046c9692f5acd42f08d2e87) | `` warp-terminal: remove emilytrau as maintainer ``                                                 |
| [`364c6405`](https://github.com/NixOS/nixpkgs/commit/364c64050b10b2f5b95857bb421fd1fa017ac46c) | `` warp-terminal: 0.2025.07.30.08.12.stable_02 -> 0.2025.08.06.08.12.stable_01 ``                   |
| [`d51aea2b`](https://github.com/NixOS/nixpkgs/commit/d51aea2bbf54fd24d1ddcbcc4a60e9eeb8fe61fd) | `` warp-terminal: 0.2025.07.23.08.12.stable_02 -> 0.2025.07.30.08.12.stable_02 ``                   |
| [`9fdcb70d`](https://github.com/NixOS/nixpkgs/commit/9fdcb70d71bf9a9811fb5de09e383fde38d167a0) | `` warp-terminal: 0.2025.07.09.08.11.stable_01 -> 0.2025.07.23.08.12.stable_02 ``                   |
| [`42ea4e04`](https://github.com/NixOS/nixpkgs/commit/42ea4e0468e79210daee7e4ac003431ad4cfecfa) | `` waydroid: 1.5.1 -> 1.5.2 ``                                                                      |
| [`5f958c27`](https://github.com/NixOS/nixpkgs/commit/5f958c274ea71d12ca9ffe60be9d88bea9aaf24b) | `` freetube: 0.23.7 -> 0.23.8 ``                                                                    |
| [`b93bc7e2`](https://github.com/NixOS/nixpkgs/commit/b93bc7e2aba77b4dcb50422e78bc38ea7a3d7ca0) | `` jol: init at 0.17 ``                                                                             |
| [`5a205cb1`](https://github.com/NixOS/nixpkgs/commit/5a205cb1dc1fd302073b700927ddf35c973e36d5) | `` maintainers: add debling ``                                                                      |
| [`c7d481ee`](https://github.com/NixOS/nixpkgs/commit/c7d481eed93762fae20fb6805635187b0b99c494) | `` rundeck-cli: makeWrapper → makeBinaryWrapper ``                                                  |
| [`5c51ba23`](https://github.com/NixOS/nixpkgs/commit/5c51ba2326e04f773017beef80f522bfeee33816) | `` linux_6_16: 6.16.2 -> 6.16.3 ``                                                                  |
| [`267f471e`](https://github.com/NixOS/nixpkgs/commit/267f471e940e60fef1fd760e277df8a5d33020bc) | `` linux: fix backwards-compat of structuredExtraConfig vs extraStructuredConfig ``                 |
| [`7a6f8fa6`](https://github.com/NixOS/nixpkgs/commit/7a6f8fa680be7871060a9541e22ba4ba48cb66e6) | `` yt-dlp: 2025.08.20 -> 2025.08.22 ``                                                              |
| [`835aabc3`](https://github.com/NixOS/nixpkgs/commit/835aabc30f6016f4c2ed99e719fe8c0ce2846382) | `` rundeck-cli: replace `jdk` with `jre11_minimal_headless` ``                                      |
| [`233f596f`](https://github.com/NixOS/nixpkgs/commit/233f596f83ac425811a0010156efb581d3add1ab) | `` jre11_minimal: init at 11.0.26 ``                                                                |
| [`c49861a9`](https://github.com/NixOS/nixpkgs/commit/c49861a97976b8807b12b9a690557274b95a254e) | `` jre: fix missing `meta`, simplify the expression ``                                              |
| [`f03a7ad4`](https://github.com/NixOS/nixpkgs/commit/f03a7ad45f6bc6f49f3aec679ff4a24ab5173442) | `` microsoft-edge: 139.0.3405.104 -> 139.0.3405.111 ``                                              |
| [`32e5e0ce`](https://github.com/NixOS/nixpkgs/commit/32e5e0cea252b782f607f36d735d68686b0d29a6) | `` shaarli: 0.14.0 -> 0.15.0 ``                                                                     |
| [`7c960412`](https://github.com/NixOS/nixpkgs/commit/7c96041211ccb27f0ae1047368184320b7095d00) | `` zfs_unstable: 2.3.3 -> 2.4.0-rc1 ``                                                              |
| [`db437453`](https://github.com/NixOS/nixpkgs/commit/db4374534894ded7ab6355941716e7c9ea1577fc) | `` firefox-esr-128-unwrapped: drop ``                                                               |
| [`31bb4298`](https://github.com/NixOS/nixpkgs/commit/31bb42981662d7e9649776eaa8adead9b066b6c7) | `` thunderbird-unwrapped: 141.0 -> 142.0 ``                                                         |
| [`e723c103`](https://github.com/NixOS/nixpkgs/commit/e723c103469ecd91b1dc5b975121750711137f71) | `` linux_xanmod_latest: 6.15.10 -> 6.15.11 ``                                                       |
| [`b5ba2a95`](https://github.com/NixOS/nixpkgs/commit/b5ba2a95ccb0a451d47a7b18c3d40d9695415c47) | `` linux_xanmod: 6.12.42 -> 6.12.43 ``                                                              |
| [`8fe975d5`](https://github.com/NixOS/nixpkgs/commit/8fe975d50f4c91ac0e476f1dbc9dcb4d96c247c3) | `` devenv: 1.8.1 -> 1.8.2 ``                                                                        |
| [`db6e7e8b`](https://github.com/NixOS/nixpkgs/commit/db6e7e8b372ec8d60688878619d1513ed25d88e0) | `` jocalsend: init at 1.6.1803 ``                                                                   |
| [`963609cb`](https://github.com/NixOS/nixpkgs/commit/963609cbda557356442f940d8c19cdd2fbef36c4) | `` immich: 1.138.0 -> 1.138.1 ``                                                                    |
| [`a9f3c3ab`](https://github.com/NixOS/nixpkgs/commit/a9f3c3abbfc9007a4350540a2c613eb3f8dc7c0f) | `` beamPackages.mixRelease: symlink mixFodDeps with MIX_DEPS_PATH ``                                |
| [`de8ff28a`](https://github.com/NixOS/nixpkgs/commit/de8ff28a5aeeb75c1b1d2bba23dabe0b345eee95) | `` fetchMavenArtifact: fix metadata support ``                                                      |
| [`e6dbca3b`](https://github.com/NixOS/nixpkgs/commit/e6dbca3b25f5218036aa17f39a1171c7253a1899) | `` couchdb3: switch to beamMinimalPackages.erlang ``                                                |
| [`e510beb2`](https://github.com/NixOS/nixpkgs/commit/e510beb2fcbb5c0bed85dee8bfa467f1618e609a) | `` limine: no need for unwrapped clang anymore ``                                                   |
| [`538b5c47`](https://github.com/NixOS/nixpkgs/commit/538b5c477ec0eb65716cc2b91ab597b2708fc399) | `` limine: 9.5.4 -> 9.6.1 ``                                                                        |
| [`8409a094`](https://github.com/NixOS/nixpkgs/commit/8409a094b354ce55fe61beef68bdc11d27eae1a4) | `` virtualisation/oci-containers: fix podman systemd service name ``                                |
| [`b9728122`](https://github.com/NixOS/nixpkgs/commit/b9728122ba70233eaa2575eb74da3f914ee960bb) | `` pypy3Packages.cython: fix ``                                                                     |
| [`df212501`](https://github.com/NixOS/nixpkgs/commit/df2125011a0ca42f467567a0e37e6793db964ba1) | `` meson: fix build when using pypy ``                                                              |
| [`9d711777`](https://github.com/NixOS/nixpkgs/commit/9d71177735d949e2ef20dafc637d16cc7e30cc09) | `` pypy.tests: disable broken test ``                                                               |
| [`d0076094`](https://github.com/NixOS/nixpkgs/commit/d0076094b77d158c6cc1d7a66d440cedb8e05e88) | `` pypy3Packages.mypy: disable ``                                                                   |
| [`810095f2`](https://github.com/NixOS/nixpkgs/commit/810095f2b7a707e23d2c5132f339fef12f5a3165) | `` pypy{27,310}: 7.3.17 -> 7.3.19, pypy311: init at 7.3.19 ``                                       |
| [`fc771a3f`](https://github.com/NixOS/nixpkgs/commit/fc771a3fc27e5454a2047dbb9ded47d56683890c) | `` jenkins: 2.504.3 -> 2.516.1 ``                                                                   |