### PR TITLE
chore(flake/nur): `bee71e97` -> `56a58305`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757171566,
-        "narHash": "sha256-4s+VP5N3QUofH3KJwYOAog+FUqwoeuvKGDSVfGks0ZA=",
+        "lastModified": 1757175473,
+        "narHash": "sha256-zi5d9XZMqZwsnEOFn2mgNQTAVp7oifTNtdqAzSsNZbc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bee71e973617ccdba8d48f88a478460745b4d263",
+        "rev": "56a58305f2668b2d5519f64eaac93e8d1cef1827",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`56a58305`](https://github.com/nix-community/NUR/commit/56a58305f2668b2d5519f64eaac93e8d1cef1827) | `` automatic update `` |
| [`9ec3aa59`](https://github.com/nix-community/NUR/commit/9ec3aa599e7c3c3550c2ccecfebd5d57527bb000) | `` automatic update `` |