### PR TITLE
chore(flake/nur): `28a0541f` -> `296f74fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756298364,
-        "narHash": "sha256-8+VIXLj6XZHVKGPH41vnOch2KqpxhZM9pLQPb9EsixM=",
+        "lastModified": 1756307733,
+        "narHash": "sha256-8JomcxPBS3YYZrVaMhAv2TYaJafxS9gp5nP+rJMvEIE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "28a0541f97e0008c08285490d4d538d95ef4a167",
+        "rev": "296f74fd85816755602cf6a2703a19a43eea69a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`296f74fd`](https://github.com/nix-community/NUR/commit/296f74fd85816755602cf6a2703a19a43eea69a5) | `` automatic update `` |
| [`22540ff6`](https://github.com/nix-community/NUR/commit/22540ff6280ac3b8cf74a0873f53c73c0db37827) | `` automatic update `` |
| [`3f2c902d`](https://github.com/nix-community/NUR/commit/3f2c902dcf0952e2634552d14c508216050092b3) | `` automatic update `` |
| [`6007cb2a`](https://github.com/nix-community/NUR/commit/6007cb2a17a3b69b5080924cd6914602fa060934) | `` automatic update `` |