### PR TITLE
chore(flake/nur): `d424cfdf` -> `97f7c5b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756912500,
-        "narHash": "sha256-OCwwlZyg8OzbcqKffRqj5SKBwjsWxA4QTHF2+3rJ7eY=",
+        "lastModified": 1756921430,
+        "narHash": "sha256-HZHGKPWFcP05+Yg0oGG3lI+z2j3V49B1joxGwDURPS8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d424cfdf387c4c4c88e2db2444a0a2aeb382b8df",
+        "rev": "97f7c5b74a6ccfa1b4c0766f0dea179cdd230fce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`97f7c5b7`](https://github.com/nix-community/NUR/commit/97f7c5b74a6ccfa1b4c0766f0dea179cdd230fce) | `` automatic update `` |
| [`525f4697`](https://github.com/nix-community/NUR/commit/525f4697cd608fbf92bce414495d86dc5baba233) | `` automatic update `` |
| [`c8eb00f9`](https://github.com/nix-community/NUR/commit/c8eb00f9c3953d72fc8a8d6fcf67db009b77bdb2) | `` automatic update `` |