### PR TITLE
chore(flake/nur): `9bf6ebed` -> `79e6a622`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756653310,
-        "narHash": "sha256-qSiun5715kEvgpe619+J6C/JGKbkqKsRycK8XyqM+xE=",
+        "lastModified": 1756661623,
+        "narHash": "sha256-Pm1+d+5XdboQG6hQP0MFD/kpHSx/oWkOSpPe1lYMo28=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9bf6ebed2c53c9ac03293616573fccaf788fb286",
+        "rev": "79e6a622d6f2072fa5c576320f4db00be2547d9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`79e6a622`](https://github.com/nix-community/NUR/commit/79e6a622d6f2072fa5c576320f4db00be2547d9f) | `` automatic update `` |
| [`bd736fec`](https://github.com/nix-community/NUR/commit/bd736fecad7e1a0c0b6070b720cc1d2545c5f661) | `` automatic update `` |
| [`76d61266`](https://github.com/nix-community/NUR/commit/76d61266c57afd63171ba78c210f501b1e4267cf) | `` automatic update `` |
| [`e3d7d6ad`](https://github.com/nix-community/NUR/commit/e3d7d6ad3d8de9f09bcbdbaec24d81de9e96d535) | `` automatic update `` |