### PR TITLE
chore(flake/nur): `50343d08` -> `d0dc086d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756351829,
-        "narHash": "sha256-wpO3UVRrUql0/9C6QetbNZCwpypMzaoiZQI214Ek4K0=",
+        "lastModified": 1756362539,
+        "narHash": "sha256-kiXa1qGjfCCERDc+ZCVRvdbMy2dmcjqXmE7WOlX/5oA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50343d0844606192ade2aa520b739fbe706b2c0b",
+        "rev": "d0dc086d7a925e6e54cdd124508f28954c383cae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d0dc086d`](https://github.com/nix-community/NUR/commit/d0dc086d7a925e6e54cdd124508f28954c383cae) | `` automatic update `` |
| [`eb506ce9`](https://github.com/nix-community/NUR/commit/eb506ce913d0e2ac0207590a8ca1f3bc23cb9993) | `` automatic update `` |
| [`848e09a7`](https://github.com/nix-community/NUR/commit/848e09a77f25fa737a45ad969aae43191a3c767c) | `` automatic update `` |
| [`93ea7d21`](https://github.com/nix-community/NUR/commit/93ea7d21d64c72341083daf1f3f86c47927bd64c) | `` automatic update `` |
| [`5f0a6570`](https://github.com/nix-community/NUR/commit/5f0a6570cd78ab94f7b2b38a74208eb4b8ada784) | `` automatic update `` |
| [`ccf16ddc`](https://github.com/nix-community/NUR/commit/ccf16ddcdefebbaeffb993e87687b0f0936de7dd) | `` automatic update `` |