### PR TITLE
chore(flake/nur): `ca644359` -> `c6a840c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756403090,
-        "narHash": "sha256-HOFWK6o9oKgLrn5t8xsZTx3UXpdbx1xFZaDrKIVPg3s=",
+        "lastModified": 1756413868,
+        "narHash": "sha256-vyWwFhgDaiyTbgrn75BIukNTJAEehJW6JhQXG91C0Ek=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca64435962e0e147534191d3b2e110807e9e9347",
+        "rev": "c6a840c65768a73531d437e6845766a8d6e50381",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c6a840c6`](https://github.com/nix-community/NUR/commit/c6a840c65768a73531d437e6845766a8d6e50381) | `` automatic update `` |
| [`f9bc9402`](https://github.com/nix-community/NUR/commit/f9bc9402cf2de28ad2da5d9f0c7446c8a842dd1e) | `` automatic update `` |
| [`4a87cbb9`](https://github.com/nix-community/NUR/commit/4a87cbb97f2de584dffae7fd89184ed4f1bf7cc4) | `` automatic update `` |
| [`8fd8eec9`](https://github.com/nix-community/NUR/commit/8fd8eec9d9284e3ff365cc43c0bb33c263f34833) | `` automatic update `` |