### PR TITLE
chore(flake/nur): `8729ec59` -> `bffccde9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1756542300,
-        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
+        "lastModified": 1756787288,
+        "narHash": "sha256-rw/PHa1cqiePdBxhF66V7R+WAP8WekQ0mCDG4CFqT8Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
+        "rev": "d0fc30899600b9b3466ddb260fd83deb486c32f1",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756869777,
-        "narHash": "sha256-JIxmYdpqAXlKDhr2YTlmJZRS8d/OHm5TLAssTbtKMMM=",
+        "lastModified": 1756875847,
+        "narHash": "sha256-2L4kOvvCDUDBBBliCNiEXrYN0VqqkB0YHuOGckpp5X8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8729ec59450d7bda9c3ab14a167bf7a10442901c",
+        "rev": "bffccde9bd7869ab355b76d53fbc25ac1f7d37eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bffccde9`](https://github.com/nix-community/NUR/commit/bffccde9bd7869ab355b76d53fbc25ac1f7d37eb) | `` automatic update `` |
| [`fe2f2504`](https://github.com/nix-community/NUR/commit/fe2f250471ec4596947d7a9aa0e2ce677e1cb7df) | `` automatic update `` |
| [`f351d2f4`](https://github.com/nix-community/NUR/commit/f351d2f4780ccf27256eea281401cbf08b8cb92d) | `` automatic update `` |
| [`46545ca2`](https://github.com/nix-community/NUR/commit/46545ca20af217314b9176c44f74c1a9f025c8f1) | `` automatic update `` |
| [`55dd30d1`](https://github.com/nix-community/NUR/commit/55dd30d13ba308aa08e5494552f86f1eff13c9a7) | `` automatic update `` |