### PR TITLE
chore(flake/nur): `1fc33f07` -> `28a0541f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756280694,
-        "narHash": "sha256-bWrjbQwAbh9sthCuu8ImJGsB9AOwv1Ul+w7B9NNtALE=",
+        "lastModified": 1756298364,
+        "narHash": "sha256-8+VIXLj6XZHVKGPH41vnOch2KqpxhZM9pLQPb9EsixM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1fc33f0742baa8fcb365317ded628630bbd0305a",
+        "rev": "28a0541f97e0008c08285490d4d538d95ef4a167",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`28a0541f`](https://github.com/nix-community/NUR/commit/28a0541f97e0008c08285490d4d538d95ef4a167) | `` automatic update `` |
| [`b635e016`](https://github.com/nix-community/NUR/commit/b635e016c10b8bbe1eab4cb70735353706b874f2) | `` automatic update `` |
| [`325f5215`](https://github.com/nix-community/NUR/commit/325f5215e0acc2140cb1df47c1c850e5050980e8) | `` automatic update `` |
| [`eabbd6a9`](https://github.com/nix-community/NUR/commit/eabbd6a9d182e190795dda8b759194e172afdd32) | `` automatic update `` |
| [`75197b91`](https://github.com/nix-community/NUR/commit/75197b9123330b2a2040998010300d15158ac2f3) | `` automatic update `` |