### PR TITLE
chore(flake/nur): `faf205d8` -> `8a70a9a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756611200,
-        "narHash": "sha256-Ql3RPoH5tSaLHDLUMjwKJ3ZI16VRwnCFUTXo9D9dtsM=",
+        "lastModified": 1756617835,
+        "narHash": "sha256-SP4oxYSOVln4AqAesxvscMsrk98UyVMUQs6KLY/yT8E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "faf205d8dca1b6effd4846f98d1308d689692397",
+        "rev": "8a70a9a512821727d86aca265757822c7bb1109c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8a70a9a5`](https://github.com/nix-community/NUR/commit/8a70a9a512821727d86aca265757822c7bb1109c) | `` automatic update `` |
| [`c7b8c3d8`](https://github.com/nix-community/NUR/commit/c7b8c3d80160c5b733d383d69020196b2601e976) | `` automatic update `` |
| [`d3cd12b8`](https://github.com/nix-community/NUR/commit/d3cd12b86af1cb398277b9bca2dda63998ba63ba) | `` automatic update `` |