### PR TITLE
chore(flake/nur): `ade8edc0` -> `34d99d18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756759493,
-        "narHash": "sha256-OYbOCec6bmqhu6IEHwdssHeDJCGeb/q0oHAVOLKz4+E=",
+        "lastModified": 1756776255,
+        "narHash": "sha256-z8ONkFHlTErjJWt6kyR8aJi5exMJjZfEhDj2mzeQ7YI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ade8edc03289b193c1d23daa3ca553b13f327c4e",
+        "rev": "34d99d18b79389d26cfad4c4584e4bbce93bbf8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`34d99d18`](https://github.com/nix-community/NUR/commit/34d99d18b79389d26cfad4c4584e4bbce93bbf8f) | `` automatic update `` |
| [`8790f83f`](https://github.com/nix-community/NUR/commit/8790f83fdd680a8480717944032caf2275de928a) | `` automatic update `` |
| [`4153e362`](https://github.com/nix-community/NUR/commit/4153e362b943a9fabc15a2a4aeddc93c7d6cd2d3) | `` automatic update `` |
| [`932edc60`](https://github.com/nix-community/NUR/commit/932edc60b98cc9fadb0d37018925ca5b9a83cf73) | `` automatic update `` |
| [`0d07ee13`](https://github.com/nix-community/NUR/commit/0d07ee13c482fa637d56f281583fc5b0da22a0de) | `` automatic update `` |