### PR TITLE
chore(flake/umu): `9e720e43` -> `9e4ad8c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -620,11 +620,11 @@
       },
       "locked": {
         "dir": "packaging/nix",
-        "lastModified": 1755559562,
-        "narHash": "sha256-fo8fHN3UWh4ynqyuCF8/4rDoMwYJgNqZvwgcBDIh11w=",
+        "lastModified": 1757244244,
+        "narHash": "sha256-1KTufp+ZY1Ap60anOXdHH6JipbqNbd8ZplAEaiviqAY=",
         "owner": "Open-Wine-Components",
         "repo": "umu-launcher",
-        "rev": "9e720e433b81fff936373b47b710f4481436010c",
+        "rev": "9e4ad8c5d15e02073da697caaa7004b2c3c20413",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                             | Message                                     |
| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
| [`9e4ad8c5`](https://github.com/Open-Wine-Components/umu-launcher/commit/9e4ad8c5d15e02073da697caaa7004b2c3c20413) | `` fix: search /sbin for ldconfig (#540) `` |