### PR TITLE
chore(flake/nur): `092fc22e` -> `ade8edc0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756745328,
-        "narHash": "sha256-9BdRuOoo+d0Kg5pXsEI2crjIvgPvUBqxtRRyzbe201U=",
+        "lastModified": 1756759493,
+        "narHash": "sha256-OYbOCec6bmqhu6IEHwdssHeDJCGeb/q0oHAVOLKz4+E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "092fc22e7002ce083b7cd5cc1b0d5dac97d39c25",
+        "rev": "ade8edc03289b193c1d23daa3ca553b13f327c4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ade8edc0`](https://github.com/nix-community/NUR/commit/ade8edc03289b193c1d23daa3ca553b13f327c4e) | `` automatic update `` |
| [`0684882e`](https://github.com/nix-community/NUR/commit/0684882ee6d2ebb142c7f0b64072976473d23b6a) | `` automatic update `` |
| [`65f25423`](https://github.com/nix-community/NUR/commit/65f254239faf83fb43e672a544ed6681aff472d7) | `` automatic update `` |
| [`70f33939`](https://github.com/nix-community/NUR/commit/70f339391f2e60c7bfe2a540677508947a881d29) | `` automatic update `` |