### PR TITLE
chore(flake/nur): `e4de97a1` -> `8df9a549`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756416356,
-        "narHash": "sha256-xcqREhXocGZPbDsvjD7ncDz8++jfX5ZwpGc0maiD9CY=",
+        "lastModified": 1756438231,
+        "narHash": "sha256-ygHQWiCuNWjHky4+0+CNOmcyvOZHgX9a/UgaXp8JEpU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e4de97a152b367ba92ee590ff67fee4f33c46d92",
+        "rev": "8df9a54900dfd3573d77845ede54bc1414226511",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8df9a549`](https://github.com/nix-community/NUR/commit/8df9a54900dfd3573d77845ede54bc1414226511) | `` automatic update `` |
| [`6985e9ff`](https://github.com/nix-community/NUR/commit/6985e9ffbd4da131c1e8de58581875461ad88132) | `` automatic update `` |
| [`21864ed4`](https://github.com/nix-community/NUR/commit/21864ed42d81538acef256889dae42626f35e429) | `` automatic update `` |
| [`26ff0f56`](https://github.com/nix-community/NUR/commit/26ff0f561b1577fbeb13e75ba74f9eed465b6b9f) | `` automatic update `` |
| [`f876637d`](https://github.com/nix-community/NUR/commit/f876637d3b795977e433ba6e3c0a128d22e125e1) | `` automatic update `` |
| [`8e2715c0`](https://github.com/nix-community/NUR/commit/8e2715c0defba743c0e71f54c959186bff0d6d02) | `` automatic update `` |