### PR TITLE
chore(flake/nur): `0cf8e952` -> `4a5b1c4d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757209845,
-        "narHash": "sha256-UOqIKs+ObXTydrmkIAI5V/xbqhYJ3iwtWDmOAQq1y9Q=",
+        "lastModified": 1757216042,
+        "narHash": "sha256-FOXPrig3D9F95b36QCoBfMPPze/IyykXv8vP+FHsJo4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0cf8e952f2336d09ef7695dccc7fe9e89445ea9c",
+        "rev": "4a5b1c4dcc80999b3cc7c8579524759ee5517e06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                  |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`4a5b1c4d`](https://github.com/nix-community/NUR/commit/4a5b1c4dcc80999b3cc7c8579524759ee5517e06) | `` automatic update ``                                   |
| [`c0380f2b`](https://github.com/nix-community/NUR/commit/c0380f2b11bd14e9718144bf378b6f05b2922177) | `` Update cachix/install-nix-action digest to 56a7bb7 `` |