### PR TITLE
chore(flake/nixpkgs): `41d292bf` -> `b4c2c57c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1756469547,
-        "narHash": "sha256-YvtD2E7MYsQ3r7K9K2G7nCslCKMPShoSEAtbjHLtH0k=",
+        "lastModified": 1756617294,
+        "narHash": "sha256-aGnd4AHIYCWQKChAkHPpX+YYCt7pA6y2LFFA/s8q0wQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "41d292bfc37309790f70f4c120b79280ce40af16",
+        "rev": "b4c2c57c31e68544982226d07e4719a2d86302a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`0c88c0fa`](https://github.com/NixOS/nixpkgs/commit/0c88c0fa6bf780ec9883f70002690b1db7030b32) | `` mattermostLatest: 10.10.1 -> 10.11.1 ``                                         |
| [`4d1f4837`](https://github.com/NixOS/nixpkgs/commit/4d1f483796be9f5423d8d687a29568269717152d) | `` mattermostLatest: 10.9.2 -> 10.10.1 ``                                          |
| [`babec0e6`](https://github.com/NixOS/nixpkgs/commit/babec0e68c7823405cd695fdaaa906b5f246b7cc) | `` mattermostLatest: 10.9.1 -> 10.9.2 ``                                           |
| [`426d3f52`](https://github.com/NixOS/nixpkgs/commit/426d3f527c5fe29e32be53b1278b479a1a392b70) | `` postgresqlPackages.pg_net: 0.19.5 -> 0.19.7 ``                                  |
| [`a308484c`](https://github.com/NixOS/nixpkgs/commit/a308484c92bc34aed63429fe71d847273c721bc4) | `` qmmp: 2.2.7 -> 2.2.8 ``                                                         |
| [`80842a1a`](https://github.com/NixOS/nixpkgs/commit/80842a1ae7447c6463620baf863a05c658fdee6d) | `` qmmp: 2.2.6 -> 2.2.7 ``                                                         |
| [`4bcc3142`](https://github.com/NixOS/nixpkgs/commit/4bcc3142fabdd797e3b676b61b6a63a992a5316c) | `` qmmp: 2.2.5 -> 2.2.6 ``                                                         |
| [`f582c943`](https://github.com/NixOS/nixpkgs/commit/f582c943596624b6ad2a6c47c623ac8d415bcc26) | `` libgeneral: 84 -> 85 ``                                                         |
| [`27fc93a5`](https://github.com/NixOS/nixpkgs/commit/27fc93a507b23f4976163e6dbb1e5b4ef259ce00) | `` libgeneral: init at 84 ``                                                       |
| [`b6baf5c2`](https://github.com/NixOS/nixpkgs/commit/b6baf5c2704dc2c89ee716900ddf94b1536cc7e3) | `` usbmuxd2: Move libgeneral into own derivation ``                                |
| [`39f22242`](https://github.com/NixOS/nixpkgs/commit/39f222425c448fdde7cc8e863b6a1cb438709a23) | `` usbmuxd2: replace pname with string literal in src ``                           |
| [`f89aa24a`](https://github.com/NixOS/nixpkgs/commit/f89aa24adc8f8e8f6525871db1a4af9e1c90a013) | `` usbmuxd2: enable `doPostInstall` for libusb1 packages that expose udev rules `` |
| [`0a992fda`](https://github.com/NixOS/nixpkgs/commit/0a992fda81d0cad2b2255f32850633046c4475de) | `` img4tool: init at 217 ``                                                        |
| [`b70e23a3`](https://github.com/NixOS/nixpkgs/commit/b70e23a3bbdd8f525cef011bfca6314305b44895) | `` nixos/postgresql-backup: add pgdumpAllOptions ``                                |
| [`3edda9e8`](https://github.com/NixOS/nixpkgs/commit/3edda9e8f37475a2a772ad2ee654a8d949cb9501) | `` nixos/postgresql-backup: do not enable assertions when module is disabled ``    |
| [`2f6d56a2`](https://github.com/NixOS/nixpkgs/commit/2f6d56a2057b4b9034720837444c183d0039dcae) | `` librewolf-unwrapped: 142.0-1 -> 142.0.1-1 ``                                    |
| [`767e8445`](https://github.com/NixOS/nixpkgs/commit/767e8445d8e681ce7c519a55e354fb26c58bcbcd) | `` discord: 0.0.104 -> 0.0.107 ``                                                  |
| [`08877223`](https://github.com/NixOS/nixpkgs/commit/08877223bbfebf1f68588a57fb462597dc1f73f4) | `` thunderbird-latest-bin-unwrapped: 141.0 -> 142.0 ``                             |
| [`5e75748b`](https://github.com/NixOS/nixpkgs/commit/5e75748b174d230ff61c6f77a8bcccfe4ecc37e0) | `` tutanota-desktop: 301.250806.1 -> 304.250825.0 ``                               |
| [`d866cfcb`](https://github.com/NixOS/nixpkgs/commit/d866cfcbd779a91bfcea62a1703cf38fb3b9ccb0) | `` python3Packages.protobuf5: 5.29.4 -> 5.29.5 ``                                  |
| [`75e3d27e`](https://github.com/NixOS/nixpkgs/commit/75e3d27eb11d322d18130ad2da09043c4402c3e7) | `` win-pvdrivers: drop ``                                                          |
| [`4229d616`](https://github.com/NixOS/nixpkgs/commit/4229d6161cf158daf17482ae798abd8d9e62bd54) | `` zulip: 5.12.0 → 5.12.1 ``                                                       |
| [`f814e824`](https://github.com/NixOS/nixpkgs/commit/f814e824f8aa301d34899a21ae0f1a2d305e01ed) | `` ci/github-script/labels: auto close package request issues ``                   |
| [`792b94e7`](https://github.com/NixOS/nixpkgs/commit/792b94e7535b403a3ae83cffd18486e804ab1a2d) | `` ISSUE_TEMPLATE: revert one-sentence-per-line for package_request ``             |
| [`d21a0c54`](https://github.com/NixOS/nixpkgs/commit/d21a0c543db8d69ed174a2aa9a28ccb7beec639e) | `` ISSUE_TEMPLATE: add the package request stub ``                                 |
| [`de495ba1`](https://github.com/NixOS/nixpkgs/commit/de495ba15b2872a23681bee017611a4a64c0a421) | `` git-annex: patch another test failure ``                                        |
| [`09b09ec3`](https://github.com/NixOS/nixpkgs/commit/09b09ec38d1261bc3cc2ac02559c0e4e9da09871) | `` nodejs_24: 24.6.0 -> 24.7.0 ``                                                  |
| [`0beac304`](https://github.com/NixOS/nixpkgs/commit/0beac304d7570c843ae914aea5af15c0f7f22297) | `` ci: replace nix_2_24 with nix_2_28 ``                                           |
| [`1cc89ba1`](https://github.com/NixOS/nixpkgs/commit/1cc89ba1551beb7114f5beff569bbe4f77309b3c) | `` mprisence: 1.2.5 -> 1.2.6 ``                                                    |
| [`b5aed0c3`](https://github.com/NixOS/nixpkgs/commit/b5aed0c39373c4d7acc0c66d2d5f645e042b1463) | `` meshcentral: 1.1.48 -> 1.1.49 ``                                                |
| [`b9a900d2`](https://github.com/NixOS/nixpkgs/commit/b9a900d2944ba76f8eac82504dd85b10ba4832cb) | `` grafana: 12.0.3 -> 12.0.4 ``                                                    |
| [`d7102c56`](https://github.com/NixOS/nixpkgs/commit/d7102c56dc6514af78017109e43893ced04b6da8) | `` phpPackages.composer: 2.8.5 -> 2.8.11, add completion, adopt ``                 |
| [`073f11a7`](https://github.com/NixOS/nixpkgs/commit/073f11a724ca12bd8c21f981f733fa72b21360fc) | `` commitlint-rs: 0.2.2 -> 0.2.3 ``                                                |
| [`62917c99`](https://github.com/NixOS/nixpkgs/commit/62917c9960cfe1c63c78a8067b16a82fe9454a2a) | `` nextcloudPackages.apps: update ``                                               |
| [`70ebfe9f`](https://github.com/NixOS/nixpkgs/commit/70ebfe9f89b55b528c1867cc4afb5f89d2604340) | `` nextcloud31: 31.0.7 -> 31.0.8 ``                                                |
| [`a7c85f2c`](https://github.com/NixOS/nixpkgs/commit/a7c85f2cb3fb2f4d053bc89eaeb0f0945c30a306) | `` nextcloud30: 30.0.13 -> 30.0.14 ``                                              |
| [`9a9c4f3f`](https://github.com/NixOS/nixpkgs/commit/9a9c4f3f2a8b3c2bdbc43ffeea1a2ffd4dcf6e48) | `` treewide: remove myself from a few more packages ``                             |
| [`73120866`](https://github.com/NixOS/nixpkgs/commit/73120866fa6e1b1e4bdf182df3e2f8650bead859) | `` teams/flyingcircus: remove ma27 from members ``                                 |
| [`83f39752`](https://github.com/NixOS/nixpkgs/commit/83f3975285de67d0fa451def22116944a79760eb) | `` ed-odyssey-materials-helper: 2.240 -> 2.243 ``                                  |
| [`e4d90113`](https://github.com/NixOS/nixpkgs/commit/e4d90113e5fc5a04b8462c7c27a43b80074d0580) | `` firefly-iii-data-importer: 1.7.9 -> 1.7.10 ``                                   |
| [`73bda6dc`](https://github.com/NixOS/nixpkgs/commit/73bda6dc05ce6fa413b4b14d834029c253f0d4d7) | `` ncrack: fix build ``                                                            |
| [`6c3231aa`](https://github.com/NixOS/nixpkgs/commit/6c3231aab5943240ae0e861f3d79298eb53ecfe5) | `` discord-canary: 0.0.740 -> 0.0.745 ``                                           |
| [`9637ea29`](https://github.com/NixOS/nixpkgs/commit/9637ea29249d488fde110aab362fe3a801e325a8) | `` peertube: 7.2.1 -> 7.2.3 ``                                                     |
| [`f7add915`](https://github.com/NixOS/nixpkgs/commit/f7add915b01da2a2ac0ba8a32919a0a997d91395) | `` libsignal-ffi: add SchweGELBin as maintainer ``                                 |
| [`264c9588`](https://github.com/NixOS/nixpkgs/commit/264c9588114593e06e1ff66c1b36a8838b1c0ac2) | `` mautrix-signal: add SchweGELBin as maintainer ``                                |
| [`446cd85c`](https://github.com/NixOS/nixpkgs/commit/446cd85c4da58bdc00bac5505eff1cfd4cb2168e) | `` mautrix-signal: 0.8.5 -> 0.8.6 ``                                               |
| [`64a021a6`](https://github.com/NixOS/nixpkgs/commit/64a021a67bcdc3e8734f509c7506dd381728d9cd) | `` libsignal-ffi: 0.76.1 -> 0.78.2 ``                                              |
| [`38f6c996`](https://github.com/NixOS/nixpkgs/commit/38f6c9967dcf58965c8021370f97bbbdf99e0959) | `` tutanota-desktop: adopt ``                                                      |
| [`b30d6b10`](https://github.com/NixOS/nixpkgs/commit/b30d6b1030f2c80c91c991aeaf13377af53f10e9) | `` maintainers: add s0ssh ``                                                       |
| [`ff53e487`](https://github.com/NixOS/nixpkgs/commit/ff53e487ddad86ac38dc12ef2c834c5e1cbf8d8e) | `` tutanota-desktop: 299.250725.1 -> 301.250806.1 ``                               |
| [`7197c347`](https://github.com/NixOS/nixpkgs/commit/7197c3479696bcfe845b3a35d616b9aa8f09be10) | `` tutanota-desktop: add awwpotato as maintainer ``                                |
| [`9d790134`](https://github.com/NixOS/nixpkgs/commit/9d7901340ab14d3ea6db761a11728c88e3af6446) | `` tutanota-desktop: add electron ozone flags ``                                   |
| [`7cbe49d2`](https://github.com/NixOS/nixpkgs/commit/7cbe49d2495f56682f3d6c264a8db40eb2672f6b) | `` sope: apply patch for CVE-2025-53603 ``                                         |
| [`b1fe6da0`](https://github.com/NixOS/nixpkgs/commit/b1fe6da0be086f16a130ed7fe424df9220c65d61) | `` h2o: apply patch for CVE-2025-8671 ``                                           |
| [`cdda5f59`](https://github.com/NixOS/nixpkgs/commit/cdda5f59fa2dd714858716f99d380e2f099a9d92) | `` scribus: fix build with poppler 25.07.0 ``                                      |
| [`271b0a70`](https://github.com/NixOS/nixpkgs/commit/271b0a7066f338fedb51f25b5a6222cdf69330a1) | `` inkscape: fix build with poppler 25.07.0 ``                                     |
| [`367468ee`](https://github.com/NixOS/nixpkgs/commit/367468eec47249c4fd3ede7b46d70f82186cc11a) | `` poppler: 25.05.0 -> 25.07.0 ``                                                  |
| [`397612a3`](https://github.com/NixOS/nixpkgs/commit/397612a3ff50d92003e9047bda8bcef3eb803f0d) | `` poppler: remove rec when using finalAttrs ``                                    |
| [`58fdb095`](https://github.com/NixOS/nixpkgs/commit/58fdb09505d5464c0333d5c66d17d5da8eec345f) | `` bind: 9.20.10 -> 9.20.11 ``                                                     |
| [`ea8bdcc9`](https://github.com/NixOS/nixpkgs/commit/ea8bdcc95f496a3e5f1103b453ee868e516fa6e5) | `` bind: 9.20.9 -> 9.20.10 ``                                                      |