### PR TITLE
chore(flake/catppuccin): `d96b7f75` -> `f2e3c4c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1756285318,
-        "narHash": "sha256-GD4YREVbkIpj/+YFatStQCsALkA1w5bYL/+oa8aET90=",
+        "lastModified": 1756293646,
+        "narHash": "sha256-VgJtXf3j4/4nJJAk7Ol2un7U6+7tN54sj4nWP+wpYSo=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "d96b7f75d43fb8e6300089f65807a742253bab7f",
+        "rev": "f2e3c4c73d4fbd5e2c24ae44075ded300fe7b52b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                     |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`f2e3c4c7`](https://github.com/catppuccin/nix/commit/f2e3c4c73d4fbd5e2c24ae44075ded300fe7b52b) | `` docs: Update obsolete flake attribute for importing catppuccin (#710) `` |