### PR TITLE
chore(flake/nur): `da0d0a30` -> `849e949d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756932302,
-        "narHash": "sha256-8+qTrm7PrHOog/ImzoTgeHuABfH0C2WQgnLvL6iTLSI=",
+        "lastModified": 1756943002,
+        "narHash": "sha256-EjCUp4JcSeTzPCDwwaJZCmAV8dejVYCH+uRaWzJDDnU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da0d0a30c9c9d8eb44526a6e545a47aec3b576cd",
+        "rev": "849e949d461b5b1ac83450254f71b47d429e4923",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`849e949d`](https://github.com/nix-community/NUR/commit/849e949d461b5b1ac83450254f71b47d429e4923) | `` automatic update `` |
| [`401d5bdf`](https://github.com/nix-community/NUR/commit/401d5bdfbce5d969a4654ee61c21cca744eb9911) | `` automatic update `` |
| [`0951866d`](https://github.com/nix-community/NUR/commit/0951866da58eb749d4a25eb241ab4df65866db70) | `` automatic update `` |