### PR TITLE
chore(flake/chaotic): `9e9e5812` -> `478969e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1756606761,
-        "narHash": "sha256-lcHMwq0LVcS1mP9o0pq00Von8PsXMsFPPo3ZXGWa7DU=",
+        "lastModified": 1756909345,
+        "narHash": "sha256-dSz08uK6NlgGxfo7F7E8rBB3lAROWdncOFTH/lZLVFI=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "9e9e58125b4ba190658235106858f9733b25a1b4",
+        "rev": "478969e9fcd639751841009415df6178044cb6e2",
         "type": "github"
       },
       "original": {
@@ -382,11 +382,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1756542300,
-        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
-        "owner": "NixOS",
+        "lastModified": 1756896242,
+        "narHash": "sha256-fokvf0dI+4frI1QbrN7bGsHfK5V+kx/cgSVJPb4yr8k=",
+        "owner": "PedroHLC",
         "repo": "nixpkgs",
-        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
+        "rev": "ca9bf1d602372d663b797031a860faeacbb898b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                                          |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`478969e9`](https://github.com/chaotic-cx/nyx/commit/478969e9fcd639751841009415df6178044cb6e2) | `` README: update about linuxPackages_cachyos-ltos; linuxPackages_cachyos: fix meta.platforms `` |
| [`0bc1f6d8`](https://github.com/chaotic-cx/nyx/commit/0bc1f6d8e3681325f59225c6e50d3b5c9b29a6ad) | `` failures: update x86_64-linux ``                                                              |
| [`6b547e56`](https://github.com/chaotic-cx/nyx/commit/6b547e56d14f2cebb74e0dbe686449f385a3c7fd) | `` linux_cachyos-lto: adopt nixpkgs#402198 (#1115) ``                                            |
| [`b79419b5`](https://github.com/chaotic-cx/nyx/commit/b79419b5f00fd5d75ea013f7f12064a4eca8accf) | `` scx_git: lint ``                                                                              |
| [`38044e7b`](https://github.com/chaotic-cx/nyx/commit/38044e7ba1cf365e2b896a8a6f5cb5efb0837b75) | `` nixpkgs: 20250830-d7600c7 -> 20250902-d0fc308 ``                                              |