### PR TITLE
chore(flake/nur): `c3ba10a3` -> `e81b0f0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757127991,
-        "narHash": "sha256-i7mH79iF8GqqRnelkcqso3XbGKSKGs0ByKGnE/KZZas=",
+        "lastModified": 1757136865,
+        "narHash": "sha256-5wtxNgCgHyBteowh5VgG3S4bFn32/JBj8gSswtkl8PA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c3ba10a3e727990158f320b2deacdb67cedde572",
+        "rev": "e81b0f0b76610dc5fdfaca70a8e298dfc8fa0cd0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e81b0f0b`](https://github.com/nix-community/NUR/commit/e81b0f0b76610dc5fdfaca70a8e298dfc8fa0cd0) | `` automatic update `` |
| [`ebc8ca55`](https://github.com/nix-community/NUR/commit/ebc8ca55275ce264aa5388a00f63d83d02fb09dd) | `` automatic update `` |
| [`eb7c6acc`](https://github.com/nix-community/NUR/commit/eb7c6acc50c3102593696717380985a12188699b) | `` automatic update `` |
| [`1047bb61`](https://github.com/nix-community/NUR/commit/1047bb615b4cd70ece868f84ee1654b4388b17af) | `` automatic update `` |
| [`eed070ec`](https://github.com/nix-community/NUR/commit/eed070ec61779ca471d5501f9fdee3144735d2f9) | `` automatic update `` |