### PR TITLE
chore(flake/disko): `a5c4f2ab` -> `c8a0e78d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1756733629,
-        "narHash": "sha256-dwWGlDhcO5SMIvMSTB4mjQ5Pvo2vtxvpIknhVnSz2I8=",
+        "lastModified": 1757255839,
+        "narHash": "sha256-XH33B1X888Xc/xEXhF1RPq/kzKElM0D5C9N6YdvOvIc=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a5c4f2ab72e3d1ab43e3e65aa421c6f2bd2e12a1",
+        "rev": "c8a0e78d86b12ea67be6ed0f7cae7f9bfabae75a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                  |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`c8a0e78d`](https://github.com/nix-community/disko/commit/c8a0e78d86b12ea67be6ed0f7cae7f9bfabae75a) | `` examples: gpt partition attributes `` |
| [`31fe7eda`](https://github.com/nix-community/disko/commit/31fe7eda2690ba0c4db54a96d18614edd8bfefd1) | `` gpt: add partition attributes ``      |