### PR TITLE
chore(flake/nur): `bb88ceea` -> `be08d5e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756690330,
-        "narHash": "sha256-67sxdFRVlIYRiFQSWhgNFlqiBRXcNABg7id0OcRzkoo=",
+        "lastModified": 1756698854,
+        "narHash": "sha256-RQ7+4EODLWUNuedGR0lPmfXg3k2ABXBoy4X4cORFm00=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bb88ceeaf1ded4f86966304c4f0534be92b2f4d6",
+        "rev": "be08d5e4fb91afdf5a61f0b1b87f727a1b846b60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`be08d5e4`](https://github.com/nix-community/NUR/commit/be08d5e4fb91afdf5a61f0b1b87f727a1b846b60) | `` automatic update `` |
| [`6c69c15b`](https://github.com/nix-community/NUR/commit/6c69c15b713d7a0bde6de2b37bb0161ffbd4034b) | `` automatic update `` |
| [`189ed868`](https://github.com/nix-community/NUR/commit/189ed8680a6af68a0f42fe41e96beb65c182e5f7) | `` automatic update `` |
| [`49f2a4ac`](https://github.com/nix-community/NUR/commit/49f2a4ac326dcc68a940cf163c85b0ca3fc717de) | `` automatic update `` |