### PR TITLE
chore(flake/nur): `9e911d2a` -> `8a8e6a40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756448304,
-        "narHash": "sha256-Lz0lkrjDNPzxOSS4ANJC2mhB/ZTZRd/HI+GlDNFH+EE=",
+        "lastModified": 1756458770,
+        "narHash": "sha256-WnhzIIMGBIVneuUC1QX72xqs00x3jylE9nejO+8OHvM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9e911d2a0e9d74a5ab28da8a1f32134a1e374be7",
+        "rev": "8a8e6a40629e22f8f7560bdf1c1468556f6ce8ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8a8e6a40`](https://github.com/nix-community/NUR/commit/8a8e6a40629e22f8f7560bdf1c1468556f6ce8ad) | `` automatic update `` |
| [`03705ef6`](https://github.com/nix-community/NUR/commit/03705ef6b1649096c83aa15908a921f17a32c5b0) | `` automatic update `` |
| [`c491462a`](https://github.com/nix-community/NUR/commit/c491462aee2fc0787e92bf2c54f95b59585ac5a5) | `` automatic update `` |
| [`e37c2aa6`](https://github.com/nix-community/NUR/commit/e37c2aa66cd0229d0c1d7afcfe52240377f3ac56) | `` automatic update `` |
| [`23434fd7`](https://github.com/nix-community/NUR/commit/23434fd75614ec677013b3554dbb0481c11dd6ab) | `` automatic update `` |