### PR TITLE
chore(flake/nur): `079e3cfb` -> `6601ad51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756535300,
-        "narHash": "sha256-y014ofVUxHFxXPVTomb301zVGhmafXhGElD6swrO2mk=",
+        "lastModified": 1756543639,
+        "narHash": "sha256-1T/B6KN9a0ySLNWRqjeTWf1OnkQcV5dd4JhhDlYhHFc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "079e3cfb90e6111b17e9440daa272878ed40ba3e",
+        "rev": "6601ad51748e8300809cd91d863ca2fb1b61b777",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6601ad51`](https://github.com/nix-community/NUR/commit/6601ad51748e8300809cd91d863ca2fb1b61b777) | `` automatic update `` |
| [`35d8dc0a`](https://github.com/nix-community/NUR/commit/35d8dc0a41322f126498f395575df74c2f03d6ec) | `` automatic update `` |
| [`83369ce5`](https://github.com/nix-community/NUR/commit/83369ce5e97d54965283cf02e7f8969b93e00a83) | `` automatic update `` |