### PR TITLE
chore(flake/nur): `fc7b109f` -> `d8cfb3ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756889379,
-        "narHash": "sha256-3NSHfLMBFSlMFpBdd4/jUfdPCIDA7mcw2m5eKEgVsbU=",
+        "lastModified": 1756903679,
+        "narHash": "sha256-5LILWgddjmHxmZ+kXW+UQVHiPCCP0/VIg9X1Y4wGpKo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc7b109fc7b7bbeacac51fa8f793c48c5442b343",
+        "rev": "d8cfb3ad481b6b86982c0fe6220eef68ea53695c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d8cfb3ad`](https://github.com/nix-community/NUR/commit/d8cfb3ad481b6b86982c0fe6220eef68ea53695c) | `` automatic update `` |
| [`dbc389f3`](https://github.com/nix-community/NUR/commit/dbc389f337e2a9a01e5b3c412b303394c2058f26) | `` automatic update `` |
| [`5df818e5`](https://github.com/nix-community/NUR/commit/5df818e5b09b36da300d6ea41fa0952cb02cfe47) | `` automatic update `` |