### PR TITLE
chore(flake/nur): `5675a2af` -> `d7843c8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756975820,
-        "narHash": "sha256-Wl8Cqi2tVrpcjkpAzGZvqS9i3a8wDXc0FFGLTW8iNEs=",
+        "lastModified": 1756986193,
+        "narHash": "sha256-YFCcCPTR6YajgpcoZSC0jtSPiG6qPukYpsdmQCEPIis=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5675a2af522928febb98d2d65797eabe0fb06925",
+        "rev": "d7843c8e7bcd55ebc4ba26d4d618bafaa41268f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d7843c8e`](https://github.com/nix-community/NUR/commit/d7843c8e7bcd55ebc4ba26d4d618bafaa41268f6) | `` automatic update `` |
| [`36672620`](https://github.com/nix-community/NUR/commit/36672620ca0010440e1df9007b133543de4a174c) | `` automatic update `` |
| [`52c7f62e`](https://github.com/nix-community/NUR/commit/52c7f62eb3e5c74c9079ce883f123d7902f70d67) | `` automatic update `` |