### PR TITLE
chore(flake/nur): `849e949d` -> `6b3dd332`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756943002,
-        "narHash": "sha256-EjCUp4JcSeTzPCDwwaJZCmAV8dejVYCH+uRaWzJDDnU=",
+        "lastModified": 1756956322,
+        "narHash": "sha256-AcPrSy8UU9W/swLd0qjcoAwutDqFEx3emsT+Xbk7t9k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "849e949d461b5b1ac83450254f71b47d429e4923",
+        "rev": "6b3dd33277a0902f71b015befab9a15df9042602",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6b3dd332`](https://github.com/nix-community/NUR/commit/6b3dd33277a0902f71b015befab9a15df9042602) | `` automatic update `` |
| [`1f0371a4`](https://github.com/nix-community/NUR/commit/1f0371a4a94a9d7d2cb92974fd6a25ac2f529201) | `` automatic update `` |
| [`e54de3c2`](https://github.com/nix-community/NUR/commit/e54de3c212379cd0c2ec1b2a205fe5629418fe54) | `` automatic update `` |
| [`21f6498d`](https://github.com/nix-community/NUR/commit/21f6498d8b91893c7342ad2c89f2b8e889c80ffc) | `` automatic update `` |
| [`4819403d`](https://github.com/nix-community/NUR/commit/4819403ddfde2dadb4ef81f06eb52fbd19d8d368) | `` automatic update `` |