### PR TITLE
chore(flake/nur): `f3306e41` -> `86c7e905`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756328417,
-        "narHash": "sha256-C+wZeLECXHjUZf8HFKJg93+QpavgG8ojSs1aNV+Mf3A=",
+        "lastModified": 1756344739,
+        "narHash": "sha256-LultfbGn5rQ0akVpVMSzRGjFaHzpi9w7rURDX42ETg8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f3306e414ea749fe1b7329582f58f0b910a3f1fc",
+        "rev": "86c7e9052c37678510a3e7544c327877948e0637",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`86c7e905`](https://github.com/nix-community/NUR/commit/86c7e9052c37678510a3e7544c327877948e0637) | `` automatic update `` |
| [`c9fdb902`](https://github.com/nix-community/NUR/commit/c9fdb90218bdddde49916afd44e2d8a73e3f70aa) | `` automatic update `` |
| [`c75bc319`](https://github.com/nix-community/NUR/commit/c75bc3193585cb85fbdd56e8462a851fbc5e09f5) | `` automatic update `` |
| [`1f693539`](https://github.com/nix-community/NUR/commit/1f693539e1da901a6da002555d5480e887a5adc1) | `` automatic update `` |
| [`c06a4179`](https://github.com/nix-community/NUR/commit/c06a4179c75515de10b2e751bd4f10a8c94a2ee1) | `` automatic update `` |