### PR TITLE
chore(flake/nur): `f016bfe1` -> `98a7fd9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757085314,
-        "narHash": "sha256-F700ti69+gI3rxwYH0ttN8IK653UBOATtUEgcqb1efI=",
+        "lastModified": 1757092851,
+        "narHash": "sha256-ZmIQ+/1TUfq1CQX94HAezq3njgRde1EBVjUq4P+EMw4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f016bfe15394374b63ee5d26150e3e8540566d69",
+        "rev": "98a7fd9e56640a4497fddc58b659e5e1656a6966",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`98a7fd9e`](https://github.com/nix-community/NUR/commit/98a7fd9e56640a4497fddc58b659e5e1656a6966) | `` automatic update `` |
| [`381e1fa0`](https://github.com/nix-community/NUR/commit/381e1fa04eccb9304d0f4c19a5899e13dd6290e6) | `` automatic update `` |