### PR TITLE
chore(flake/nur): `3efe965f` -> `e82a8b00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756485854,
-        "narHash": "sha256-2il7zOeQGdwo+9cURSlcILKp5XnxyB6Cmh6ZT+u/zjo=",
+        "lastModified": 1756524478,
+        "narHash": "sha256-2oSBlcYCgwrVxUZwM8MV6hBFsfsWFbeN5ErQiCA+38s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3efe965f5eb94fd3c54d5e3f52ed2ca9ad0b7863",
+        "rev": "e82a8b0095f54edb6bbbb1d862f3da502dca1396",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e82a8b00`](https://github.com/nix-community/NUR/commit/e82a8b0095f54edb6bbbb1d862f3da502dca1396) | `` automatic update `` |
| [`f5a72b6f`](https://github.com/nix-community/NUR/commit/f5a72b6fb998a069c155b0b81590daff63ad098c) | `` automatic update `` |
| [`f7d227cd`](https://github.com/nix-community/NUR/commit/f7d227cda218f964b87783715fd50caa8f8eec44) | `` automatic update `` |
| [`ef21027c`](https://github.com/nix-community/NUR/commit/ef21027c9847f69026ee1d83885dc416593422c8) | `` automatic update `` |
| [`d5d977b0`](https://github.com/nix-community/NUR/commit/d5d977b038ea81fa09ea21dde15dffdb2589359b) | `` automatic update `` |
| [`e52eff6b`](https://github.com/nix-community/NUR/commit/e52eff6b35a0c45ab6d6da89f63d887c6303b760) | `` automatic update `` |
| [`a188dc3b`](https://github.com/nix-community/NUR/commit/a188dc3b0cf84b4e33d8e6a78082fab84a6f49bc) | `` automatic update `` |
| [`01bf774f`](https://github.com/nix-community/NUR/commit/01bf774fb095f9b61f9e22a7f5749a4e81a9a8e4) | `` automatic update `` |
| [`8f90aebc`](https://github.com/nix-community/NUR/commit/8f90aebc0a8fa73f86b3b5b05ae1e7fc3f4cafc2) | `` automatic update `` |
| [`b2265b49`](https://github.com/nix-community/NUR/commit/b2265b493740043246359d0a0e81cbcee920b42e) | `` automatic update `` |