### PR TITLE
chore(flake/chaotic): `523e462e` -> `7b9fd94d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1756994413,
-        "narHash": "sha256-GnMAKR8LIcOdwgr9OBckulDS5Nsjbi5ikRYRj4mKwCI=",
+        "lastModified": 1757011047,
+        "narHash": "sha256-y4cFEDZ7Mmz4vLPSc2pDF7OXJ9ylW3cOU2Tztx/ApI0=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "523e462e883e76d4a42d94f533456b380442c30a",
+        "rev": "7b9fd94dccd3a22f32dff8560f248991300f8c16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                 |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`7b9fd94d`](https://github.com/chaotic-cx/nyx/commit/7b9fd94dccd3a22f32dff8560f248991300f8c16) | `` failures: update x86_64-linux ``                     |
| [`ad3940f0`](https://github.com/chaotic-cx/nyx/commit/ad3940f0ee6daaffe112e088c98ac8d7b8ffe01c) | `` linux_cachyos: adopt thin LTO in mainline (#1176) `` |