### PR TITLE
chore(flake/nur): `fbc47a63` -> `bee71e97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757154267,
-        "narHash": "sha256-BlNCGhyUoRuOvVa6Vbf5CznThGLdT6mYEjp40fCDhR0=",
+        "lastModified": 1757171566,
+        "narHash": "sha256-4s+VP5N3QUofH3KJwYOAog+FUqwoeuvKGDSVfGks0ZA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fbc47a63bdcd73f11ba4b6ee1babadeb0a948645",
+        "rev": "bee71e973617ccdba8d48f88a478460745b4d263",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bee71e97`](https://github.com/nix-community/NUR/commit/bee71e973617ccdba8d48f88a478460745b4d263) | `` automatic update `` |
| [`4d10e65c`](https://github.com/nix-community/NUR/commit/4d10e65c528b1d24c98c7ec850423aabd635647a) | `` automatic update `` |