### PR TITLE
chore(flake/nixpkgs): `84c26d62` -> `41d292bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1756346337,
-        "narHash": "sha256-al0UcN5mXrO/p5lcH0MuQaj+t97s3brzCii8GfCBMuA=",
+        "lastModified": 1756469547,
+        "narHash": "sha256-YvtD2E7MYsQ3r7K9K2G7nCslCKMPShoSEAtbjHLtH0k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "84c26d62ce9e15489c63b83fc44e6eb62705d2c9",
+        "rev": "41d292bfc37309790f70f4c120b79280ce40af16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`e18f7b23`](https://github.com/NixOS/nixpkgs/commit/e18f7b23df803b85fb18f33637b30d2130f72101) | `` linux_xanmod: update script improvements ``                                    |
| [`65877c9e`](https://github.com/NixOS/nixpkgs/commit/65877c9ea8c0c0e939952a29bfdeff74b1a68170) | `` linux_xanmod_latest: 6.15.11 -> 6.16.4 ``                                      |
| [`aa689a31`](https://github.com/NixOS/nixpkgs/commit/aa689a31e909e8af43946cc7e4fe18b51fa2cfc6) | `` linux_xanmod: 6.12.43 -> 6.12.44 ``                                            |
| [`712d84dc`](https://github.com/NixOS/nixpkgs/commit/712d84dc52c8a93992873eb92a2b651df4b8c340) | `` why3: 1.8.0 -> 1.8.1 ``                                                        |
| [`01342bf5`](https://github.com/NixOS/nixpkgs/commit/01342bf56822f48cd89f40ed5640ac6c23c43e91) | `` python3Packages.pyinterp: init at 2025.8.1 ``                                  |
| [`b4049488`](https://github.com/NixOS/nixpkgs/commit/b4049488b7a5adb07f853c3e992de8a45b4f9a60) | `` gst_all_1.gst-plugins-rs: disable all tests ``                                 |
| [`3e8466ac`](https://github.com/NixOS/nixpkgs/commit/3e8466acba138c5e647d32c0887ec7f80b9b905c) | `` brave: 1.81.136 -> 1.81.137 ``                                                 |
| [`2b26158a`](https://github.com/NixOS/nixpkgs/commit/2b26158aafe09d095950cddefe1cc0911f44df98) | `` facetimehd-calibration: fix build ``                                           |
| [`36ab4f0c`](https://github.com/NixOS/nixpkgs/commit/36ab4f0c4e1c477f938ecbe874a7e029e38a24fe) | `` perlPackages.CGISimple: 1.280 -> 1.282 ``                                      |
| [`28bf994c`](https://github.com/NixOS/nixpkgs/commit/28bf994c6c722f9f940b07971b111bee59d327a6) | `` {palemoon-bin,palemoon-gtk2-bin}: 33.8.1.2 -> 33.8.2 ``                        |
| [`9dcb2d49`](https://github.com/NixOS/nixpkgs/commit/9dcb2d494f65f75ab00a83a14233dd7173d09a38) | `` gitlab: 18.2.2 -> 18.2.5 ``                                                    |
| [`2ad81b79`](https://github.com/NixOS/nixpkgs/commit/2ad81b79c58a286e072e5931df2ddd9291b51f83) | `` hopper: 5.18.0 -> 5.19.4 ``                                                    |
| [`3a662854`](https://github.com/NixOS/nixpkgs/commit/3a6628548a9a964a5c6fb0e2cd4b21757d2c7ce5) | `` hopper: fix up the download URL ``                                             |
| [`579c4e6a`](https://github.com/NixOS/nixpkgs/commit/579c4e6a608a453a58c7ed2d93970c90f23a6204) | `` ci/eval.full: allow local comparison with rebuilds ``                          |
| [`d9a6405e`](https://github.com/NixOS/nixpkgs/commit/d9a6405eab184e012c8ce29a81b97150f25be5c7) | `` ci/eval: clarify README with current defaults and memory requirements ``       |
| [`65e68731`](https://github.com/NixOS/nixpkgs/commit/65e687311898830d6d2cf7df2a9b71095cd40844) | `` firefox-beta: fix darwin build ``                                              |
| [`953de687`](https://github.com/NixOS/nixpkgs/commit/953de6877e373dd5870c7fceb547b52a639a7228) | `` aerc: 0.20.1 -> 0.21.0 ``                                                      |
| [`78f9199d`](https://github.com/NixOS/nixpkgs/commit/78f9199d91f62752f255e50d732f0bd2da001987) | `` linux_5_4: 5.4.296 -> 5.4.297 ``                                               |
| [`3b901e18`](https://github.com/NixOS/nixpkgs/commit/3b901e18def1d6e475aea354effbd775794fa11e) | `` linux_5_10: 5.10.240 -> 5.10.241 ``                                            |
| [`1caab313`](https://github.com/NixOS/nixpkgs/commit/1caab313dae551f7cd57df4f8ad07097349469a0) | `` linux_5_15: 5.15.189 -> 5.15.190 ``                                            |
| [`86ce12ab`](https://github.com/NixOS/nixpkgs/commit/86ce12aba2e9f521e9684c00f10fda7be537aee3) | `` linux_6_1: 6.1.148 -> 6.1.149 ``                                               |
| [`6ace103b`](https://github.com/NixOS/nixpkgs/commit/6ace103b13dad25090e47dfbd69176a218ca58c4) | `` linux_6_6: 6.6.102 -> 6.6.103 ``                                               |
| [`9dbb3029`](https://github.com/NixOS/nixpkgs/commit/9dbb302928609df866046e3d5faf18c9bd334129) | `` linux_6_12: 6.12.43 -> 6.12.44 ``                                              |
| [`33f96dc2`](https://github.com/NixOS/nixpkgs/commit/33f96dc275a2cc183da895d0771c3485b8d642cb) | `` linux_6_16: 6.16.3 -> 6.16.4 ``                                                |
| [`a720fcdf`](https://github.com/NixOS/nixpkgs/commit/a720fcdfe185029978b423d5130d90229e0ad9f2) | `` fixup! gst_all_1.gst-plugins-rs: disable tests ``                              |
| [`75578f8a`](https://github.com/NixOS/nixpkgs/commit/75578f8a25ed0651d813b670127382e3726bf713) | `` gst_all_1.gst-plugins-rs: disable tests ``                                     |
| [`99e41ac1`](https://github.com/NixOS/nixpkgs/commit/99e41ac14662f5ed0685a9b38e6e7ded3661fd4d) | `` radicle-node: fix update script ``                                             |
| [`883ed2e6`](https://github.com/NixOS/nixpkgs/commit/883ed2e657e22f6a2de0de6a559df9b954825e2a) | `` vscode: 1.103.1 -> 1.103.2 ``                                                  |
| [`143f2523`](https://github.com/NixOS/nixpkgs/commit/143f2523d6dfdd29d41f752cd8d6aa329fa0824b) | `` vscode: 1.103.0 -> 1.103.1 ``                                                  |
| [`999ed3e0`](https://github.com/NixOS/nixpkgs/commit/999ed3e0a75011203cace2ea48256b1662ee37ea) | `` vscode: 1.102.3 -> 1.103.0 ``                                                  |
| [`a34c00ad`](https://github.com/NixOS/nixpkgs/commit/a34c00adc80af1d76cf927c6b661d738a483310e) | `` vscode: remove rec ``                                                          |
| [`a041fcff`](https://github.com/NixOS/nixpkgs/commit/a041fcff252fdf6dfd352783a9115addbccf73d2) | `` vscode: remove misleading description ``                                       |
| [`778c4be6`](https://github.com/NixOS/nixpkgs/commit/778c4be6066b0d8529de648cb86cd96aa430b8ff) | `` monero-{cli,gui}: 0.18.4.1 -> 0.18.4.2 ``                                      |
| [`4d4006c3`](https://github.com/NixOS/nixpkgs/commit/4d4006c39d04985f138e2929d220936ca6350dcb) | `` linuxKernel.kernels.linux_zen: 6.16.1 -> 6.16.3 ``                             |
| [`d985743a`](https://github.com/NixOS/nixpkgs/commit/d985743a800280f1556d5a61f7973f0bee754f08) | `` python3Packages.async-upnp-client: 0.44.0 -> 0.45.0 ``                         |
| [`6e8b9c9d`](https://github.com/NixOS/nixpkgs/commit/6e8b9c9d679ccf629ecbcb5d849bf79105abc27e) | `` mautrix-whatsapp: 0.12.3 -> 0.12.4 ``                                          |
| [`4e4b50b0`](https://github.com/NixOS/nixpkgs/commit/4e4b50b05edca55bfd7a7f948a9d1c01f2c3402b) | `` thunderbird-esr: 128.x -> 140.x ``                                             |
| [`4c6417ac`](https://github.com/NixOS/nixpkgs/commit/4c6417ace42835fd657779cd42fc52981501e201) | `` thunderbird-140: init at 140.2.0esr ``                                         |
| [`1a96a329`](https://github.com/NixOS/nixpkgs/commit/1a96a3293b679df76894459649d7a890417cf6f8) | `` python3Packages.cfn-lint: patch a test issue ``                                |
| [`70e73fb8`](https://github.com/NixOS/nixpkgs/commit/70e73fb8ee3c217a3f99ceb0b9e4dee69e482c6f) | `` firefox-beta-unwrapped: 142.0b9 -> 143.0b2 ``                                  |
| [`ed9e27e0`](https://github.com/NixOS/nixpkgs/commit/ed9e27e0d8b66bf93932b347730894ac76da5937) | `` firefox-devedition-unwrapped: 142.0b9 -> 143.0b2 ``                            |
| [`7b1e6e9b`](https://github.com/NixOS/nixpkgs/commit/7b1e6e9b96b621cb6ab954423c5370f881916dba) | `` buildMozillaMach: use nss_3_114 as needed ``                                   |
| [`54a5d9b0`](https://github.com/NixOS/nixpkgs/commit/54a5d9b0ab38a8b2c11c282af139df9552d221b6) | `` nss_3_114: init ``                                                             |
| [`ccebda2e`](https://github.com/NixOS/nixpkgs/commit/ccebda2e55948805af8e305a013e4e0aa283fd62) | `` nss_latest: 3.114 -> 3.115 ``                                                  |
| [`95691238`](https://github.com/NixOS/nixpkgs/commit/9569123863f5a80dc47873f42816dcdc8c4875ea) | `` jenkins: 2.516.1 -> 2.516.2 ``                                                 |
| [`db78acab`](https://github.com/NixOS/nixpkgs/commit/db78acabb3b3d110fde4a1f8fde752baf77d999a) | `` valkey: 8.0.4 -> 8.0.5 ``                                                      |
| [`ead41c37`](https://github.com/NixOS/nixpkgs/commit/ead41c37a84cc365a98c910118e6f11609da642e) | `` python3Packages.aiohttp: patch CVE-2025-53643 ``                               |
| [`916e2797`](https://github.com/NixOS/nixpkgs/commit/916e27971d74a2b50a39fc0cea95fc346a7df0d6) | `` jdk: 21.0.7+6 -> 21.0.8+9 ``                                                   |
| [`d1267a9a`](https://github.com/NixOS/nixpkgs/commit/d1267a9a87a270e3c0c7fb57b98c832b5d72b322) | `` ruby_3_3: 3.3.8 -> 3.3.9 ``                                                    |
| [`3cb47987`](https://github.com/NixOS/nixpkgs/commit/3cb47987b597b24d4e332c2760ad4e52c81fe214) | `` bubblewrap: add dev output to reduce closure size of static build (#433640) `` |
| [`14259668`](https://github.com/NixOS/nixpkgs/commit/14259668ab312c3672708a75ec8330a52a13a9af) | `` cacert: 3.114 -> 3.115 ``                                                      |
| [`717624da`](https://github.com/NixOS/nixpkgs/commit/717624dad37f550bb8d5a0afa2984b37529ad193) | `` libpq: 17.5 -> 17.6 ``                                                         |
| [`252bfb41`](https://github.com/NixOS/nixpkgs/commit/252bfb418954370d6237803683c3a15b63f55fde) | `` gstreamer: 1.26.0 -> 1.26.3 ``                                                 |
| [`079dd272`](https://github.com/NixOS/nixpkgs/commit/079dd272c63ee497a9e5a453deeafda9e3330c0a) | `` audiofile: add many CVE patches ``                                             |
| [`4c59feaf`](https://github.com/NixOS/nixpkgs/commit/4c59feaf51fa1f663eab137d134156368beb8d07) | `` systemd: 257.7 -> 257.8 ``                                                     |
| [`a6cf0575`](https://github.com/NixOS/nixpkgs/commit/a6cf057596325f809244dc4c57e249e0d80baf5b) | `` mbedtls: restore patch to fix build on aarch64 ``                              |
| [`205462f6`](https://github.com/NixOS/nixpkgs/commit/205462f6f0e7f85a9e1963f2ab23c241827a8b5f) | `` sdl3: 3.2.14 -> 3.2.20 ``                                                      |
| [`fe6cb717`](https://github.com/NixOS/nixpkgs/commit/fe6cb717e302cec1a96f1942ddb4c44b89f7d2eb) | `` nodejs_22: 22.17.1 -> 22.18.0 ``                                               |
| [`44b1d7c3`](https://github.com/NixOS/nixpkgs/commit/44b1d7c3620f2dde6feb3136af6568ecc4f28128) | `` strace: 6.15 -> 6.16 ``                                                        |
| [`10fa8389`](https://github.com/NixOS/nixpkgs/commit/10fa8389c10f8f139e7fab29ab6f4061d774124f) | `` go_1_24: 1.24.5 -> 1.24.6 ``                                                   |
| [`cdcc6a98`](https://github.com/NixOS/nixpkgs/commit/cdcc6a9885d5c246ba069918fb53e5f96f79ede7) | `` mbedtls: 3.6.3 -> 3.6.4 ``                                                     |
| [`4d9c0c2f`](https://github.com/NixOS/nixpkgs/commit/4d9c0c2f06e12f11285ae74933d29867b9ceb440) | `` cacert: 3.113.1 -> 3.114 ``                                                    |
| [`4efe076b`](https://github.com/NixOS/nixpkgs/commit/4efe076b221be05a0ed5e35f108139ba6dc3e4e7) | `` tcl,tk: 8.6.15 -> 8.6.16 ``                                                    |
| [`ef75aca7`](https://github.com/NixOS/nixpkgs/commit/ef75aca7a0a99ea7ac8edf1fa062373af7e2d55d) | `` python313: 3.13.4 -> 3.13.5 ``                                                 |