### PR TITLE
chore(flake/chaotic): `11bfa4c0` -> `4c45cf8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1757182941,
-        "narHash": "sha256-81TKa5U84gRc6krwhVOwb5gpgXgYxIeS1kkwOTw1GN4=",
+        "lastModified": 1757250892,
+        "narHash": "sha256-DSFHpYTUN3lReQcv6PXuyR9TmArH2Y40Z1JGLjVdt1A=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "11bfa4c0dc07da1e7e49c5111cc9bfa1260ba98f",
+        "rev": "4c45cf8a489b8214a3a14c348ee851ff7aedfa1a",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757072639,
-        "narHash": "sha256-8aC1lUvVpu2BBBgX7iKYyf5nyuGfoyYStxD4es3mzuM=",
+        "lastModified": 1757075491,
+        "narHash": "sha256-a+NMGl5tcvm+hyfSG2DlVPa8nZLpsumuRj1FfcKb2mQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a51e585a05d318f988dfe09ec7fe31de966d9a76",
+        "rev": "f56bf065f9abedc7bc15e1f2454aa5c8edabaacf",
         "type": "github"
       },
       "original": {
@@ -552,11 +552,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757039615,
-        "narHash": "sha256-qm53+EUFfzyF8F0MEscHGqf9tx462GV3/zUZrn9wiQU=",
+        "lastModified": 1757125853,
+        "narHash": "sha256-noKkYHKpT5lpvNSYrlH56d8cedthZfs010Uv6vTqLT4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4486e04adbb4b0e39f593767f2c36e2211003d01",
+        "rev": "8b70793a6be183536a5d562056dac10b7b36820d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                    |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`4c45cf8a`](https://github.com/chaotic-cx/nyx/commit/4c45cf8a489b8214a3a14c348ee851ff7aedfa1a) | `` Revert "tdlib_git: 20250818210923-5c77c46 -> 20250905230832-bdec6af" `` |
| [`3cb69e3f`](https://github.com/chaotic-cx/nyx/commit/3cb69e3f853866162d8d7b907037b69ccb8c5d68) | `` Bump 20250907-1 (#1180) ``                                              |
| [`6633eadd`](https://github.com/chaotic-cx/nyx/commit/6633eaddf942b88e8bef2d611c403bf4ac332613) | `` fix bumper; fmt ``                                                      |
| [`126d9b02`](https://github.com/chaotic-cx/nyx/commit/126d9b02aad411da2264bae0bcdcfb9073ec4c39) | `` failures: update aarch64-linux ``                                       |