### PR TITLE
chore(flake/nur): `d0dc086d` -> `f2146752`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756362539,
-        "narHash": "sha256-kiXa1qGjfCCERDc+ZCVRvdbMy2dmcjqXmE7WOlX/5oA=",
+        "lastModified": 1756372381,
+        "narHash": "sha256-dhKg4NIG9HSvm6RsIiHyan0V1thib92EblijrEhmhlk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d0dc086d7a925e6e54cdd124508f28954c383cae",
+        "rev": "f2146752bbbf85d1b0b3a67daab08b30e2345298",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f2146752`](https://github.com/nix-community/NUR/commit/f2146752bbbf85d1b0b3a67daab08b30e2345298) | `` automatic update `` |
| [`e4fe43b3`](https://github.com/nix-community/NUR/commit/e4fe43b366ebfdc6126e22d1ad4340c69a8f8edc) | `` automatic update `` |
| [`0b27ecad`](https://github.com/nix-community/NUR/commit/0b27ecadaa908972b67ed34fadd0e713466aa305) | `` automatic update `` |
| [`9d1cb2f4`](https://github.com/nix-community/NUR/commit/9d1cb2f41acb7dd148cee968875938588ee51bce) | `` automatic update `` |
| [`348fa027`](https://github.com/nix-community/NUR/commit/348fa027f5e365d2ba4fff4f3c96ac8b0a4db91b) | `` automatic update `` |