### PR TITLE
chore(flake/nixpkgs): `b4c2c57c` -> `7c815e51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1756617294,
-        "narHash": "sha256-aGnd4AHIYCWQKChAkHPpX+YYCt7pA6y2LFFA/s8q0wQ=",
+        "lastModified": 1756754095,
+        "narHash": "sha256-9Rsn9XEWINExosFkKEqdp8EI6Mujr1gmQiyrEcts2ls=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b4c2c57c31e68544982226d07e4719a2d86302a8",
+        "rev": "7c815e513adbf03c9098b2bd230c1e0525c8a7f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`0420b329`](https://github.com/NixOS/nixpkgs/commit/0420b329f6e5944e8595774769a17003b10ab047) | `` postgrest: 13.0.5 -> 13.0.6 ``                                                 |
| [`cbe4381a`](https://github.com/NixOS/nixpkgs/commit/cbe4381a2c06fd9f2aeb518855ddf06345d04f61) | `` postgrest: 13.0.4 -> 13.0.5 ``                                                 |
| [`1bb90a21`](https://github.com/NixOS/nixpkgs/commit/1bb90a21dbe0cf98aa002de6c2b4aa177565d582) | `` haskellPackages.postgrest: 13.0.0 -> 13.0.4 ``                                 |
| [`317667d7`](https://github.com/NixOS/nixpkgs/commit/317667d7b576f1010a4adeee62c2455d3681548c) | `` librewolf-bin-unwrapped: 142.0.1 -> 142.0.1-1 ``                               |
| [`4198e557`](https://github.com/NixOS/nixpkgs/commit/4198e557f3e402376672ecf50a5d43c2c0011d3e) | `` ci/eval/compare: handle missing packages ``                                    |
| [`120cf68a`](https://github.com/NixOS/nixpkgs/commit/120cf68ade2464680324967920ae2662cf7719d9) | `` nixos/glitchtip: add stateDir option ``                                        |
| [`0cdcf4e6`](https://github.com/NixOS/nixpkgs/commit/0cdcf4e6fbea0c9cbe22c088f638db7e96c9c944) | `` nixos/glitchtip: fix sourcemap uploads ``                                      |
| [`9978b140`](https://github.com/NixOS/nixpkgs/commit/9978b14017c98851dc29b9dada4a204b3f5edd15) | `` nixos/tests/glitchtip: test sourcemap uploads ``                               |
| [`ad0f2f28`](https://github.com/NixOS/nixpkgs/commit/ad0f2f28ec10f105aaead3e1b71ce91cfd171c47) | `` nixos/radicle: add httpd.aliases option ``                                     |
| [`b6fe1205`](https://github.com/NixOS/nixpkgs/commit/b6fe1205080b83a0b18c393b2cf82d1a999fd76d) | `` virt-manager: 5.0.0 -> 5.1.0 ``                                                |
| [`17096cea`](https://github.com/NixOS/nixpkgs/commit/17096cea47d8ee98a7b4f53ac844865cbd582bce) | `` llvmPackages_git: 22.0.0-unstable-2025-08-24 -> 22.0.0-unstable-2025-08-31 ``  |
| [`10265dc0`](https://github.com/NixOS/nixpkgs/commit/10265dc092a77dab188d1bca3cbfc602f8b3470d) | `` llvmPackages_git: 22.0.0-unstable-2025-08-17 -> 22.0.0-unstable-2025-08-24 ``  |
| [`5266a6d9`](https://github.com/NixOS/nixpkgs/commit/5266a6d93832bd52a3db9268573c72ac3959bac4) | `` nixos/public-inbox: fix inboxdir option ``                                     |
| [`03a94846`](https://github.com/NixOS/nixpkgs/commit/03a9484617e33660fe3d72cada4ee46fb17eaa24) | `` nixos/tests/openvswitch: improve ping check resiliency ``                      |
| [`368188fa`](https://github.com/NixOS/nixpkgs/commit/368188fa0057581ccd24cc8ac6b84cf7fd4b0c5d) | `` bakelite: 0.4.2-unstable-2023-05-30 -> 0.4.2-unstable-2024-08-02 ``            |
| [`dd3e8f66`](https://github.com/NixOS/nixpkgs/commit/dd3e8f668a65215a6ba7c7b28dca44912bab787b) | `` ci/eval/compare: refactor ``                                                   |
| [`d766035d`](https://github.com/NixOS/nixpkgs/commit/d766035d6544bb385b307c5de6c4bb5ed08c91cd) | `` ci/eval/compare: only check changed attrpaths ``                               |
| [`f6634a66`](https://github.com/NixOS/nixpkgs/commit/f6634a6670386d5dd57d40ae5913441a50104dd7) | `` ci/eval/compare: remove package validity check ``                              |
| [`7dd8ed0a`](https://github.com/NixOS/nixpkgs/commit/7dd8ed0a70132310fc19a044d94e2973a38093c8) | `` ci/eval/compare: ping maintainers of removed packages ``                       |
| [`f7765deb`](https://github.com/NixOS/nixpkgs/commit/f7765deb89191e742301d157d496b02f4b07f62c) | `` chhoto-url: 6.2.13 -> 6.3.0 ``                                                 |
| [`76505d15`](https://github.com/NixOS/nixpkgs/commit/76505d15910fb73be98698eac1e406ed559d7dc8) | `` discord-ptb: 0.0.156 -> 0.0.158 ``                                             |
| [`12c008ec`](https://github.com/NixOS/nixpkgs/commit/12c008ecbf7058dbdb32477a708220dc7890f60a) | `` optnix: 0.2.0 -> 0.3.0 ``                                                      |
| [`8db24a63`](https://github.com/NixOS/nixpkgs/commit/8db24a63489c5fb187fe50870d90bb97907a97f0) | `` maintainers: fix GitHub handles ``                                             |
| [`1628802b`](https://github.com/NixOS/nixpkgs/commit/1628802b4fabed6811a83ec68787622d196c4f95) | `` maintainers: drop srghma ``                                                    |
| [`3a27e7cb`](https://github.com/NixOS/nixpkgs/commit/3a27e7cb4ad09c6edc3ed226e2e17f2dda5af87a) | `` maintainers: drop hikari ``                                                    |
| [`a2ca8a6f`](https://github.com/NixOS/nixpkgs/commit/a2ca8a6f2bbedb9aa5f6041e20b285883d76ace4) | `` maintainers: drop elysasrc ``                                                  |
| [`3cdbdc50`](https://github.com/NixOS/nixpkgs/commit/3cdbdc50c5172c72d239f8f818ecfcd4ea345f73) | `` maintainers: drop galaxy ``                                                    |
| [`b04e603d`](https://github.com/NixOS/nixpkgs/commit/b04e603de3d75495a611c75f7508ba3baf3a2107) | `` maintainers: drop chrpinedo ``                                                 |
| [`023cfcc0`](https://github.com/NixOS/nixpkgs/commit/023cfcc04796c171b8649617e0ddfbb68070e767) | `` zeal: migrate to pkgs/by-name, use qt6 ``                                      |
| [`d44c6318`](https://github.com/NixOS/nixpkgs/commit/d44c6318124a5119d5661b8988bbde1456b94760) | `` qolibri: move to by-name, switch to Qt6 ``                                     |
| [`df76d0f2`](https://github.com/NixOS/nixpkgs/commit/df76d0f26e283ba458cfbed7672c46fb1b0fb130) | `` optnix: init at 0.2.0 ``                                                       |
| [`4e2bc0c7`](https://github.com/NixOS/nixpkgs/commit/4e2bc0c7bce2f54ecaa39ccee5e601ecd3fcefd4) | `` flyctl: 0.3.171 -> 0.3.172 ``                                                  |
| [`af39794d`](https://github.com/NixOS/nixpkgs/commit/af39794d2a7403f0121a02cd11af252c2e7ff3aa) | `` warp-terminal: 0.2025.08.20.08.11.stable_03 -> 0.2025.08.27.08.11.stable_03 `` |
| [`93fea8e3`](https://github.com/NixOS/nixpkgs/commit/93fea8e34a0e5c3651e2c14b0c4836c7990f3bcb) | `` keycloak: makeWrapper -> makeBinaryWrapper ``                                  |
| [`cd7498bc`](https://github.com/NixOS/nixpkgs/commit/cd7498bc822ef15ba6a704bd7389b1da6b9d2c3d) | `` keycloak: switch to finalAttrs pattern ``                                      |
| [`2857912b`](https://github.com/NixOS/nixpkgs/commit/2857912ba0fe59a458b1d70b94135c80ff8f26f2) | `` forgejo-lts: 11.0.3 -> 11.0.4 ``                                               |
| [`7f7f5d63`](https://github.com/NixOS/nixpkgs/commit/7f7f5d63fa6f5e784f852ba36a16142968a0265b) | `` forgejo: 12.0.1 -> 12.0.2 ``                                                   |
| [`f36fdd63`](https://github.com/NixOS/nixpkgs/commit/f36fdd634d2dd433e6abf9d583ecbf2f209aceb9) | `` postfix-tlspol: 1.8.15 -> 1.8.16 ``                                            |
| [`d427bffe`](https://github.com/NixOS/nixpkgs/commit/d427bffe369418c66f224417bbce3ce65663864a) | `` postfix-tlspol: 1.8.14 -> 1.8.15 ``                                            |
| [`386f454f`](https://github.com/NixOS/nixpkgs/commit/386f454f176d9c6056c5951d4ab178dbb772a536) | `` openvswitch: 3.5.1 -> 3.5.2 ``                                                 |
| [`43fb0898`](https://github.com/NixOS/nixpkgs/commit/43fb0898d595fc8d4a87a7f608694e67da97bbea) | `` firefox-bin-unwrapped: 142.0 -> 142.0.1 ``                                     |
| [`700ef0a5`](https://github.com/NixOS/nixpkgs/commit/700ef0a56a5b4c7edd1da66587224e4cc74e8edd) | `` firefox-unwrapped: 142.0 -> 142.0.1 ``                                         |
| [`06da25ca`](https://github.com/NixOS/nixpkgs/commit/06da25caeca7dd640612a1272dda68a765d5b5df) | `` php83: 8.3.24 -> 8.3.25 ``                                                     |
| [`e006e084`](https://github.com/NixOS/nixpkgs/commit/e006e08461ca8569c6b4fe3f85b1442fd0be957d) | `` nightfox-gtk-theme: 0-unstable-2025-07-28 -> 0-unstable-2025-08-21 ``          |
| [`d522ba2c`](https://github.com/NixOS/nixpkgs/commit/d522ba2c3d35b09bb1788a8730e6126ef15a3a9c) | `` nightfox-gtk-theme: 0-unstable-2025-07-21 -> 0-unstable-2025-07-28 ``          |
| [`4ce47ce0`](https://github.com/NixOS/nixpkgs/commit/4ce47ce0c38cf76fb953d641569989fcd698b548) | `` openscad: fix application icon ``                                              |
| [`ed4a34a9`](https://github.com/NixOS/nixpkgs/commit/ed4a34a99bd889846e25c5b415c6ee5919df5809) | `` proton-ge-bin: GE-Proton10-13 -> GE-Proton10-15 ``                             |
| [`293bb76a`](https://github.com/NixOS/nixpkgs/commit/293bb76acb49290f5a9df4f5a58cc456fff20393) | `` komikku: 1.85.0 -> 1.86.0 ``                                                   |