### PR TITLE
chore(flake/nur): `97f7c5b7` -> `da0d0a30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756921430,
-        "narHash": "sha256-HZHGKPWFcP05+Yg0oGG3lI+z2j3V49B1joxGwDURPS8=",
+        "lastModified": 1756932302,
+        "narHash": "sha256-8+qTrm7PrHOog/ImzoTgeHuABfH0C2WQgnLvL6iTLSI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "97f7c5b74a6ccfa1b4c0766f0dea179cdd230fce",
+        "rev": "da0d0a30c9c9d8eb44526a6e545a47aec3b576cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`da0d0a30`](https://github.com/nix-community/NUR/commit/da0d0a30c9c9d8eb44526a6e545a47aec3b576cd) | `` automatic update `` |
| [`d3aeae12`](https://github.com/nix-community/NUR/commit/d3aeae122319e2494327bec090962655e5353b77) | `` automatic update `` |
| [`61863e1c`](https://github.com/nix-community/NUR/commit/61863e1cb58c7842a7dcad2a4d56c269af5df770) | `` automatic update `` |
| [`b8d6fb99`](https://github.com/nix-community/NUR/commit/b8d6fb9913e279b7ec3495b844c968882eb3eeb6) | `` automatic update `` |
| [`f97cfb54`](https://github.com/nix-community/NUR/commit/f97cfb549b11588db68bb52400c5ec7edcad928e) | `` automatic update `` |