### PR TITLE
chore(flake/nur): `931c653b` -> `8729ec59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756831509,
-        "narHash": "sha256-IsOjRsuuiWwJMse0ZyTT5YOAhmE+l7CBJ7l5wxZ+NIY=",
+        "lastModified": 1756869777,
+        "narHash": "sha256-JIxmYdpqAXlKDhr2YTlmJZRS8d/OHm5TLAssTbtKMMM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "931c653b4ecee6d21326626409721f742022591b",
+        "rev": "8729ec59450d7bda9c3ab14a167bf7a10442901c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8729ec59`](https://github.com/nix-community/NUR/commit/8729ec59450d7bda9c3ab14a167bf7a10442901c) | `` automatic update `` |
| [`888f3383`](https://github.com/nix-community/NUR/commit/888f3383ea4dc678be67317e5e9f229bb772584b) | `` automatic update `` |
| [`56dde8b9`](https://github.com/nix-community/NUR/commit/56dde8b941b873709a2eee5e912ce8a161fe47a1) | `` automatic update `` |
| [`8c520217`](https://github.com/nix-community/NUR/commit/8c5202177d2830f9affbd629206f7916b9a27303) | `` automatic update `` |
| [`5fd13c87`](https://github.com/nix-community/NUR/commit/5fd13c8731a4689e99b33469620c91fd930eb937) | `` automatic update `` |
| [`143985f9`](https://github.com/nix-community/NUR/commit/143985f9f846656911cb35fdc3403a68a2363b87) | `` automatic update `` |
| [`d93f4f98`](https://github.com/nix-community/NUR/commit/d93f4f98abf2f40fcf7f01e767b921fd464c0f71) | `` automatic update `` |
| [`223667f0`](https://github.com/nix-community/NUR/commit/223667f0bf566fde8c8e1791e8e0a1be8603c24e) | `` automatic update `` |
| [`e5a00c9e`](https://github.com/nix-community/NUR/commit/e5a00c9e0aa0ea3987864e642a6ab3bc38d4e835) | `` automatic update `` |
| [`026cbef0`](https://github.com/nix-community/NUR/commit/026cbef09e235753672904ff30253130f08b9557) | `` automatic update `` |
| [`6172faa4`](https://github.com/nix-community/NUR/commit/6172faa42e3fde720fb8ee632f96686a774d3533) | `` automatic update `` |