### PR TITLE
chore(flake/nur): `d7843c8e` -> `4afb7733`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756986193,
-        "narHash": "sha256-YFCcCPTR6YajgpcoZSC0jtSPiG6qPukYpsdmQCEPIis=",
+        "lastModified": 1756998887,
+        "narHash": "sha256-v7hscMqPwSoZ69f6aX66xkrpegXNGXCUSDe+xakIKG8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d7843c8e7bcd55ebc4ba26d4d618bafaa41268f6",
+        "rev": "4afb77330dd461444b3df5dd997ca6e3d441fdd3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4afb7733`](https://github.com/nix-community/NUR/commit/4afb77330dd461444b3df5dd997ca6e3d441fdd3) | `` automatic update `` |
| [`bac20268`](https://github.com/nix-community/NUR/commit/bac202687eb587c6e599db878c487bfe3169341d) | `` automatic update `` |
| [`67ec92c4`](https://github.com/nix-community/NUR/commit/67ec92c42741fc61204745d5e5e10bf65c19f5cd) | `` automatic update `` |
| [`674e3af3`](https://github.com/nix-community/NUR/commit/674e3af377e5b2c14019382c4e071c7a42e60107) | `` automatic update `` |