### PR TITLE
chore(flake/nur): `4afb7733` -> `b76f27a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1756998887,
-        "narHash": "sha256-v7hscMqPwSoZ69f6aX66xkrpegXNGXCUSDe+xakIKG8=",
+        "lastModified": 1757002913,
+        "narHash": "sha256-ZdJO3jxkW+jVewPM+iJMTtj7lEOD6mccCL8J1icLaWQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4afb77330dd461444b3df5dd997ca6e3d441fdd3",
+        "rev": "b76f27a18b17a44de12df32fe03da2695b04eefc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b76f27a1`](https://github.com/nix-community/NUR/commit/b76f27a18b17a44de12df32fe03da2695b04eefc) | `` automatic update `` |
| [`4385b643`](https://github.com/nix-community/NUR/commit/4385b6432daaf4820bd206c4c359db2dec541997) | `` automatic update `` |