### PR TITLE
chore(flake/nur): `bffccde9` -> `fc7b109f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756875847,
-        "narHash": "sha256-2L4kOvvCDUDBBBliCNiEXrYN0VqqkB0YHuOGckpp5X8=",
+        "lastModified": 1756889379,
+        "narHash": "sha256-3NSHfLMBFSlMFpBdd4/jUfdPCIDA7mcw2m5eKEgVsbU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bffccde9bd7869ab355b76d53fbc25ac1f7d37eb",
+        "rev": "fc7b109fc7b7bbeacac51fa8f793c48c5442b343",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc7b109f`](https://github.com/nix-community/NUR/commit/fc7b109fc7b7bbeacac51fa8f793c48c5442b343) | `` automatic update `` |
| [`d2382032`](https://github.com/nix-community/NUR/commit/d2382032dd42ff9769e3877e56d07c96f160fb6f) | `` automatic update `` |
| [`635dfa20`](https://github.com/nix-community/NUR/commit/635dfa20c5c8637e1c1b8e86fe851455ff67eda7) | `` automatic update `` |