### PR TITLE
chore(flake/chaotic): `e347ef62` -> `11bfa4c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1757122261,
-        "narHash": "sha256-K4b+ujyYhbur7TY4JCiiKXdNLeAvsAkoFW8ulOkfayY=",
+        "lastModified": 1757182941,
+        "narHash": "sha256-81TKa5U84gRc6krwhVOwb5gpgXgYxIeS1kkwOTw1GN4=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "e347ef625cf40c90592e419521b0d5127272a045",
+        "rev": "11bfa4c0dc07da1e7e49c5111cc9bfa1260ba98f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                         |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`11bfa4c0`](https://github.com/chaotic-cx/nyx/commit/11bfa4c0dc07da1e7e49c5111cc9bfa1260ba98f) | `` linux_cachyos: fix aarch64 eval ``           |
| [`c1773f2f`](https://github.com/chaotic-cx/nyx/commit/c1773f2f8002d7e495442c1b2a73661ddc7b6754) | `` linux_cachyos-lto: fix nvidiaPackages too `` |
| [`a5d74bd2`](https://github.com/chaotic-cx/nyx/commit/a5d74bd2352bd7f7abfa52489fc89261b12471dd) | `` linux_cachyos-lto: fix zenpower ``           |
| [`7826b73f`](https://github.com/chaotic-cx/nyx/commit/7826b73f6a7e3ec2b9806b57bfefc16a61fd322f) | `` mesa_git/test: organize it ``                |
| [`c87089b3`](https://github.com/chaotic-cx/nyx/commit/c87089b3af8411f355fb329c0291c7bb4080581b) | `` linux_cachyos-lto: fix ZFS ``                |
| [`dcf54a30`](https://github.com/chaotic-cx/nyx/commit/dcf54a304f6f0032f32a9fd5418e9058d3597ae3) | `` failures: update x86_64-linux ``             |
| [`a24d66f1`](https://github.com/chaotic-cx/nyx/commit/a24d66f1fa39356ad1b80e598b29080bc12d0f46) | `` linux_cachyos-lto: fix nvidia-settings ``    |