### PR TITLE
chore(flake/nur): `8df9a549` -> `9e911d2a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756438231,
-        "narHash": "sha256-ygHQWiCuNWjHky4+0+CNOmcyvOZHgX9a/UgaXp8JEpU=",
+        "lastModified": 1756448304,
+        "narHash": "sha256-Lz0lkrjDNPzxOSS4ANJC2mhB/ZTZRd/HI+GlDNFH+EE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8df9a54900dfd3573d77845ede54bc1414226511",
+        "rev": "9e911d2a0e9d74a5ab28da8a1f32134a1e374be7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9e911d2a`](https://github.com/nix-community/NUR/commit/9e911d2a0e9d74a5ab28da8a1f32134a1e374be7) | `` automatic update `` |
| [`cd2dd40f`](https://github.com/nix-community/NUR/commit/cd2dd40f42140aa120795cfd6d12e6dda2ee3d36) | `` automatic update `` |