### PR TITLE
chore(flake/nur): `e82a8b00` -> `079e3cfb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756524478,
-        "narHash": "sha256-2oSBlcYCgwrVxUZwM8MV6hBFsfsWFbeN5ErQiCA+38s=",
+        "lastModified": 1756535300,
+        "narHash": "sha256-y014ofVUxHFxXPVTomb301zVGhmafXhGElD6swrO2mk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e82a8b0095f54edb6bbbb1d862f3da502dca1396",
+        "rev": "079e3cfb90e6111b17e9440daa272878ed40ba3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`079e3cfb`](https://github.com/nix-community/NUR/commit/079e3cfb90e6111b17e9440daa272878ed40ba3e) | `` automatic update `` |
| [`94fc286b`](https://github.com/nix-community/NUR/commit/94fc286b50459ae33020e65bc80d358042a02b64) | `` automatic update `` |
| [`6a9b4f10`](https://github.com/nix-community/NUR/commit/6a9b4f1024750decd179e59d57dc3c2b586af414) | `` automatic update `` |
| [`3b3c996b`](https://github.com/nix-community/NUR/commit/3b3c996bbe9e8dc3788a2222beda3967b78534f8) | `` automatic update `` |