### PR TITLE
chore(flake/nur): `d8cfb3ad` -> `d424cfdf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756903679,
-        "narHash": "sha256-5LILWgddjmHxmZ+kXW+UQVHiPCCP0/VIg9X1Y4wGpKo=",
+        "lastModified": 1756912500,
+        "narHash": "sha256-OCwwlZyg8OzbcqKffRqj5SKBwjsWxA4QTHF2+3rJ7eY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d8cfb3ad481b6b86982c0fe6220eef68ea53695c",
+        "rev": "d424cfdf387c4c4c88e2db2444a0a2aeb382b8df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d424cfdf`](https://github.com/nix-community/NUR/commit/d424cfdf387c4c4c88e2db2444a0a2aeb382b8df) | `` automatic update `` |