### PR TITLE
chore(flake/nix-gaming): `e479c636` -> `61514879`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -232,11 +232,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1757210397,
-        "narHash": "sha256-pGAd0KLt6FMu7x742zs4OVYkoUx2o6vJGvYUVZJpNG4=",
+        "lastModified": 1757296410,
+        "narHash": "sha256-vXYNuMUggreF8lrupnQRzEQg+NXxE6++/KMp2iLom+8=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "e479c636519292b50de48f73d7df6cf14c745a1c",
+        "rev": "615148794c092768c39017bffae1eec410515870",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message               |
| --------------------------------------------------------------------------------------------------- | --------------------- |
| [`61514879`](https://github.com/fufexan/nix-gaming/commit/615148794c092768c39017bffae1eec410515870) | `` Update packages `` |