### PR TITLE
chore(flake/chaotic): `4a5332e5` -> `eb7cf67e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1756168382,
-        "narHash": "sha256-qHwmBOx6RATjYkdoVzf+LN55DTBCAarTjs2ANNs7yzA=",
+        "lastModified": 1756305271,
+        "narHash": "sha256-CF5TgUQodAPjdV15/9FWeMhBvYCYnnTBFQUJsMXkAZs=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "4a5332e5a4eba9eac822b660c8c6acadc9501b48",
+        "rev": "eb7cf67e1da24adb753cc0ab83d2b17cec155963",
         "type": "github"
       },
       "original": {
@@ -382,11 +382,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1755615617,
-        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "lastModified": 1756125398,
+        "narHash": "sha256-XexyKZpf46cMiO5Vbj+dWSAXOnr285GHsMch8FBoHbc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "rev": "3b9f00d7a7bf68acd4c4abb9d43695afb04e03a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                       |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`eb7cf67e`](https://github.com/chaotic-cx/nyx/commit/eb7cf67e1da24adb753cc0ab83d2b17cec155963) | `` failures: update x86_64-linux ``                           |
| [`6b903a4d`](https://github.com/chaotic-cx/nyx/commit/6b903a4dce0df00bc715da071f6c20a2c5060915) | `` linux_cachyos: add isLTS, isZen, isHardened,and isLibre `` |
| [`9f919376`](https://github.com/chaotic-cx/nyx/commit/9f9193761b28fc36e3d1ec9cff46227da69ea5b5) | `` nixpkgs: bump to 20250826 ``                               |