### PR TITLE
chore(flake/nur): `0b567e06` -> `0cf8e952`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1756787288,
-        "narHash": "sha256-rw/PHa1cqiePdBxhF66V7R+WAP8WekQ0mCDG4CFqT8Y=",
+        "lastModified": 1757068644,
+        "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d0fc30899600b9b3466ddb260fd83deb486c32f1",
+        "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757187795,
-        "narHash": "sha256-2uK7hr8H5zuN3ZiNfHea5xZDcNH7/1H4ZvbgncIeWWk=",
+        "lastModified": 1757209845,
+        "narHash": "sha256-UOqIKs+ObXTydrmkIAI5V/xbqhYJ3iwtWDmOAQq1y9Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0b567e06e3fb68ce9995f81892201387d5e752e7",
+        "rev": "0cf8e952f2336d09ef7695dccc7fe9e89445ea9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                         |
| -------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`0cf8e952`](https://github.com/nix-community/NUR/commit/0cf8e952f2336d09ef7695dccc7fe9e89445ea9c) | `` automatic update ``          |
| [`7b68e165`](https://github.com/nix-community/NUR/commit/7b68e1657603ae9226666c92f94fdc8432054a62) | `` automatic update ``          |
| [`0fa961ea`](https://github.com/nix-community/NUR/commit/0fa961eaeb9aad03af42c19f20c60b682e920bd3) | `` Add willenbug to repos ``    |
| [`38addda1`](https://github.com/nix-community/NUR/commit/38addda19d2ac5676e98a2c95494d9cb55d7944b) | `` add AstroOrbis repository `` |
| [`2f7c629f`](https://github.com/nix-community/NUR/commit/2f7c629f6a98d48a0235b3ccb68c301eeb62ffd2) | `` automatic update ``          |