### PR TITLE
chore(flake/nur): `be08d5e4` -> `5c499545`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756698854,
-        "narHash": "sha256-RQ7+4EODLWUNuedGR0lPmfXg3k2ABXBoy4X4cORFm00=",
+        "lastModified": 1756706212,
+        "narHash": "sha256-QX/ArRE5jKgr9xvZUN8LOpnUdtHAvGq1JaNUoLvoOSk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "be08d5e4fb91afdf5a61f0b1b87f727a1b846b60",
+        "rev": "5c49954555ad21b9dfd18d772988b1f97935e3ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5c499545`](https://github.com/nix-community/NUR/commit/5c49954555ad21b9dfd18d772988b1f97935e3ea) | `` automatic update `` |
| [`a8b026eb`](https://github.com/nix-community/NUR/commit/a8b026eb0836d4aaabb7b3ad3c7d3549072b1af0) | `` automatic update `` |
| [`c0824978`](https://github.com/nix-community/NUR/commit/c0824978e58d3d0ea7ac01a1e0ec384604118c23) | `` automatic update `` |