### PR TITLE
chore(flake/nur): `5c499545` -> `9eedce97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756706212,
-        "narHash": "sha256-QX/ArRE5jKgr9xvZUN8LOpnUdtHAvGq1JaNUoLvoOSk=",
+        "lastModified": 1756715062,
+        "narHash": "sha256-uHFLpsYRHpnSEfMbfNbrpnkIHePfyBfzzMU2hNsKDMw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5c49954555ad21b9dfd18d772988b1f97935e3ea",
+        "rev": "9eedce975c6324407871669fd27b10582832fd27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9eedce97`](https://github.com/nix-community/NUR/commit/9eedce975c6324407871669fd27b10582832fd27) | `` automatic update `` |
| [`effb8c7a`](https://github.com/nix-community/NUR/commit/effb8c7ab9fbfba86d31703a6101469489ab9df8) | `` automatic update `` |