### PR TITLE
chore(flake/nixpkgs): `7c815e51` -> `0e6684e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1756754095,
-        "narHash": "sha256-9Rsn9XEWINExosFkKEqdp8EI6Mujr1gmQiyrEcts2ls=",
+        "lastModified": 1756886854,
+        "narHash": "sha256-6tooT142NLcFjt24Gi4B0G1pgWLvfw7y93sYEfSHlLI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7c815e513adbf03c9098b2bd230c1e0525c8a7f9",
+        "rev": "0e6684e6c5755325f801bda1751a8a4038145d7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`228dfd1a`](https://github.com/NixOS/nixpkgs/commit/228dfd1a425e2a6def803d09920a8ea5d748f24f) | `` ocamlPackages.janeStreet: recurseIntoAttrs ``                                  |
| [`22d1b975`](https://github.com/NixOS/nixpkgs/commit/22d1b9750f969202adaf9f074e7a9f9f8d0e49c0) | `` ocamlPackages.systemd: replace `meta.platform` with `meta.platforms` ``        |
| [`6159ae06`](https://github.com/NixOS/nixpkgs/commit/6159ae065371d1c6c5a8a2cf1b679d978c36d633) | `` element-desktop: 1.11.109 -> 1.11.110 ``                                       |
| [`b63a14c7`](https://github.com/NixOS/nixpkgs/commit/b63a14c793864217bae871ed80658ceb4b37c430) | `` element-unwrapped: 1.11.109 -> 1.11.110 ``                                     |
| [`a469fa12`](https://github.com/NixOS/nixpkgs/commit/a469fa12e5149640472d4d694e6154aadd642db6) | `` grav: 1.7.48 -> 1.7.49.2 ``                                                    |
| [`908dbaf1`](https://github.com/NixOS/nixpkgs/commit/908dbaf1e7d3b1d8258faea22fd2bd5552de6af3) | `` nixos/grav: remove X-XSS-Protection ``                                         |
| [`4b5e614d`](https://github.com/NixOS/nixpkgs/commit/4b5e614d94873d4d65cafc3b048fa135934e6386) | `` nixos/grav: use PHP 8.3 ``                                                     |
| [`298b99df`](https://github.com/NixOS/nixpkgs/commit/298b99df71b6b89bbea2cc99eb178a94b95eb70d) | `` synapse-admin-etkecc: 0.11.1-etke45 -> 0.11.1-etke46 ``                        |
| [`85354319`](https://github.com/NixOS/nixpkgs/commit/85354319d8699188331253b44df01596d0457eb0) | `` haskell{,Packages}: use recurseIntoAttrs (#437195) ``                          |
| [`128d420c`](https://github.com/NixOS/nixpkgs/commit/128d420c79872f143d8ec63a6ab8a6f6c4d8243e) | `` release.nix: don't use special treatment for more package sets ``              |
| [`eb884e84`](https://github.com/NixOS/nixpkgs/commit/eb884e84e6d74f5b004740d33109eae9fb0d70c2) | `` tests: recourse into ``                                                        |
| [`2928372e`](https://github.com/NixOS/nixpkgs/commit/2928372ee09848c3bd4a7eec665e395a8e91ea5a) | `` roundcubePlugins: eval and build ``                                            |
| [`b21e4184`](https://github.com/NixOS/nixpkgs/commit/b21e41849e39f06c77eacf671390e08fd0f8d1e3) | `` nodePackages{,_latest}: eval and build ``                                      |
| [`2d23d2b2`](https://github.com/NixOS/nixpkgs/commit/2d23d2b2acc896f54f18ece3953195cbe5e5479f) | `` packages-config.nix: remove redundant package sets ``                          |
| [`c370743b`](https://github.com/NixOS/nixpkgs/commit/c370743bb648ff9ac566b5e04c97e386dec1ac82) | `` warp-terminal: 0.2025.08.27.08.11.stable_03 -> 0.2025.08.27.08.11.stable_04 `` |
| [`06820bc3`](https://github.com/NixOS/nixpkgs/commit/06820bc36f9b47d5d8e8cdc1d08e768eec77bb8f) | `` chunksync: add yayayayaka to maintainers ``                                    |
| [`b0d16ddd`](https://github.com/NixOS/nixpkgs/commit/b0d16ddd09865f26d4f94ca9cc14f23b6ed02615) | `` chunkfs: add yayayayaka to maintainers ``                                      |
| [`ec1a6988`](https://github.com/NixOS/nixpkgs/commit/ec1a698859adacd37f1add44dcdc6a59fcfbe591) | `` bup: 0.33.8 -> 0.33.9 ``                                                       |
| [`e82179b6`](https://github.com/NixOS/nixpkgs/commit/e82179b67c2ac1489f96433d14a88889c9cf672b) | `` spotify-player: 0.20.7 -> 0.21.0 ``                                            |
| [`9280bbc3`](https://github.com/NixOS/nixpkgs/commit/9280bbc36b6d44608179ca68699fbdb63873bba1) | `` spotify-player: 0.20.6 -> 0.20.7 ``                                            |
| [`baa26ee3`](https://github.com/NixOS/nixpkgs/commit/baa26ee39ebfb347c210dda2c39157eb3ca05fe1) | `` spotify-player: 0.20.5 -> 0.20.6 ``                                            |
| [`4bdac60b`](https://github.com/NixOS/nixpkgs/commit/4bdac60bfe32c41103ae500ddf894c258291dd61) | `` minizinc: update gecode to 6.3.0 ``                                            |
| [`2eb5bb50`](https://github.com/NixOS/nixpkgs/commit/2eb5bb508734a5f6a824b82e56dcbf50d3f142c2) | `` testdisk{,-qt}: 7.1 -> 7.2 ``                                                  |
| [`fb92a140`](https://github.com/NixOS/nixpkgs/commit/fb92a140f237576da5c89ece278923dcd75a47c5) | `` nixos/tests/pleroma: rm x-xss-protection ``                                    |
| [`13748590`](https://github.com/NixOS/nixpkgs/commit/13748590dc4751e73a03b992dc1a2961a42ea803) | `` topiary: 0.6.0 -> 0.6.1 ``                                                     |
| [`dc7763c5`](https://github.com/NixOS/nixpkgs/commit/dc7763c56422185ec7f3346067569a84a5ed27a9) | `` snipe-it: 8.2.0 -> 8.2.1 ``                                                    |
| [`9ad134e1`](https://github.com/NixOS/nixpkgs/commit/9ad134e1ba4f395af3f44542b487e04fb663a1fc) | `` sunvox: Fix hash, update archive URL ``                                        |
| [`f8ecf8cc`](https://github.com/NixOS/nixpkgs/commit/f8ecf8cc3783428f9e618869fb4f1ce879b04d50) | `` build(deps): bump cachix/install-nix-action from 31.5.2 to 31.6.0 ``           |
| [`41ff3c19`](https://github.com/NixOS/nixpkgs/commit/41ff3c193d294abfe47775a08eae3d0302047e59) | `` bup: 0.33.7 -> 0.33.8 ``                                                       |
| [`2f2221f4`](https://github.com/NixOS/nixpkgs/commit/2f2221f44c6e2d91f9ffd9484105337c2b83a6a1) | `` maintainers: require GitHub handle ``                                          |
| [`10b2d601`](https://github.com/NixOS/nixpkgs/commit/10b2d601a66c4ba708df0a57ec0a1237e43cafc8) | `` maintainers: drop gm6k ``                                                      |
| [`b3205132`](https://github.com/NixOS/nixpkgs/commit/b32051328dbd5bbfd9e16d6cd0cca601990ff045) | `` maintainers: add github/githubId for tomkoid ``                                |
| [`46d32b93`](https://github.com/NixOS/nixpkgs/commit/46d32b9380e2fe31dc7b95010d7cb266a8c6fc6b) | `` vivaldi: 7.5.3735.64 -> 7.5.3735.66 ``                                         |
| [`2f54522f`](https://github.com/NixOS/nixpkgs/commit/2f54522fa2d17ee369404ff0c2ed917f98c5d065) | `` warp-plus: add phanirithvij as maintainer, unbreak ``                          |
| [`e9c4bf97`](https://github.com/NixOS/nixpkgs/commit/e9c4bf977a3d467382925705892c8ee534055bca) | `` warp-plus: 1.2.6 -> 1.2.6-unstable-2025-08-13 ``                               |
| [`b2e397ff`](https://github.com/NixOS/nixpkgs/commit/b2e397ff89e4011c2d92e79264466608b289df2b) | `` treewide: remove `paveloom` as maintainer ``                                   |
| [`1bcf6497`](https://github.com/NixOS/nixpkgs/commit/1bcf64972da682f439589eacb2d0876562c189c9) | `` warp-plus: 1.2.5 -> 1.2.6 ``                                                   |
| [`f4b2746d`](https://github.com/NixOS/nixpkgs/commit/f4b2746db8a895f4bb72e523e3a657d1346c25c5) | `` easyrsa: 3.2.3 -> 3.2.4 ``                                                     |
| [`d81145a0`](https://github.com/NixOS/nixpkgs/commit/d81145a0f85af089cf9190e0d40551ab4f8bd929) | `` lmstudio: 0.3.23.3 -> 0.3.24.6 ``                                              |
| [`8531d351`](https://github.com/NixOS/nixpkgs/commit/8531d35134595642273346a2860d28c0ab3192a5) | `` chhoto-url: 6.3.0 -> 6.3.1 ``                                                  |
| [`27d2e273`](https://github.com/NixOS/nixpkgs/commit/27d2e273004b09a466f3aeb3350e0992f1607bcd) | `` nixos/grafana: don't set X-XSS-Protection anymore ``                           |
| [`4398ea96`](https://github.com/NixOS/nixpkgs/commit/4398ea964b6fe41d10c2f5a27b6b890c0770acdf) | `` nixos/kanboard: remove X-XSS-Protection ``                                     |
| [`30f77dfd`](https://github.com/NixOS/nixpkgs/commit/30f77dfd6ef3bd3c8d0f9da68be884ba11b471c5) | `` rcu: 4.0.25 -> 4.0.26 ``                                                       |
| [`a54f5978`](https://github.com/NixOS/nixpkgs/commit/a54f59786b88a8ec64cc81b9c9aecda6bb6d74d5) | `` rcu: 4.0.24 -> 4.0.25 ``                                                       |
| [`5a534679`](https://github.com/NixOS/nixpkgs/commit/5a534679b08bae8ef973592c11cc7f510e5f0f9f) | `` jasmin-compiler: 2025.06.0 → 2025.06.1 ``                                      |
| [`6e4ada68`](https://github.com/NixOS/nixpkgs/commit/6e4ada68f224c19a18d358c881b5c5b97d5fa663) | `` microsoft-edge: 139.0.3405.111 -> 139.0.3405.125 ``                            |
| [`396b7653`](https://github.com/NixOS/nixpkgs/commit/396b7653d4b3aff22f7231c291e82f3e2e62a8af) | `` vencord: 1.12.12 -> 1.12.13 ``                                                 |
| [`e4408d52`](https://github.com/NixOS/nixpkgs/commit/e4408d52e5581773899dec31e492579c3e68b329) | `` mattermost: tests: use UTF-8 for database charset ``                           |
| [`e15890c3`](https://github.com/NixOS/nixpkgs/commit/e15890c3fee2fda9387041334d1041d236846db5) | `` nixos/mattermost: remove fallback charset for MySQL ``                         |
| [`b746d410`](https://github.com/NixOS/nixpkgs/commit/b746d41068ac084d9aeba71d645a7492b82f9189) | `` niri: 25.05.1 -> 25.08 ``                                                      |
| [`f55f49e5`](https://github.com/NixOS/nixpkgs/commit/f55f49e5bc3e63b2adb21a3ef025027aaa2bfba1) | `` drum-machine: 1.3.1 -> 1.4.0 ``                                                |
| [`afa5bb9d`](https://github.com/NixOS/nixpkgs/commit/afa5bb9d9cbb1ef91ce18c98aba6f269b06464ed) | `` deja-dup: 48.3 -> 48.4 ``                                                      |
| [`2ad8820f`](https://github.com/NixOS/nixpkgs/commit/2ad8820f5aab657b1c0f5cefe21956f99a476fd7) | `` speedtest: 1.3.0 -> 1.4.0 ``                                                   |
| [`e8e051bf`](https://github.com/NixOS/nixpkgs/commit/e8e051bff495495ce9c173b97848cdc0a9e41dae) | `` video-trimmer: fix cross compilation ``                                        |
| [`9a9cdbde`](https://github.com/NixOS/nixpkgs/commit/9a9cdbde6e2ee89ca461cc1bc1392dc3f4d7dc52) | `` sydbox: 3.37.8 -> 3.37.9 ``                                                    |
| [`dd65300e`](https://github.com/NixOS/nixpkgs/commit/dd65300ee30954ed2a909cdbeda79bd3260648c3) | `` spot: fix cross compilation ``                                                 |