### PR TITLE
chore(flake/home-manager): `54b2879c` -> `07fc025f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756245065,
-        "narHash": "sha256-aAZNbGcWrVRZgWgkQbkabSGcDVRDMgON4BipMy69gvI=",
+        "lastModified": 1756679287,
+        "narHash": "sha256-Xd1vOeY9ccDf5VtVK12yM0FS6qqvfUop8UQlxEB+gTQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "54b2879ce622d44415e727905925e21b8f833a98",
+        "rev": "07fc025fe10487dd80f2ec694f1cd790e752d0e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`07fc025f`](https://github.com/nix-community/home-manager/commit/07fc025fe10487dd80f2ec694f1cd790e752d0e8) | `` fcitx5: migrate to qt6Packages ``           |
| [`f9fa795a`](https://github.com/nix-community/home-manager/commit/f9fa795a290f326c28556e3946796feb81ba50fc) | `` hyprpanel: deprecate `theme.name` option `` |