### PR TITLE
chore(flake/nur): `8a70a9a5` -> `f6a5a7b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756617835,
-        "narHash": "sha256-SP4oxYSOVln4AqAesxvscMsrk98UyVMUQs6KLY/yT8E=",
+        "lastModified": 1756630008,
+        "narHash": "sha256-weZiVKbiWQzTifm6qCxzhxghEu5mbh9mWNUdkzOLCR0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8a70a9a512821727d86aca265757822c7bb1109c",
+        "rev": "f6a5a7b60dd6065e78ef06390767e689ffa3c23f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f6a5a7b6`](https://github.com/nix-community/NUR/commit/f6a5a7b60dd6065e78ef06390767e689ffa3c23f) | `` automatic update `` |
| [`88de2636`](https://github.com/nix-community/NUR/commit/88de26363dced399c9e45da9bc6bf09f52f8edb1) | `` automatic update `` |
| [`f45c90f7`](https://github.com/nix-community/NUR/commit/f45c90f7f8aed2e6f64d0fe6e17a7237d5fe81e0) | `` automatic update `` |
| [`b781e5e4`](https://github.com/nix-community/NUR/commit/b781e5e4cb8d82bb972b4b33506cece14d88759f) | `` automatic update `` |