### PR TITLE
chore(flake/nur): `b8e7bafc` -> `46ca2903`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756813408,
-        "narHash": "sha256-f7bnnYN/af9hcsiW8NZblVFReRDrl1zjBDsFq2uTSJ0=",
+        "lastModified": 1756824287,
+        "narHash": "sha256-mUwzJSu1vg+oaaJ5/4Nj7+S3ttLy0J/jy9/iAwbFShs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8e7bafc21fbc2b3fb9bafd4ae0c8f789d14349d",
+        "rev": "46ca29032c89a78b943b7c37fddf5742a36c6e01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`46ca2903`](https://github.com/nix-community/NUR/commit/46ca29032c89a78b943b7c37fddf5742a36c6e01) | `` automatic update `` |
| [`959a03fe`](https://github.com/nix-community/NUR/commit/959a03fe31a83362741b83a0ad0cbfe46a3217ea) | `` automatic update `` |
| [`c9c4e73a`](https://github.com/nix-community/NUR/commit/c9c4e73a1b1edb2dce5ed903be2be1b49947964d) | `` automatic update `` |