### PR TITLE
chore(flake/nur): `c8199f22` -> `627b698a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757219531,
-        "narHash": "sha256-KO3QrZV96+QM9lIpDix8F/EtOk9zkf76FVDGzwSg/UM=",
+        "lastModified": 1757236417,
+        "narHash": "sha256-u6h/CRAL173S84dlU3ehncUF8wPobt+tEPd72rqC5Zw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c8199f22106c3e248487911ce96739a8d9efce48",
+        "rev": "627b698af6cd79c4df1a20d710259f36fbf13400",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`627b698a`](https://github.com/nix-community/NUR/commit/627b698af6cd79c4df1a20d710259f36fbf13400) | `` automatic update `` |
| [`8a658e88`](https://github.com/nix-community/NUR/commit/8a658e88908c68fd49e58658ca2d57f34b9fd96c) | `` automatic update `` |
| [`d03c8bf5`](https://github.com/nix-community/NUR/commit/d03c8bf5f965d104d551e33b7acb5539d88a147e) | `` automatic update `` |
| [`6642db7e`](https://github.com/nix-community/NUR/commit/6642db7e89840ab903a200e90322a29344b0ddd3) | `` automatic update `` |
| [`5c68f6ca`](https://github.com/nix-community/NUR/commit/5c68f6ca670d9f6b7f5a24971ab65236e0f70b2c) | `` automatic update `` |