### PR TITLE
chore(flake/nixpkgs): `4e7667a9` -> `84c26d62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1756217674,
-        "narHash": "sha256-TH1SfSP523QI7kcPiNtMAEuwZR3Jdz0MCDXPs7TS8uo=",
+        "lastModified": 1756346337,
+        "narHash": "sha256-al0UcN5mXrO/p5lcH0MuQaj+t97s3brzCii8GfCBMuA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4e7667a90c167f7a81d906e5a75cba4ad8bee620",
+        "rev": "84c26d62ce9e15489c63b83fc44e6eb62705d2c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`98bbd773`](https://github.com/NixOS/nixpkgs/commit/98bbd7733fbd48547053104d32108e7c29f89eb3) | `` maintainers: add github/githubId for lenny ``                              |
| [`687c37c1`](https://github.com/NixOS/nixpkgs/commit/687c37c1e4c58df795f2a3ada05127629d6b1198) | `` linux_testing: 6.17-rc2 -> 6.17-rc3 ``                                     |
| [`f0dce1b1`](https://github.com/NixOS/nixpkgs/commit/f0dce1b196764dd601a2581d2e9847c547e920c4) | `` ungoogled-chromium: 139.0.7258.138-1 -> 139.0.7258.154-1 ``                |
| [`28f760ee`](https://github.com/NixOS/nixpkgs/commit/28f760ee18e3cf65a4d40e9480880dcde5f9fd13) | `` moonlight: 1.3.26 -> 1.3.27 ``                                             |
| [`d20f544e`](https://github.com/NixOS/nixpkgs/commit/d20f544e7a42f2ec846ee41524f609e864238c5c) | `` google-chrome: remove `jnsgruk` as a maintainer ``                         |
| [`f4936501`](https://github.com/NixOS/nixpkgs/commit/f493650174444a58e8996a9eb5f957c2641b1b36) | `` google-chrome: 139.0.7258.127 -> 139.0.7258.154 ``                         |
| [`44124188`](https://github.com/NixOS/nixpkgs/commit/441241887fb0700d9e8216738cce7b43e2f2888a) | `` invoiceplane: fix build ``                                                 |
| [`abefda7c`](https://github.com/NixOS/nixpkgs/commit/abefda7c06ba1fe55c691f6c4b6402cacf46837f) | `` chromium,chromedriver: 139.0.7258.138 -> 139.0.7258.154 ``                 |
| [`97059780`](https://github.com/NixOS/nixpkgs/commit/97059780dfee9d723dc09d42fc74f54c0aa87abe) | `` shellhub-agent: 0.20.0 -> 0.20.1 ``                                        |
| [`2e92b0c3`](https://github.com/NixOS/nixpkgs/commit/2e92b0c39b98affd3699a6da664f36b865665691) | `` matrix-synapse: 1.136.0 -> 1.137.0 ``                                      |
| [`2ae749c3`](https://github.com/NixOS/nixpkgs/commit/2ae749c34c1ed31d7eb45cd10fa22714dbf26eb7) | `` buildMozillaMach: restore MOZ_SYSTEM_DIR patch ``                          |
| [`0cfc9941`](https://github.com/NixOS/nixpkgs/commit/0cfc9941e95ca5cb2572afc1bc60c87d6d7f8581) | `` imagemagick: 7.1.2-1 -> 7.1.2-2 ``                                         |
| [`fa6d8afc`](https://github.com/NixOS/nixpkgs/commit/fa6d8afce0bfa7b8e8c9d9d625511b98c0163a90) | `` ciderpress2: init at 1.1.0 ``                                              |
| [`567cb1b2`](https://github.com/NixOS/nixpkgs/commit/567cb1b27129bb03bfc6f256ba04957257d32772) | `` maintainers: add erichelgeson ``                                           |
| [`29fd041e`](https://github.com/NixOS/nixpkgs/commit/29fd041e6037a4ace8bcc9fa05efda3c19416cf9) | `` lutris: Add adwaita-icon-theme to FHS environment ``                       |
| [`6a76c3e5`](https://github.com/NixOS/nixpkgs/commit/6a76c3e5c587df081c3ad08b458b44ec4bd33883) | `` lmath: init at 1.10.15 ``                                                  |
| [`cece573a`](https://github.com/NixOS/nixpkgs/commit/cece573a817c5b7d34a96ec86266e164192226fc) | `` maintainers: add langsjo ``                                                |
| [`a227b149`](https://github.com/NixOS/nixpkgs/commit/a227b1497c03ef06ef0cdf5571f9b3690c0d1125) | `` glitchtip: use django-allauth headless-spec optional dependencies ``       |
| [`fd628014`](https://github.com/NixOS/nixpkgs/commit/fd628014491c64f3c2599cbd6fd567b1f388ffa0) | `` python3Packages.django-allauth: add headless-spec optional dependencies `` |
| [`4ac842be`](https://github.com/NixOS/nixpkgs/commit/4ac842be6e865ef31042f301478315588b17dc14) | `` ed-odyssey-materials-helper: 2.223 -> 2.240 ``                             |
| [`b66c9343`](https://github.com/NixOS/nixpkgs/commit/b66c93435efda249381029ea6f8ca4945dda7c94) | `` oo7: 0.4.3 -> 0.5.0 ``                                                     |
| [`75e39c95`](https://github.com/NixOS/nixpkgs/commit/75e39c9515a20584a891e47b78442955deed7875) | `` log4cxx: 1.2.0 -> 1.5.0 ``                                                 |
| [`3ecacf46`](https://github.com/NixOS/nixpkgs/commit/3ecacf46f1924b866212611642480271610c2825) | `` linux-rpi*: set isLTS ``                                                   |
| [`959a1bef`](https://github.com/NixOS/nixpkgs/commit/959a1bef3c752f2492df02f618e168fb761b56cb) | `` linux-rt: set isLTS ``                                                     |
| [`fa606a28`](https://github.com/NixOS/nixpkgs/commit/fa606a288f8da7a009c357c86245bd50cc048a50) | `` linux_xanmod: set isLTS ``                                                 |
| [`6b62562f`](https://github.com/NixOS/nixpkgs/commit/6b62562faaf5d1d9bb08d1fbaebde3d733f7e5a1) | `` linux-kernels: add LTS flag ``                                             |
| [`a8374765`](https://github.com/NixOS/nixpkgs/commit/a83747655fdec633c110aea84347675fd4f1fe86) | `` github-runner: 2.327.1 -> 2.328.0 (#435227) ``                             |
| [`8081987e`](https://github.com/NixOS/nixpkgs/commit/8081987e90f57d3a0af55c44393842353f9b7115) | `` radicle-node: add defelo as maintainer ``                                  |
| [`f745d6e1`](https://github.com/NixOS/nixpkgs/commit/f745d6e1fd1369d5aaacea9c023b8132688b8b2e) | `` radicle-node: add updateScript ``                                          |
| [`9824e031`](https://github.com/NixOS/nixpkgs/commit/9824e0313144715874dc433e8f7f349ac105ac78) | `` radicle-node: use versionCheckHook ``                                      |
| [`2abe5550`](https://github.com/NixOS/nixpkgs/commit/2abe555029a97fef9100eaab9b39ce314e268100) | `` radicle-node: use makeBinaryWrapper ``                                     |
| [`1693dcc0`](https://github.com/NixOS/nixpkgs/commit/1693dcc050f55c2f8964181e975da36649935681) | `` radicle-node: depend on gitMinimal instead of git ``                       |
| [`ace0e80f`](https://github.com/NixOS/nixpkgs/commit/ace0e80fbbde4d1849dbd3c9f8ce8a5c202d5759) | `` radicle-node: use canonical release reference ``                           |
| [`da071327`](https://github.com/NixOS/nixpkgs/commit/da07132794142d3b5fdd299d681a5ab661dc69b7) | `` radicle-node: use finalAttrs pattern ``                                    |
| [`9e1a85ba`](https://github.com/NixOS/nixpkgs/commit/9e1a85bacb3d8863125baa04e7acbd2750a351d4) | `` electron-chromedriver_37: 37.2.6 -> 37.3.1 ``                              |
| [`8c6374ef`](https://github.com/NixOS/nixpkgs/commit/8c6374efe77dbefd273843c114a43b5aa300cf3d) | `` electron_37-bin: 37.2.6 -> 37.3.1 ``                                       |
| [`be0a79b6`](https://github.com/NixOS/nixpkgs/commit/be0a79b66533eec09a5844c68b8ad2fe9eaf3478) | `` electron-chromedriver_36: 36.7.3 -> 36.8.1 ``                              |
| [`cb5d16c9`](https://github.com/NixOS/nixpkgs/commit/cb5d16c95f72f3ae48c108709fd356e51b205ed0) | `` electron_36-bin: 36.7.3 -> 36.8.1 ``                                       |
| [`af5e10ab`](https://github.com/NixOS/nixpkgs/commit/af5e10ab128299076034d30ef480ccaaa061a5e1) | `` electron-chromedriver_35: 35.7.4 -> 35.7.5 ``                              |
| [`d139a62e`](https://github.com/NixOS/nixpkgs/commit/d139a62ee5b669b57d65212ef850d5cc0a11916c) | `` electron_35-bin: 35.7.4 -> 35.7.5 ``                                       |
| [`1c964d7d`](https://github.com/NixOS/nixpkgs/commit/1c964d7d241caee2b79af4ca319860ec2d081875) | `` electron-source.electron_37: 37.2.6 -> 37.3.1 ``                           |
| [`a537f9f9`](https://github.com/NixOS/nixpkgs/commit/a537f9f909e66b6e9e11d588a79d5bb5494d73e6) | `` electron-source.electron_36: 36.7.3 -> 36.8.1 ``                           |
| [`9505994d`](https://github.com/NixOS/nixpkgs/commit/9505994d290a3cca345ca121b7da13f54d15d826) | `` electron-source.electron_35: 35.7.4 -> 35.7.5 ``                           |
| [`808637f3`](https://github.com/NixOS/nixpkgs/commit/808637f395397dcb07170949a16744dd22bb3dce) | `` postfix: 3.10.3 -> 3.10.4 ``                                               |
| [`55ce6a83`](https://github.com/NixOS/nixpkgs/commit/55ce6a8344befbee9c4b36df2d3c565a07f223d4) | `` nixos/borgmatic: do not use pg_dumpall when a format is set (#413251) ``   |
| [`41ccae21`](https://github.com/NixOS/nixpkgs/commit/41ccae213cae06f9e3255eec772a65651ac221fb) | `` factorio-experimental: 2.0.60 -> 2.0.64 ``                                 |
| [`5e3fde4f`](https://github.com/NixOS/nixpkgs/commit/5e3fde4f8cfe74a9409b3516af73ad40d61a1fb1) | `` factorio: 2.0.55 -> 2.0.60 ``                                              |
| [`3a1c2246`](https://github.com/NixOS/nixpkgs/commit/3a1c2246fd2efd0694d4a9352fddea0f99dc3495) | `` factorio, factorio-experimental: 2.0.{43,45} -> 2.0.55 ``                  |