### PR TITLE
chore(flake/nur): `38d05e3e` -> `678bf16a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756784167,
-        "narHash": "sha256-gYKRYQgTbFmIu3u5S3I0Qn1aHv3M1sCfFPy/PiyhnYI=",
+        "lastModified": 1756791666,
+        "narHash": "sha256-PSwg6aIlR2+ACQ+1CV76kiXdl/E21fQG6/7xCoOcbCY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "38d05e3ed2bfadddd5a8aecb03eb4988ad9399f5",
+        "rev": "678bf16a5f1a7e2df5b75d4c62da44bc67921462",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`678bf16a`](https://github.com/nix-community/NUR/commit/678bf16a5f1a7e2df5b75d4c62da44bc67921462) | `` automatic update `` |
| [`2cc1337c`](https://github.com/nix-community/NUR/commit/2cc1337cc18f60d9fd9df787dae2bc7a5239202d) | `` automatic update `` |
| [`c66615c6`](https://github.com/nix-community/NUR/commit/c66615c6892d6a7f17c5ee9bb6d001f7fee12e4b) | `` automatic update `` |
| [`7a8a4b4b`](https://github.com/nix-community/NUR/commit/7a8a4b4bfbb0f2268d31f37b4d7aa127450510ef) | `` automatic update `` |