### PR TITLE
chore(flake/nur): `3f0eeedf` -> `c9b6d431`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757105782,
-        "narHash": "sha256-t6ysDkG1ISWe4XE/M/o8msGguTTPKRpZJugfkLsvMLs=",
+        "lastModified": 1757121723,
+        "narHash": "sha256-amj8ERxl6VEWkGykH8rY0sa3hUbOQ2vq3NPUlIdKc9E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3f0eeedfbb93e70a080e84b3689725ebe2051969",
+        "rev": "c9b6d43164299ad7e6ba1d1eec0a9cd94b03d402",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c9b6d431`](https://github.com/nix-community/NUR/commit/c9b6d43164299ad7e6ba1d1eec0a9cd94b03d402) | `` automatic update `` |
| [`f41e071a`](https://github.com/nix-community/NUR/commit/f41e071a63ec1bff719a3db6ba31197177586693) | `` automatic update `` |
| [`c3753db5`](https://github.com/nix-community/NUR/commit/c3753db57145fc2aa3b0d52756d3db05aa60263d) | `` automatic update `` |