### PR TITLE
chore(flake/nur): `b76f27a1` -> `4f158b03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757002913,
-        "narHash": "sha256-ZdJO3jxkW+jVewPM+iJMTtj7lEOD6mccCL8J1icLaWQ=",
+        "lastModified": 1757017375,
+        "narHash": "sha256-k/ulDq0TYDm2ZSPrYKBQdzbogC5MOSk88mRCCPzJ2hc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b76f27a18b17a44de12df32fe03da2695b04eefc",
+        "rev": "4f158b03c32b74653522982636a150823978d18b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f158b03`](https://github.com/nix-community/NUR/commit/4f158b03c32b74653522982636a150823978d18b) | `` automatic update `` |
| [`d299518c`](https://github.com/nix-community/NUR/commit/d299518c172661c7f3f796fe950e3365f34400e4) | `` automatic update `` |
| [`013f349c`](https://github.com/nix-community/NUR/commit/013f349cd4cb734e9a79eeaa934ffd0cb9b686b9) | `` automatic update `` |
| [`30ebeecf`](https://github.com/nix-community/NUR/commit/30ebeecfa46d5604b8fd15c3ac971d3a37022b46) | `` automatic update `` |