### PR TITLE
chore(flake/nur): `678bf16a` -> `bb53c97b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756791666,
-        "narHash": "sha256-PSwg6aIlR2+ACQ+1CV76kiXdl/E21fQG6/7xCoOcbCY=",
+        "lastModified": 1756804374,
+        "narHash": "sha256-lWvspPwnTuhzCUal/cxYPVZephspwXgsoWATWhA1Sm0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "678bf16a5f1a7e2df5b75d4c62da44bc67921462",
+        "rev": "bb53c97b200b0b92c5795b5d9696389e53a1653a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bb53c97b`](https://github.com/nix-community/NUR/commit/bb53c97b200b0b92c5795b5d9696389e53a1653a) | `` automatic update `` |
| [`17592a6e`](https://github.com/nix-community/NUR/commit/17592a6e8f9e4bc6f9dd8d577e80010f216c811e) | `` automatic update `` |
| [`1d4a42c8`](https://github.com/nix-community/NUR/commit/1d4a42c87f9627a6d211a0fd0e2f1b9c2525c845) | `` automatic update `` |
| [`daf72458`](https://github.com/nix-community/NUR/commit/daf72458b0b2379681f8978a429b5f1428865c13) | `` automatic update `` |
| [`94b0b2ad`](https://github.com/nix-community/NUR/commit/94b0b2ad8785904c0ecc53ad746207392063c3c3) | `` automatic update `` |