### PR TITLE
chore(flake/nur): `296f74fd` -> `9e0cff73`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756307733,
-        "narHash": "sha256-8JomcxPBS3YYZrVaMhAv2TYaJafxS9gp5nP+rJMvEIE=",
+        "lastModified": 1756316263,
+        "narHash": "sha256-pKtOWF0ike6QRk9nVDCqhQK5S10OvN8jxNCEUF1bNQk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "296f74fd85816755602cf6a2703a19a43eea69a5",
+        "rev": "9e0cff7371e59778ca4408f55a0107505c3da233",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9e0cff73`](https://github.com/nix-community/NUR/commit/9e0cff7371e59778ca4408f55a0107505c3da233) | `` automatic update `` |
| [`a6f7dd4d`](https://github.com/nix-community/NUR/commit/a6f7dd4d32d876cdb3aec5741a125ff6dc7f7ec6) | `` automatic update `` |
| [`5651d12e`](https://github.com/nix-community/NUR/commit/5651d12e076d7c3444d066728945d8bccca181c5) | `` automatic update `` |