### PR TITLE
chore(flake/nur): `34d99d18` -> `38d05e3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756776255,
-        "narHash": "sha256-z8ONkFHlTErjJWt6kyR8aJi5exMJjZfEhDj2mzeQ7YI=",
+        "lastModified": 1756784167,
+        "narHash": "sha256-gYKRYQgTbFmIu3u5S3I0Qn1aHv3M1sCfFPy/PiyhnYI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "34d99d18b79389d26cfad4c4584e4bbce93bbf8f",
+        "rev": "38d05e3ed2bfadddd5a8aecb03eb4988ad9399f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`38d05e3e`](https://github.com/nix-community/NUR/commit/38d05e3ed2bfadddd5a8aecb03eb4988ad9399f5) | `` automatic update `` |
| [`e0dd581f`](https://github.com/nix-community/NUR/commit/e0dd581fe4388b99545889845f7d26a9358d445b) | `` automatic update `` |