### PR TITLE
chore(flake/nixos-hardware): `a65b650d` -> `6b794188`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -289,11 +289,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1756245047,
-        "narHash": "sha256-9bHzrVbjAudbO8q4vYFBWlEkDam31fsz0J7GB8k4AsI=",
+        "lastModified": 1756749628,
+        "narHash": "sha256-62s9aqvqD+1l118jOuck7/h4Ab638T4BHRULUCtnXvc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a65b650d6981e23edd1afa1f01eb942f19cdcbb7",
+        "rev": "6b7941884f249526a8b446fab5ba579b4ce47af1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`e903fd79`](https://github.com/NixOS/nixos-hardware/commit/e903fd796da4396598e1d0573f7516927feb3577) | `` Revert "apple: add hid_apple.iso_layout=0 kernel param" ``                     |
| [`a57aded4`](https://github.com/NixOS/nixos-hardware/commit/a57aded40e877bb419d98f8290efa4b8aa5beada) | `` Update README.md - wireplumber example issue ``                                |
| [`f3444245`](https://github.com/NixOS/nixos-hardware/commit/f3444245a78f55dd22fca2f9f52b1f3e5382572b) | `` apple/t2: sync stable patches (6.12.43 -> 6.12.44) ``                          |
| [`9691e6ee`](https://github.com/NixOS/nixos-hardware/commit/9691e6ee8a33dec6f8222314785868415bb78560) | `` apple/t2: sync stable patches ``                                               |
| [`bfda6f34`](https://github.com/NixOS/nixos-hardware/commit/bfda6f34d3eaf310ea2565bd51bc48aabcc45f3a) | `` dell/precision/7520: use stable nvidia driver (not legacy) ``                  |
| [`59e2d82c`](https://github.com/NixOS/nixos-hardware/commit/59e2d82cc23b05e99815ae7ad95f454905f3689d) | `` ran formatter for mbp11,4 ``                                                   |
| [`6439a46c`](https://github.com/NixOS/nixos-hardware/commit/6439a46c7ce9bf5b0d51438e0e316b748cf42fd5) | `` feat: add MECHREVO Yilong15Pro(GM5HG0A) ``                                     |
| [`cfb36e4f`](https://github.com/NixOS/nixos-hardware/commit/cfb36e4feb6a9a423510260a7959eb0831461570) | `` fix: add missing import of ideapad 16iah8 ``                                   |
| [`5e741b56`](https://github.com/NixOS/nixos-hardware/commit/5e741b56dc39de0ff7f2565867dd08a2118155b2) | `` added supporting files ``                                                      |
| [`17113fc1`](https://github.com/NixOS/nixos-hardware/commit/17113fc124517f837c27f3ebb3a23659a7ca4442) | `` Added g533q ``                                                                 |
| [`0413405b`](https://github.com/NixOS/nixos-hardware/commit/0413405b45b381c8c8fa25d8e81fcbb395bc423e) | `` feat: ✨ add ThinkPad T14 Intel Gen 6 hardware support ``                       |
| [`e3e3717d`](https://github.com/NixOS/nixos-hardware/commit/e3e3717d85ca1105afc9ec5b3a6a4ce4ba204135) | `` apple/t2: kernel 6.15 -> 6.16; sync patches ``                                 |
| [`2d512d0f`](https://github.com/NixOS/nixos-hardware/commit/2d512d0f4ef9908c104c4e451bb1571fe81a4267) | `` removed s2idle for macbookpro11,4 as default ``                                |
| [`6287c9e1`](https://github.com/NixOS/nixos-hardware/commit/6287c9e15f1f575157e8c8b7627b5b5858265821) | `` build(deps): bump actions/checkout from 4 to 5 ``                              |
| [`292aeb6f`](https://github.com/NixOS/nixos-hardware/commit/292aeb6fd6a33045f73e24cbf51ed22ef4156094) | `` added macbook pro 11,4 config ``                                               |
| [`c4af46bb`](https://github.com/NixOS/nixos-hardware/commit/c4af46bb6a91f90a99d9fc0b89a0fda85122943b) | `` raspberry-pi/4: support enabling/disabling media-controller api on tc358743 `` |
| [`680761f0`](https://github.com/NixOS/nixos-hardware/commit/680761f019c3d37c5a3d920b1ff8c61ded68cd6b) | `` fix: tc358743 dt overlay ``                                                    |
| [`139a6586`](https://github.com/NixOS/nixos-hardware/commit/139a6586edaa656ca7beee79d6bf397af4066fc3) | `` Add Lenovo Thinkpad P16s AMD Gen 4 ``                                          |
| [`aaecdd8d`](https://github.com/NixOS/nixos-hardware/commit/aaecdd8d3bd6e7e52a6375e7bab914582ce5e540) | `` Update flake.lock, dropping unused `nixpkgs` input ``                          |