### PR TITLE
chore(flake/nur): `b9a56872` -> `352c4bc0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757294685,
-        "narHash": "sha256-XzHaG/cZKxx6mGTexEkUPt4nwPrmAvvgb0nx14Dupjs=",
+        "lastModified": 1757302598,
+        "narHash": "sha256-V44YWNb5698djf1RpgIkXQ2HxTR9n2V1dYcL6ijlySU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9a5687246c335478d56106f2393926d65ed28bc",
+        "rev": "352c4bc0e1499b55bd6e42e10c47e05f25c07015",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`352c4bc0`](https://github.com/nix-community/NUR/commit/352c4bc0e1499b55bd6e42e10c47e05f25c07015) | `` automatic update `` |
| [`9cf21f20`](https://github.com/nix-community/NUR/commit/9cf21f200c4e151e779d276df7058895cfcebef8) | `` automatic update `` |