### PR TITLE
chore(flake/nur): `6b3dd332` -> `6ca27b26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756956322,
-        "narHash": "sha256-AcPrSy8UU9W/swLd0qjcoAwutDqFEx3emsT+Xbk7t9k=",
+        "lastModified": 1756961635,
+        "narHash": "sha256-hETvQcILTg5kChjYNns1fD5ELdsYB/VVgVmBtqKQj9A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b3dd33277a0902f71b015befab9a15df9042602",
+        "rev": "6ca27b2654ac55e3f6e0ca434c1b4589ae22b370",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6ca27b26`](https://github.com/nix-community/NUR/commit/6ca27b2654ac55e3f6e0ca434c1b4589ae22b370) | `` automatic update `` |
| [`eb715078`](https://github.com/nix-community/NUR/commit/eb715078c5bc28280ee58d4a79c547dbda11eb79) | `` automatic update `` |
| [`3c3568dd`](https://github.com/nix-community/NUR/commit/3c3568ddbc9e0b1dc41595a273cb9fb876a7c6eb) | `` automatic update `` |
| [`dd182564`](https://github.com/nix-community/NUR/commit/dd182564771bb89df85270c740f06063ee0829a1) | `` automatic update `` |
| [`a535df5a`](https://github.com/nix-community/NUR/commit/a535df5a7a43a3f67a7aa169b57a446dd2541cde) | `` automatic update `` |