### PR TITLE
chore(flake/chaotic): `a65b368d` -> `9e9e5812`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1756471819,
-        "narHash": "sha256-vKcFkgjcQaxja/B5Q9fk4xwn1AB0Fa1S/uUbnSvVAPM=",
+        "lastModified": 1756606761,
+        "narHash": "sha256-lcHMwq0LVcS1mP9o0pq00Von8PsXMsFPPo3ZXGWa7DU=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "a65b368d67e78606f89241259eca6b67eaf70f99",
+        "rev": "9e9e58125b4ba190658235106858f9733b25a1b4",
         "type": "github"
       },
       "original": {
@@ -382,11 +382,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1756266583,
-        "narHash": "sha256-cr748nSmpfvnhqSXPiCfUPxRz2FJnvf/RjJGvFfaCsM=",
+        "lastModified": 1756542300,
+        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a6d5427d99ec71c64f0b93d45778c889005d9c2",
+        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                       |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`9e9e5812`](https://github.com/chaotic-cx/nyx/commit/9e9e58125b4ba190658235106858f9733b25a1b4) | `` failures: update x86_64-linux ``           |
| [`6766fcc0`](https://github.com/chaotic-cx/nyx/commit/6766fcc02ff91f2faa07b9f834eb2a8654de69b3) | `` nixpkgs: bump to 20250830 ``               |
| [`dc64c272`](https://github.com/chaotic-cx/nyx/commit/dc64c27219693ba365b4e61f2689fe8d3058c4f5) | `` scx_git: fix eval (#1174) ``               |
| [`364bbaea`](https://github.com/chaotic-cx/nyx/commit/364bbaea9034c1e723f4fc96774fc23e77503f6c) | `` scx_git: 71cd096 -> 3cb29c0 (#1173) ``     |
| [`96fc6394`](https://github.com/chaotic-cx/nyx/commit/96fc6394579c6f827302273b2bd4811e6762c9b7) | `` nixpkgs: bump to 20250829 ``               |
| [`23ee8569`](https://github.com/chaotic-cx/nyx/commit/23ee856917eef45ef32f62b7f157283a87ec6509) | `` linux_cachyos: 6.16.3 -> 6.16.4 (#1172) `` |