### PR TITLE
chore(flake/nixpkgs): `0e6684e6` -> `fe83bbdd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1756886854,
-        "narHash": "sha256-6tooT142NLcFjt24Gi4B0G1pgWLvfw7y93sYEfSHlLI=",
+        "lastModified": 1757020766,
+        "narHash": "sha256-PLoSjHRa2bUbi1x9HoXgTx2AiuzNXs54c8omhadyvp0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0e6684e6c5755325f801bda1751a8a4038145d7d",
+        "rev": "fe83bbdde2ccdc2cb9573aa846abe8363f79a97a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`e038a0ef`](https://github.com/NixOS/nixpkgs/commit/e038a0ef49faf4a6a6a39ba59ec75ca4a3b9a96f) | `` matrix-alertmanager-receiver: 2025.8.20 -> 2025.8.27 ``                  |
| [`d0477a7a`](https://github.com/NixOS/nixpkgs/commit/d0477a7a4e2f4a5da1aedd24640c1001a906e18e) | `` stats: 2.11.49 -> 2.11.51 ``                                             |
| [`ff7d80da`](https://github.com/NixOS/nixpkgs/commit/ff7d80da5d54ca9b932a03827de4fb09f33e7ae4) | `` stats: 2.11.45 -> 2.11.49 ``                                             |
| [`57ee4828`](https://github.com/NixOS/nixpkgs/commit/57ee482824ab447858efbba7862f010308933956) | `` esphome: apply patch for CVE-2025-57808 ``                               |
| [`a31b3ef0`](https://github.com/NixOS/nixpkgs/commit/a31b3ef05a41c625fb621c3fd12c0e7125898099) | `` e-imzo: 4.71 -> 4.73 ``                                                  |
| [`a3d26832`](https://github.com/NixOS/nixpkgs/commit/a3d26832c73919870267bc8e04d9c75cb28b8ea9) | `` platformioPackages: move packages inside to top-level ``                 |
| [`0fca2d3d`](https://github.com/NixOS/nixpkgs/commit/0fca2d3d1740ff09df8c804485ff53865846fbc3) | `` gns3Packages: eval and build ``                                          |
| [`2c8fb092`](https://github.com/NixOS/nixpkgs/commit/2c8fb092543a40762e2bb8c78b1f3bc42770926f) | `` fusePackages: remove from search (#437198) ``                            |
| [`b347e419`](https://github.com/NixOS/nixpkgs/commit/b347e419d935df0c66b88eaf6bacb084929d4350) | `` radicle-node: 1.3.0 -> 1.4.0 ``                                          |
| [`61232c0f`](https://github.com/NixOS/nixpkgs/commit/61232c0f7982a61e3347cbcc1fbc77846a641ff6) | `` discord-canary: 0.0.745 -> 0.0.748 ``                                    |
| [`7c71ca4e`](https://github.com/NixOS/nixpkgs/commit/7c71ca4e6e7af575aa0a3136dca5bbc412380abb) | `` linux/hardened/patches/6.12: v6.12.41-hardened1 -> v6.12.43-hardened1 `` |
| [`4fb01d18`](https://github.com/NixOS/nixpkgs/commit/4fb01d18f40501c57a8f7dc7beb07d8567f5c15b) | `` postgresqlPackages.pg_cron: 1.6.5 -> 1.6.6 ``                            |
| [`a858d3a0`](https://github.com/NixOS/nixpkgs/commit/a858d3a05d18ec7ca1353118a1e8ba5427c12521) | `` tauno-monitor: 0.2.15 -> 0.2.16 ``                                       |
| [`235848c7`](https://github.com/NixOS/nixpkgs/commit/235848c7e1edd220e635a63f3047e3ac613967b2) | `` python3Packages.django_5: 5.1.11 -> 5.1.12 ``                            |
| [`8cb70044`](https://github.com/NixOS/nixpkgs/commit/8cb70044c1ae255bc9e81a58d77cd36064ab1af9) | `` slack: 4.45.64 -> 4.45.69 ``                                             |
| [`1cd85186`](https://github.com/NixOS/nixpkgs/commit/1cd8518673005498c49d5a142b2a07fad86c1c35) | `` slack: add sources.nix & fix update.sh ``                                |
| [`a7b5cd82`](https://github.com/NixOS/nixpkgs/commit/a7b5cd82e1cc3976b4ab59bd8828a20d3123260c) | `` slack: split by system ``                                                |
| [`746c13f1`](https://github.com/NixOS/nixpkgs/commit/746c13f1b463f84359f07714d1253c0a4d9b1aae) | `` slack: avoid with lib; ``                                                |
| [`d1b3b3ce`](https://github.com/NixOS/nixpkgs/commit/d1b3b3cec523a9d360b257b97126877297dfe3d3) | `` slack: copy entire .app on darwin ``                                     |
| [`b962f24c`](https://github.com/NixOS/nixpkgs/commit/b962f24c1a98265dd1f8ea7e80ed81641a76fb2a) | `` slack: add prince213 to maintainers ``                                   |
| [`b791e737`](https://github.com/NixOS/nixpkgs/commit/b791e737f4a88ab10253f01f582f51e00d9857b8) | `` php84: 8.4.11 -> 8.4.12 ``                                               |
| [`6ff95f50`](https://github.com/NixOS/nixpkgs/commit/6ff95f50e9bc1738c308e2e8e89be2f603fa2424) | `` chromium,chromedriver: 139.0.7258.154 -> 140.0.7339.80 ``                |
| [`fd89e235`](https://github.com/NixOS/nixpkgs/commit/fd89e235b89571ad4a487855596f7e0a091f214c) | `` chromium: fix building M140 with Rust <1.89 ``                           |
| [`26dcc22f`](https://github.com/NixOS/nixpkgs/commit/26dcc22f8d6df87f78777eb1f719a42eb5a1752f) | `` chromium: prepare for M140 ``                                            |
| [`33bb1b67`](https://github.com/NixOS/nixpkgs/commit/33bb1b67d71717ed7fd28d3a439bb519adc2bf4d) | `` chromium: fix typo in `update.mjs` ``                                    |
| [`62834175`](https://github.com/NixOS/nixpkgs/commit/62834175f8c55b0e48a4f0678d9a24e9ac5b6ba0) | `` chromium: adapt updater to the new gn package ``                         |
| [`416016b5`](https://github.com/NixOS/nixpkgs/commit/416016b57da22825450ddd86e077e2f0e8c85f85) | `` electron: adapt updater to the new gn package ``                         |
| [`0f34d64a`](https://github.com/NixOS/nixpkgs/commit/0f34d64ab24f3a8d04953555e6690d92b567e5b1) | `` chromium: add compat shim for new gn src FODs from unstable ``           |
| [`36d4d054`](https://github.com/NixOS/nixpkgs/commit/36d4d0541e1ee71c899fdeca444934fe6dac82be) | `` netpeek: 0.2.3.1 -> 0.2.4 ``                                             |
| [`161e6834`](https://github.com/NixOS/nixpkgs/commit/161e6834f76062ab17c6465c1081b1519cfc893f) | `` netpeek: init at 0.2.3.1 ``                                              |
| [`8ac9934a`](https://github.com/NixOS/nixpkgs/commit/8ac9934a03c9921223539dae10e4357d933b5491) | `` mattermostLatest: 10.11.1 -> 10.11.2 ``                                  |
| [`ac3330b0`](https://github.com/NixOS/nixpkgs/commit/ac3330b0265ff20eb72d259f8a2fecd20bf0295d) | `` zulip: 5.12.1 → 5.12.2 ``                                                |
| [`82822c92`](https://github.com/NixOS/nixpkgs/commit/82822c9232046ab7add756aac4fd4e1a53735b0f) | `` smtp4dev: 3.8.6 -> 3.9.0 ``                                              |
| [`c96d9a16`](https://github.com/NixOS/nixpkgs/commit/c96d9a165b4c891dac4e4ab28952f4f12541899d) | `` smtp4dev: add version check ``                                           |
| [`e654129e`](https://github.com/NixOS/nixpkgs/commit/e654129e96cf81fc8876c86174de2bb765562bca) | `` ci/eval/attrpaths: update cross stdenvs ``                               |
| [`cc8ee674`](https://github.com/NixOS/nixpkgs/commit/cc8ee67459adc00f6bd291272589f35489a28f58) | `` treewide: remove __recurseIntoDerivationForReleaseJobs ``                |
| [`5c22b88f`](https://github.com/NixOS/nixpkgs/commit/5c22b88f2be3324ac2a9ebe880f23d72c9a0b1c2) | `` ci/eval: remove unused checkMeta argument ``                             |
| [`3c6789fb`](https://github.com/NixOS/nixpkgs/commit/3c6789fbed52366ca0a12a92264df6e8581b6710) | `` ci/eval/attrpaths: refactor ``                                           |
| [`d3322670`](https://github.com/NixOS/nixpkgs/commit/d332267042a0853216886acd6a15deff08585a37) | `` ci/eval/attrpaths: remove left-over condition ``                         |
| [`a24803b2`](https://github.com/NixOS/nixpkgs/commit/a24803b26f8d86f8ac5f0475731fe435fa63a04c) | `` ci/eval: remove ofborg references ``                                     |
| [`87af6a62`](https://github.com/NixOS/nixpkgs/commit/87af6a62abdc99ff021141e567e93fe4b3ff77be) | `` top-level/release-outpaths: move to ci/eval ``                           |
| [`47364ef8`](https://github.com/NixOS/nixpkgs/commit/47364ef8f0f9dd743dedd5536aa370e02611091e) | `` bs-manager: 1.5.3 -> 1.5.4 ``                                            |
| [`27522714`](https://github.com/NixOS/nixpkgs/commit/27522714f935652a33ea4db247d31b4b50a24d4b) | `` synapse-admin-etkecc: 0.11.1-etke46 -> 0.11.1-etke47 ``                  |
| [`3eb88df4`](https://github.com/NixOS/nixpkgs/commit/3eb88df40d74d782c899cae0f92ab6f4469a0972) | `` envoy-bin: 1.34.5 -> 1.34.6 ``                                           |
| [`f9b989d7`](https://github.com/NixOS/nixpkgs/commit/f9b989d74daa02342086809c3df06c9dec93912e) | `` linux-rt_6_6: 6.6.87-rt54 -> 6.6.101-rt59 ``                             |
| [`6e1b9e75`](https://github.com/NixOS/nixpkgs/commit/6e1b9e7578086e9db4efaf6841b5f3f83763778d) | `` linux-rt_6_1: 6.1.134-rt51 -> 6.1.146-rt53 ``                            |
| [`1235fcb8`](https://github.com/NixOS/nixpkgs/commit/1235fcb8b696c69d5a1d2f0e2872563529deb5d8) | `` linux-rt_5_4: 5.4.293-rt98 -> 5.4.296-rt100 ``                           |
| [`894a8238`](https://github.com/NixOS/nixpkgs/commit/894a8238a2323685812bfc3ffd9041d85fb179c8) | `` linux-rt_5_15: 5.15.183-rt85 -> 5.15.189-rt87 ``                         |
| [`6a8580ba`](https://github.com/NixOS/nixpkgs/commit/6a8580ba43888f798411aaa370b2324dad4d3127) | `` linux-rt_5_10: 5.10.237-rt131 -> 5.10.240-rt134 ``                       |
| [`50eba04c`](https://github.com/NixOS/nixpkgs/commit/50eba04c2a8f8fc6144f6332de1a6bf54b396631) | `` linux_testing: 6.17-rc3 -> 6.17-rc4 ``                                   |
| [`c2a69263`](https://github.com/NixOS/nixpkgs/commit/c2a6926346465765503606aa6d868a797fb106c3) | `` snipe-it: 8.2.1 -> 8.3.0 ``                                              |
| [`18b5f8c2`](https://github.com/NixOS/nixpkgs/commit/18b5f8c2a59184aad6681b6b84fc55cadffa0427) | `` caddy: clean up withPlugins logic and support replacement ``             |
| [`9aea62f7`](https://github.com/NixOS/nixpkgs/commit/9aea62f77fc1260be6d1ec525287176d4eed1bfe) | `` electron-source.electron_37: 37.3.1 -> 37.4.0 ``                         |
| [`a1ced86a`](https://github.com/NixOS/nixpkgs/commit/a1ced86ad12594a3e67e98c3fb5b459d3005b35c) | `` electron-chromedriver_37: 37.3.1 -> 37.4.0 ``                            |
| [`6fe9685e`](https://github.com/NixOS/nixpkgs/commit/6fe9685e3a4792a28de9c45797932010292fc6bc) | `` electron_37-bin: 37.3.1 -> 37.4.0 ``                                     |
| [`391ceb50`](https://github.com/NixOS/nixpkgs/commit/391ceb505e83a2bbd1e8a410e8b602b697a6dd4a) | `` ntpd-rs: 1.6.1 -> 1.6.2 ``                                               |
| [`c85c6554`](https://github.com/NixOS/nixpkgs/commit/c85c6554aabe1ff42f9d38feab7a8f136aeb4948) | `` nixos/grocy: don't set X-XSS-Protection anymore ``                       |
| [`d8c2bd99`](https://github.com/NixOS/nixpkgs/commit/d8c2bd99a82e4741b974020ba8a78de420d6fec7) | `` {nixos/,}grocy: add diogotcorreia as maintainer ``                       |
| [`4365f6d5`](https://github.com/NixOS/nixpkgs/commit/4365f6d556ce53fcf68ae6060b3bed35e293ca9c) | `` firefox-devedition-unwrapped: 143.0b2 -> 143.0b7 ``                      |
| [`963142e7`](https://github.com/NixOS/nixpkgs/commit/963142e7a661ad5629df979befbaaa5516c628bb) | `` firefox-beta-unwrapped: 143.0b2 -> 143.0b7 ``                            |
| [`be5e42da`](https://github.com/NixOS/nixpkgs/commit/be5e42da13df98d8cf431fb16dc51e22d31132aa) | `` linux/hardened/patches/6.12: v6.12.34-hardened1 -> v6.12.41-hardened1 `` |
| [`7a9baae4`](https://github.com/NixOS/nixpkgs/commit/7a9baae4e77185420cd523ffa6a614ed841d7317) | `` linux_6_15: remove ``                                                    |
| [`aed1df8d`](https://github.com/NixOS/nixpkgs/commit/aed1df8d73c24e20c494eb69ce4d73761219b5d4) | `` zfs_2_3: 2.3.3 -> 2.3.4 ``                                               |
| [`7089c8bd`](https://github.com/NixOS/nixpkgs/commit/7089c8bdffe604a9d28056e32744122843a965d2) | `` jetty: 12.0.25 -> 12.1.0 ``                                              |
| [`0abcabe2`](https://github.com/NixOS/nixpkgs/commit/0abcabe23cf78fadacb0dc75e850c35bfac5a7b9) | `` jetty_12: 12.0.23 -> 12.0.25 ``                                          |
| [`9a893234`](https://github.com/NixOS/nixpkgs/commit/9a893234ccc969340ff955b9b7ef1d22f83ffb10) | `` jetty: 12.0.22 -> 12.0.23 ``                                             |
| [`83c94898`](https://github.com/NixOS/nixpkgs/commit/83c9489844372a13b7773ccd0a3b72e6dbca5b10) | `` jetty: 12.0.21 -> 12.0.22 ``                                             |
| [`e3505d02`](https://github.com/NixOS/nixpkgs/commit/e3505d022e43dc0ab8dfd40f528f0d848057939e) | `` outline: 0.85.1 -> 0.86.1 ``                                             |
| [`5d66e61d`](https://github.com/NixOS/nixpkgs/commit/5d66e61dd77d81fa284b4df1a06bdc69ba056e37) | `` fetch-yarn-deps: follow relative redirects ``                            |
| [`3bb594ad`](https://github.com/NixOS/nixpkgs/commit/3bb594ad6293349442a60426768b735d9d1fd83a) | `` devenv: upgrade nix version for 1.8.2 ``                                 |