### PR TITLE
chore(flake/nur): `627b698a` -> `d244f159`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757236417,
-        "narHash": "sha256-u6h/CRAL173S84dlU3ehncUF8wPobt+tEPd72rqC5Zw=",
+        "lastModified": 1757246002,
+        "narHash": "sha256-tGGjRl5x6e0sYwVCCveWwLSH5b0ntaFDxjfSyrz4+Ek=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "627b698af6cd79c4df1a20d710259f36fbf13400",
+        "rev": "d244f159840581aa186a134a307e201c615591d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d244f159`](https://github.com/nix-community/NUR/commit/d244f159840581aa186a134a307e201c615591d2) | `` automatic update `` |
| [`8642333b`](https://github.com/nix-community/NUR/commit/8642333b775094d6943f6db2f79f80aacb73f209) | `` automatic update `` |
| [`2f37c307`](https://github.com/nix-community/NUR/commit/2f37c3070cf29f1daa4494a6c39c61d39cc27585) | `` automatic update `` |
| [`4dcb0b2b`](https://github.com/nix-community/NUR/commit/4dcb0b2bddd4456fc10d7f29862a1f1b1fd304e9) | `` automatic update `` |