### PR TITLE
chore(flake/nur): `0768df88` -> `1fc33f07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756275235,
-        "narHash": "sha256-YTbfVlVKXkBxgJo+2ra+7yLod/eOWZQzYpEPzEko+/o=",
+        "lastModified": 1756280694,
+        "narHash": "sha256-bWrjbQwAbh9sthCuu8ImJGsB9AOwv1Ul+w7B9NNtALE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0768df88122ee3795d2544aabce4161bb1e6efcd",
+        "rev": "1fc33f0742baa8fcb365317ded628630bbd0305a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1fc33f07`](https://github.com/nix-community/NUR/commit/1fc33f0742baa8fcb365317ded628630bbd0305a) | `` automatic update `` |
| [`01edf600`](https://github.com/nix-community/NUR/commit/01edf6006a601e634d623b2fdf99c37b7a7a0159) | `` automatic update `` |