### PR TITLE
chore(flake/nur): `79e6a622` -> `bc2a79d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756661623,
-        "narHash": "sha256-Pm1+d+5XdboQG6hQP0MFD/kpHSx/oWkOSpPe1lYMo28=",
+        "lastModified": 1756673099,
+        "narHash": "sha256-HCcQtLMupYBJ7mhacI/8w6sEV2BjSNymxwr3y7KkbRU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "79e6a622d6f2072fa5c576320f4db00be2547d9f",
+        "rev": "bc2a79d83aed043e15e2fa2a3993f7dcba3aa774",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bc2a79d8`](https://github.com/nix-community/NUR/commit/bc2a79d83aed043e15e2fa2a3993f7dcba3aa774) | `` automatic update `` |
| [`fab06af4`](https://github.com/nix-community/NUR/commit/fab06af4f743a74c48cde0fc56748956f9a4d03d) | `` automatic update `` |
| [`0ccfe1e7`](https://github.com/nix-community/NUR/commit/0ccfe1e7fef66b73d3e9fb0dafc4dcdde4b4f581) | `` automatic update `` |