### PR TITLE
chore(flake/nixpkgs-unstable): `d0fc3089` -> `8eb28adf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1756787288,
-        "narHash": "sha256-rw/PHa1cqiePdBxhF66V7R+WAP8WekQ0mCDG4CFqT8Y=",
+        "lastModified": 1757068644,
+        "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d0fc30899600b9b3466ddb260fd83deb486c32f1",
+        "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`bc5f7c59`](https://github.com/NixOS/nixpkgs/commit/bc5f7c59a7b165138ae4474b7c78bc9b14480c41) | `` postgresqlPackages.pgvector: 0.8.0 -> 0.8.1 ``                                            |
| [`19ca3419`](https://github.com/NixOS/nixpkgs/commit/19ca34196837487bb77f9ba9fe1c62dcdd26dc1d) | `` python3Packages.vulcan-api: drop ``                                                       |
| [`2221d387`](https://github.com/NixOS/nixpkgs/commit/2221d387458f7b1bb836b9992e68444491045ba4) | `` warp-terminal: 0.2025.08.27.08.11.stable_04 -> 0.2025.09.03.08.11.stable_03 ``            |
| [`ba600c99`](https://github.com/NixOS/nixpkgs/commit/ba600c9923cd59db1a24b2d367561204578c21c2) | `` pyradio: 0.9.3.11.15 -> 0.9.3.11.16 ``                                                    |
| [`2462ed55`](https://github.com/NixOS/nixpkgs/commit/2462ed55bef4b62d5eef38d9b0bff283500bf34e) | `` python313Packages.gitignore-parser: modernize ``                                          |
| [`ba1cc928`](https://github.com/NixOS/nixpkgs/commit/ba1cc9284ec9f766e31bac51fe1142f7cbfbbeef) | `` ananicy-rules-cachyos: 0-unstable-2025-08-09 -> 0-unstable-2025-09-03 ``                  |
| [`93613836`](https://github.com/NixOS/nixpkgs/commit/93613836d92811742306ca0873fb0db54a04f4f0) | `` hath-rust: 1.11.0 -> 1.12.1 ``                                                            |
| [`2f336e2a`](https://github.com/NixOS/nixpkgs/commit/2f336e2a073df0f60e56f68b49f0301de8683975) | `` haskell.packages.integer-simple: remove unused includes ``                                |
| [`07cb32de`](https://github.com/NixOS/nixpkgs/commit/07cb32debe7052211fa60aa6bb2f991f57b7c626) | `` haskell.packages.native-bignum: exclude recurseForDerivations ``                          |
| [`c7ce4a83`](https://github.com/NixOS/nixpkgs/commit/c7ce4a83116209ee857420a3b74f4c37ebd11837) | `` rainfrog: 0.3.5 -> 0.3.7 ``                                                               |
| [`414c23fa`](https://github.com/NixOS/nixpkgs/commit/414c23faccf416ff4995ca999de620597ab8c1c5) | `` ncps: Add support for the --cache-temp-path flag ``                                       |
| [`a0817f37`](https://github.com/NixOS/nixpkgs/commit/a0817f37f23f077e53fe14bc5589bdeb00e558ab) | `` ncps: Add support for the --prometheus-enabled flag ``                                    |
| [`e58ee364`](https://github.com/NixOS/nixpkgs/commit/e58ee36452929bc96bfe44cdc2f8b6ef47c9d939) | `` libretro.dosbox-pure: 0-unstable-2025-08-03 -> 0-unstable-2025-09-04 ``                   |
| [`b3b99889`](https://github.com/NixOS/nixpkgs/commit/b3b99889415c73ee67ccd785618478e4466cfa0f) | `` mame: 0.279 -> 0.280 ``                                                                   |
| [`2f98adcb`](https://github.com/NixOS/nixpkgs/commit/2f98adcb65dff992e5ef3d416e2abc97d4846835) | `` rabbitmqadmin-ng: 2.8.1 -> 2.9.0 ``                                                       |
| [`769479a6`](https://github.com/NixOS/nixpkgs/commit/769479a610392252c368d9d8466b9182d8c17d0b) | `` virtualbox: bump virtualboxKVM patch to 20250903 ``                                       |
| [`28c34926`](https://github.com/NixOS/nixpkgs/commit/28c349266fbfe7e9b25c3dd1d3d38e6e025fb1ec) | `` virtualbox: drop fix-graphics-driver-loading.patch ``                                     |
| [`ed44b0d0`](https://github.com/NixOS/nixpkgs/commit/ed44b0d060de193f6685adf5d43171f30e92c48c) | `` virtualbox: bump no-update.patch ``                                                       |
| [`80df59d3`](https://github.com/NixOS/nixpkgs/commit/80df59d3793d8f834f872ec2b28ed8345da5694f) | `` virtualboxGuestAdditions: 7.1.12 -> 7.2.0 ``                                              |
| [`efe2c2f5`](https://github.com/NixOS/nixpkgs/commit/efe2c2f5d3353ca11e12c894b74e7e0726cd24a3) | `` virtualbox: 7.1.12 -> 7.2.0 ``                                                            |
| [`79caf60d`](https://github.com/NixOS/nixpkgs/commit/79caf60d78f18036fb665c27d975bf8cf6902464) | `` avbroot: 3.20.0 -> 3.22.0 ``                                                              |
| [`a6e12d75`](https://github.com/NixOS/nixpkgs/commit/a6e12d751c7a5e161dcc769e1d4db3d049177fee) | `` nezha: 1.13.1 -> 1.13.2 ``                                                                |
| [`ec5f3b80`](https://github.com/NixOS/nixpkgs/commit/ec5f3b80902b638e6fba954123049f315ecd1324) | `` cargo-insta: 1.43.1 -> 1.43.2 ``                                                          |
| [`324ce9ed`](https://github.com/NixOS/nixpkgs/commit/324ce9ed4086c5e8d42a495b788e7492abc675c7) | `` home-assistant: pin python-roborock to pytest-asyncio_0 ``                                |
| [`16b6d168`](https://github.com/NixOS/nixpkgs/commit/16b6d1688519dc85e0ea4d8639b2101e4db7fc91) | `` python3Package.zigpy-zboss: pin pytest-asyncio 0.x ``                                     |
| [`982c1565`](https://github.com/NixOS/nixpkgs/commit/982c1565d187be53dd1f79f32e02ad91073750f8) | `` Revert "python3Packages.pyvesync: 2.1.18 -> 2.18" ``                                      |
| [`e10b7c14`](https://github.com/NixOS/nixpkgs/commit/e10b7c1445805b1831bace5803c0f92caca1dcc5) | `` Revert "python3Packages.python-tado: 0.18.15 -> 0.19.2" ``                                |
| [`60f9661b`](https://github.com/NixOS/nixpkgs/commit/60f9661b81ac69ff3b5a48314d9b238020235a96) | `` Revert "python3Packages.eternalegypt: 0.0.16 -> 0.0.17" ``                                |
| [`ef926c17`](https://github.com/NixOS/nixpkgs/commit/ef926c17b09aedeb2f0a60054a1c9955d3ae502b) | `` home-assistant: pin pytraccar at 2.1.1 ``                                                 |
| [`c3315009`](https://github.com/NixOS/nixpkgs/commit/c3315009a8c07612f8a25519b93924ee3911191c) | `` home-assistant: pin aionotion at 2024.03.0 ``                                             |
| [`970e68bc`](https://github.com/NixOS/nixpkgs/commit/970e68bcf8afff618a83f51d699892a925a9a030) | `` home-assistant: pin livisi at 0.0.25 ``                                                   |
| [`ea8a5c89`](https://github.com/NixOS/nixpkgs/commit/ea8a5c8970059db884bca5d3833f3bc28c1596c0) | `` home-assistant-custom-components.yandex-station: disable failing test ``                  |
| [`f7bd484a`](https://github.com/NixOS/nixpkgs/commit/f7bd484ae279aca5240fc59e7746bd98cb77193b) | `` home-assistant-custom-components.hass_web_proxy: init at 0.0.3 ``                         |
| [`db4ac36a`](https://github.com/NixOS/nixpkgs/commit/db4ac36a25f07f496fcbca99f517866435bee1c3) | `` python3Packages.urlmatch: 1.0.0 -> 1.0.1 ``                                               |
| [`64bfebde`](https://github.com/NixOS/nixpkgs/commit/64bfebde45a4fd6348a4c5e43c7c2569bac48db9) | `` home-assistant-custom-components.oref_alert: 3.2.1 -> 3.2.2 ``                            |
| [`a4413a28`](https://github.com/NixOS/nixpkgs/commit/a4413a28989e97d7f4d7287d2ce948e4b85fdfde) | `` home-assistant-custom-lovelace-modules.custom-sidebar: 10.5.1 -> 10.5.2 ``                |
| [`d1f55627`](https://github.com/NixOS/nixpkgs/commit/d1f556274e357381a03d209210ec62c4ac4b241a) | `` home-assistant-custom-components.solax_modbus: 2025.08.3 -> 2025.09.6 ``                  |
| [`535b6a14`](https://github.com/NixOS/nixpkgs/commit/535b6a14d7dc4d97d1a605c4482b5009ad8cd843) | `` home-assistant-custom-lovelace-modules.bubble-card: 3.0.0 -> 3.0.3 ``                     |
| [`90483a70`](https://github.com/NixOS/nixpkgs/commit/90483a70c7b3600531519f2f30de16b583b07a7d) | `` home-assistant-custom-components.solis-sensor: 3.13.0 -> 3.13.1 ``                        |
| [`726eb346`](https://github.com/NixOS/nixpkgs/commit/726eb346bef32cd4f17bae37ecdd940ea132680d) | `` home-assistant-custom-components.prometheus_sensor: 1.1.2 -> 1.1.3 ``                     |
| [`e0e004c2`](https://github.com/NixOS/nixpkgs/commit/e0e004c2192f73efa7cf539afd01df1732edcfbc) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.272 -> 0.13.277 `` |
| [`52e3af69`](https://github.com/NixOS/nixpkgs/commit/52e3af69fe72674d20e561ac16b8da7c74d22e83) | `` python3Packages.homeassistant-stubs: 2025.8.3 -> 2025.9.0 ``                              |
| [`c7e477ca`](https://github.com/NixOS/nixpkgs/commit/c7e477ca3b3d5997052af5fa4d92b7bae7186938) | `` home-assistant.intents: 2025.7.30 -> 2025.8.29 ``                                         |
| [`c7e19206`](https://github.com/NixOS/nixpkgs/commit/c7e192066c0bf5ee7877a4d2ce2945aa358f3c3e) | `` home-assistant: 2025.8.3 -> 2025.9.0 ``                                                   |
| [`bf312b98`](https://github.com/NixOS/nixpkgs/commit/bf312b98a649d2656f914a56c1ba612f242636d8) | `` python3Packages.python-pooldose: init at 0.6.0 ``                                         |
| [`eb94247b`](https://github.com/NixOS/nixpkgs/commit/eb94247b3272780cadb53f21f536e8b335f3d25a) | `` python3Packages.voluptuous-serialize: 2.6.0 -> 2.7.0 ``                                   |
| [`87c8ca87`](https://github.com/NixOS/nixpkgs/commit/87c8ca879f17bbde115196be2d4fe189332c2177) | `` python3Packages.zha: 0.0.68 -> 0.0.70 ``                                                  |
| [`520cb486`](https://github.com/NixOS/nixpkgs/commit/520cb486ff9c64584112587b02abd22cffbaf14e) | `` python3Packages.zigpy: 0.82.2 -> 0.82.3 ``                                                |
| [`90cd56cd`](https://github.com/NixOS/nixpkgs/commit/90cd56cdd7c75242db99f5709977bc262700ae8e) | `` python3Packages.bellows: 0.45.3 -> 0.45.4 ``                                              |
| [`12e0650c`](https://github.com/NixOS/nixpkgs/commit/12e0650cb37a21b7d7cdd4938975fef039823b6a) | `` python3Packages.zha-quirks: 0.0.143 -> 0.0.145 ``                                         |
| [`f0132eb1`](https://github.com/NixOS/nixpkgs/commit/f0132eb1470d952b56da4fcabc5a64f0e09debaf) | `` python3Packages.yalexs: 8.12.0 -> 9.0.1 ``                                                |
| [`e4a98520`](https://github.com/NixOS/nixpkgs/commit/e4a9852052e5cb40c7d30d1330eda0e3255cdc46) | `` python3Packages.triggercmd: 0.0.27 -> 0.0.36 ``                                           |
| [`e0fcca9e`](https://github.com/NixOS/nixpkgs/commit/e0fcca9e44277a9ca532ac48099f19224f6bfb73) | `` python3Packages.systembridgeconnector: 4.1.6 -> 4.1.11 ``                                 |
| [`c44fb5fb`](https://github.com/NixOS/nixpkgs/commit/c44fb5fb7be3ba3f1e622d6b95b1344ed7118ef7) | `` python3Packages.systembridgemodels: 4.2.4 -> 4.2.5 ``                                     |
| [`6798bd03`](https://github.com/NixOS/nixpkgs/commit/6798bd034f63c1846cae7ed7ebf67765a122c717) | `` python3Packages.solarlog-cli: 0.4.0 -> 0.5.0 ``                                           |
| [`0006532a`](https://github.com/NixOS/nixpkgs/commit/0006532ab7af070b4cf642489a9c2e77ce2ca741) | `` python313Packages.pyvicare: 2.50.0 -> 2.51.0 ``                                           |
| [`6b572d12`](https://github.com/NixOS/nixpkgs/commit/6b572d12fecf29ffcebc1fe085b7c3ba570848aa) | `` python3Packages.python-matter-server: 8.0.0 -> 8.1.0 ``                                   |
| [`79cd3ac2`](https://github.com/NixOS/nixpkgs/commit/79cd3ac2a4ba497715846e1896b4c0bc522396f2) | `` python3Packages.pychromecast: 14.0.7 -> 14.0.9 ``                                         |
| [`b7e69f4e`](https://github.com/NixOS/nixpkgs/commit/b7e69f4e6542432c1980731290de2d0138035f8c) | `` python3Packages.mastodon-py: 2.0.1 -> 2.1.3 ``                                            |
| [`d6cbb405`](https://github.com/NixOS/nixpkgs/commit/d6cbb4057c9760f61fd6f6ecf56ec8e26669d715) | `` python313Packages.nextdns: 4.0.0 -> 4.1.0 ``                                              |
| [`154a0c0c`](https://github.com/NixOS/nixpkgs/commit/154a0c0c9307d43edbba584c9d1647e6a1456e0d) | `` python3Packages.homematicip: 2.2.0 -> 2.3.0 ``                                            |
| [`59cab7f5`](https://github.com/NixOS/nixpkgs/commit/59cab7f567b4c80b1d5aafef5c1414a827baac37) | `` python3Packages.hass-nabucasa: 0.111.2 -> 1.1.0 ``                                        |
| [`08f6e91c`](https://github.com/NixOS/nixpkgs/commit/08f6e91c2afbb1eee11395eb4d3918d7a702a82a) | `` python3Packages.elmax-api: 0.0.6.3 -> 0.0.6.4rc0 ``                                       |
| [`ba2af221`](https://github.com/NixOS/nixpkgs/commit/ba2af2214ec897fc247fa66c105b928da6ee022c) | `` python313Packages.fjaraskupan: 2.3.2 -> 2.3.3 ``                                          |
| [`6296534f`](https://github.com/NixOS/nixpkgs/commit/6296534f34ed3ffb2418f0f4bcf881a5e85de749) | `` python313Packages.bleak-retry-connector: 4.3.0 -> 4.4.3 ``                                |
| [`43dfc161`](https://github.com/NixOS/nixpkgs/commit/43dfc161097c5cf23f088d72f0b50fd52df374b8) | `` python3Packages.bleak-esphome: 3.1.0 -> 3.2.0 ``                                          |
| [`5fd960b7`](https://github.com/NixOS/nixpkgs/commit/5fd960b7eebf3392d36ac5c1e875b70091073317) | `` python3Packages.habluetooth: 4.0.2 -> 5.3.0 ``                                            |
| [`02b32c0d`](https://github.com/NixOS/nixpkgs/commit/02b32c0ddd5b5c4b200e8d7d1ce8777600c035f4) | `` python3Packages.airos: 0.2.11 -> 0.4.4 ``                                                 |
| [`c2ee006c`](https://github.com/NixOS/nixpkgs/commit/c2ee006c25bf345008c4b390d2cb708ba3210316) | `` python3Packages.aiontfy: 0.5.3 -> 0.5.4 ``                                                |
| [`8f3fe3a3`](https://github.com/NixOS/nixpkgs/commit/8f3fe3a3777ce47eab9b45634e375041a8d7585a) | `` python3Packages.bluetooth-adapters: 2.0.0 -> 2.1.0 ``                                     |
| [`dc275e2b`](https://github.com/NixOS/nixpkgs/commit/dc275e2be01b5e1ceaff507c651019cc6adfcaf4) | `` python313Packages.aiohasupervisor: 0.3.1 -> 0.3.2 ``                                      |
| [`e6df7476`](https://github.com/NixOS/nixpkgs/commit/e6df74763b054c7edb0d36e14322e942d40b6fd7) | `` python3Packages.aioesphomeapi: 37.2.5 -> 39.0.1 ``                                        |
| [`4bf2ba4a`](https://github.com/NixOS/nixpkgs/commit/4bf2ba4a8d02f2d57a92674214b3ee220f103bec) | `` python3Packages.aioecowitt: 2025.3.1 -> 2025.9.0 ``                                       |
| [`d1aea678`](https://github.com/NixOS/nixpkgs/commit/d1aea678d4532d03d02724079c3c63450b56dbc5) | `` python3Packages.aioazuredevops: 2.2.1 -> 2.2.2 ``                                         |
| [`e9537b8c`](https://github.com/NixOS/nixpkgs/commit/e9537b8cd7ae9b95067ec84ae8acc377a5d61bb9) | `` python3Packages.aioamazondevices: 5.0.0 -> 6.0.0 ``                                       |
| [`5d9b21fc`](https://github.com/NixOS/nixpkgs/commit/5d9b21fcb88f180e8841871d7e69348c0e720bd8) | `` home-assistant-custom-lovelace-modules.universal-remote-card: 4.7.1 -> 4.7.2 ``           |
| [`59c2c020`](https://github.com/NixOS/nixpkgs/commit/59c2c020a4781fcef7e63cd9feedef9e50f7e43a) | `` buildah-unwrapped: 1.41.3 -> 1.41.4 ``                                                    |
| [`318aad95`](https://github.com/NixOS/nixpkgs/commit/318aad956b157a85cec55ab4174cff3741f98033) | `` cargo-workspaces: 0.4.0 -> 0.4.1 ``                                                       |
| [`1f4d80da`](https://github.com/NixOS/nixpkgs/commit/1f4d80da57482872cedc6f1f00250a61a665f02f) | `` xbyak: 7.29.2 -> 7.30 ``                                                                  |
| [`cd363793`](https://github.com/NixOS/nixpkgs/commit/cd363793dd7fd7dc1b1a8f62152284d18831d67d) | `` python3Packages.pyworxcloud: 4.1.43 -> 4.1.46 ``                                          |
| [`73ad3bf5`](https://github.com/NixOS/nixpkgs/commit/73ad3bf50770a6b3bd6a1221a83053fdf1494afa) | `` python3Packages.gitignore-parser: 0.1.12 -> 0.1.13 ``                                     |
| [`c45ad99c`](https://github.com/NixOS/nixpkgs/commit/c45ad99cdf14bacb1af66ea1199e103747da4159) | `` nix-search-tv: 2.1.8 -> 2.2.0 ``                                                          |
| [`ce11d047`](https://github.com/NixOS/nixpkgs/commit/ce11d047475ca2146cecb742f0fe9cefa8c66853) | `` python313Packages.niworkflows: disable test_brain_extraction_wf_smoketest ``              |
| [`c60fb06e`](https://github.com/NixOS/nixpkgs/commit/c60fb06eb9c82d3206d819156a6e30f28dafb6af) | `` python313Packages.nilearn: 0.12.0 -> 0.12.1 ``                                            |
| [`1400b43e`](https://github.com/NixOS/nixpkgs/commit/1400b43eb7ed46a7ca6e3c39b09d9fd23a636473) | `` sendgmail: add a `mainProgram` entry ``                                                   |
| [`51285a14`](https://github.com/NixOS/nixpkgs/commit/51285a1462dabe27fadf662e242ec90fd417f989) | `` python3Packages.transformers: 4.56.0 -> 4.56.1 ``                                         |
| [`a5f35565`](https://github.com/NixOS/nixpkgs/commit/a5f3556572630cc1710e43a34ba575423ec5277c) | `` envoy: 1.35.1 -> 1.35.2 ``                                                                |
| [`9601e327`](https://github.com/NixOS/nixpkgs/commit/9601e3275e4995425fb047e7815875f7c177a88e) | `` hii: init at 1.1.5 ``                                                                     |
| [`b04c41b2`](https://github.com/NixOS/nixpkgs/commit/b04c41b2f3193cccb6f35c5293f426559f3c1c7f) | `` mcp-grafana: 0.6.3 -> 0.6.4 ``                                                            |
| [`798e1ee4`](https://github.com/NixOS/nixpkgs/commit/798e1ee4bbd4392661b8e59fa679103f8e054354) | `` plasmusic-toolbar: 3.3.0 -> 3.4.0 ``                                                      |
| [`6b5fcc7c`](https://github.com/NixOS/nixpkgs/commit/6b5fcc7c106a044dd3a9a50a22c2a2ec9e5e2f56) | `` doc/overlays: mention that final/prev are used ``                                         |
| [`d9881aad`](https://github.com/NixOS/nixpkgs/commit/d9881aadb14083be7bdc5046d114f55a13167191) | `` trufflehog: 3.90.5 -> 3.90.6 ``                                                           |
| [`9237e4cc`](https://github.com/NixOS/nixpkgs/commit/9237e4cc6219144969985cd7e8a98cbafb26190d) | `` n8n: 1.107.4 -> 1.109.2 ``                                                                |
| [`fd8ad3ae`](https://github.com/NixOS/nixpkgs/commit/fd8ad3aea379311c736add370e1299838549ef73) | `` home-manager: 0-unstable-2025-09-03 -> 0-unstable-2025-09-04 ``                           |
| [`18207722`](https://github.com/NixOS/nixpkgs/commit/1820772258e5be975529fa2ad3507b4f658ad683) | `` linux_5_4: 5.4.297 -> 5.4.298 ``                                                          |
| [`cd9b96d7`](https://github.com/NixOS/nixpkgs/commit/cd9b96d76c7eee66a59e90b3455ec2d0f6c03571) | `` linux_5_10: 5.10.241 -> 5.10.242 ``                                                       |
| [`490d8972`](https://github.com/NixOS/nixpkgs/commit/490d8972e6fcfecbac6853635df262ac16d1dd5b) | `` linux_5_15: 5.15.190 -> 5.15.191 ``                                                       |
| [`43863483`](https://github.com/NixOS/nixpkgs/commit/438634830b6aea8a96da67fb873e1d39115b9de5) | `` linux_6_1: 6.1.149 -> 6.1.150 ``                                                          |
| [`7bb37cf3`](https://github.com/NixOS/nixpkgs/commit/7bb37cf3516f94c8cd6bc367d0793484175c4fd3) | `` linux_6_6: 6.6.103 -> 6.6.104 ``                                                          |
| [`b4f77b18`](https://github.com/NixOS/nixpkgs/commit/b4f77b18772cbf15174776e11bbfac1cf22a2bd6) | `` linux_6_12: 6.12.44 -> 6.12.45 ``                                                         |
| [`71b88af3`](https://github.com/NixOS/nixpkgs/commit/71b88af37f3591561b3613cef2efb6d25041b173) | `` linux_6_16: 6.16.4 -> 6.16.5 ``                                                           |
| [`4637f861`](https://github.com/NixOS/nixpkgs/commit/4637f861a024cf4deb915a4a29013012b0accb14) | `` matrix-alertmanager-receiver: 2025.8.27 -> 2025.9.3 ``                                    |
| [`b313136f`](https://github.com/NixOS/nixpkgs/commit/b313136f3cd31fa73effa67f569708535c8c6914) | `` bootdev-cli: 1.20.1 -> 1.20.2 ``                                                          |
| [`5bd79594`](https://github.com/NixOS/nixpkgs/commit/5bd795944bb94c0192ad5cef95ff8f9230fb4139) | `` windsurf: 1.12.3 -> 1.12.4 ``                                                             |
| [`74c4a509`](https://github.com/NixOS/nixpkgs/commit/74c4a509188f5026d45f7ec97ee03cc5cfa3294f) | `` claude-code: 1.0.102 -> 1.0.105 ``                                                        |
| [`7b42d744`](https://github.com/NixOS/nixpkgs/commit/7b42d7449104da54dfd7ee048176ceee450b2f01) | `` fastfetch: 2.51.0 -> 2.51.1 ``                                                            |
| [`2f53ff3b`](https://github.com/NixOS/nixpkgs/commit/2f53ff3b8edcb4e094d16f227fec8d9adcc633c0) | `` python3Packages.unstructured: 0.18.13 -> 0.18.14 ``                                       |
| [`8baa02fa`](https://github.com/NixOS/nixpkgs/commit/8baa02fa39c294f99efc86b928eb9c8988084efe) | `` wasm-tools: 1.238.0 -> 1.238.1 ``                                                         |
| [`298e1cc0`](https://github.com/NixOS/nixpkgs/commit/298e1cc01eb117a587d696556a22219f877c5de2) | `` eloquent: fix mainProgram ``                                                              |
| [`09145f95`](https://github.com/NixOS/nixpkgs/commit/09145f956b615945cf3f94254821053bdd30a0ac) | `` dufs: 0.44.0 -> 0.45.0 ``                                                                 |