### PR TITLE
chore(flake/nur): `9e0cff73` -> `f3306e41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1756125398,
-        "narHash": "sha256-XexyKZpf46cMiO5Vbj+dWSAXOnr285GHsMch8FBoHbc=",
+        "lastModified": 1756266583,
+        "narHash": "sha256-cr748nSmpfvnhqSXPiCfUPxRz2FJnvf/RjJGvFfaCsM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3b9f00d7a7bf68acd4c4abb9d43695afb04e03a5",
+        "rev": "8a6d5427d99ec71c64f0b93d45778c889005d9c2",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756316263,
-        "narHash": "sha256-pKtOWF0ike6QRk9nVDCqhQK5S10OvN8jxNCEUF1bNQk=",
+        "lastModified": 1756328417,
+        "narHash": "sha256-C+wZeLECXHjUZf8HFKJg93+QpavgG8ojSs1aNV+Mf3A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9e0cff7371e59778ca4408f55a0107505c3da233",
+        "rev": "f3306e414ea749fe1b7329582f58f0b910a3f1fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f3306e41`](https://github.com/nix-community/NUR/commit/f3306e414ea749fe1b7329582f58f0b910a3f1fc) | `` automatic update `` |
| [`e54c5f2d`](https://github.com/nix-community/NUR/commit/e54c5f2dfcf6c4d8e1d37fd5f85d740244ae5565) | `` automatic update `` |
| [`8d51e9ff`](https://github.com/nix-community/NUR/commit/8d51e9ff3eed72c18c24ca79415d1ba1a32222bb) | `` automatic update `` |
| [`1ac433da`](https://github.com/nix-community/NUR/commit/1ac433da479bf05f99fba4786cc719fbee303855) | `` automatic update `` |
| [`302cd42d`](https://github.com/nix-community/NUR/commit/302cd42d8722164b3c13b5f38679f00bbcf9e1ac) | `` automatic update `` |
| [`67b8892c`](https://github.com/nix-community/NUR/commit/67b8892c8f4b5bac57cc78335a7fbd95f7a8fc8b) | `` automatic update `` |
| [`442eb674`](https://github.com/nix-community/NUR/commit/442eb67402ac6655bd642a8d857fef3cab0b9e7b) | `` automatic update `` |