### PR TITLE
chore(flake/chaotic): `4c45cf8a` -> `08bff060`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1757250892,
-        "narHash": "sha256-DSFHpYTUN3lReQcv6PXuyR9TmArH2Y40Z1JGLjVdt1A=",
+        "lastModified": 1757267471,
+        "narHash": "sha256-ThyzQzi0uQn5Ui8jFRcjpWOWpjX00utBegHhMfBKyZE=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "4c45cf8a489b8214a3a14c348ee851ff7aedfa1a",
+        "rev": "08bff060191426d82e0cb95fc6a328e632087744",
         "type": "github"
       },
       "original": {
@@ -382,11 +382,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1756989294,
-        "narHash": "sha256-vh3F0p7pGvj9tItYjlqiZ3zTJCuw9+d74RhYCYLuaBQ=",
+        "lastModified": 1757238739,
+        "narHash": "sha256-ovEq9v+Xc+oQH1zvQo28rT/YVqMQK2TRgUcNanvo2Zk=",
         "owner": "PedroHLC",
         "repo": "nixpkgs",
-        "rev": "f04ea9d87566cfe950cf45d7311a9964dcf3bf38",
+        "rev": "6d8fca2c92488ff860524dd3400aa90a3310123e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                             |
| ----------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`08bff060`](https://github.com/chaotic-cx/nyx/commit/08bff060191426d82e0cb95fc6a328e632087744) | `` failures: update x86_64-linux `` |
| [`5f09da78`](https://github.com/chaotic-cx/nyx/commit/5f09da78337f224ebfb4b3e021f335d99edc24ae) | `` nixpkgs bump ``                  |