### PR TITLE
chore(flake/nur): `d244f159` -> `063ad791`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757246002,
-        "narHash": "sha256-tGGjRl5x6e0sYwVCCveWwLSH5b0ntaFDxjfSyrz4+Ek=",
+        "lastModified": 1757258126,
+        "narHash": "sha256-T08tTsDewVHB6RmA0xWn3OmyNRWElMSBhgqYI/BdoPk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d244f159840581aa186a134a307e201c615591d2",
+        "rev": "063ad7918b03b2edf8a8db18d3604016244415cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`063ad791`](https://github.com/nix-community/NUR/commit/063ad7918b03b2edf8a8db18d3604016244415cc) | `` automatic update `` |
| [`33dc71f0`](https://github.com/nix-community/NUR/commit/33dc71f0bc337f655063b814f874c64553415937) | `` automatic update `` |
| [`be31ab0a`](https://github.com/nix-community/NUR/commit/be31ab0a5feb8cafabf07b3ddcf1079233647341) | `` automatic update `` |
| [`09050f3a`](https://github.com/nix-community/NUR/commit/09050f3a51a353ecde4a7c137e76abb58710ed95) | `` automatic update `` |