### PR TITLE
chore(flake/nur): `e81b0f0b` -> `a526a67c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757136865,
-        "narHash": "sha256-5wtxNgCgHyBteowh5VgG3S4bFn32/JBj8gSswtkl8PA=",
+        "lastModified": 1757149947,
+        "narHash": "sha256-czeC/NUGD6vFtzgmVHnMVRgG+oM946P9NnIHk5mMhhM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e81b0f0b76610dc5fdfaca70a8e298dfc8fa0cd0",
+        "rev": "a526a67cecb4aee7c2d1f8ee2d00c8c642b1e10f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a526a67c`](https://github.com/nix-community/NUR/commit/a526a67cecb4aee7c2d1f8ee2d00c8c642b1e10f) | `` automatic update `` |
| [`8054d4d5`](https://github.com/nix-community/NUR/commit/8054d4d5a95852868746fa3f14ea2f9eb18ba68e) | `` automatic update `` |
| [`8009dbff`](https://github.com/nix-community/NUR/commit/8009dbffdc33f5e7beee5cbe000527991faf8783) | `` automatic update `` |