### PR TITLE
chore(flake/nur): `352c4bc0` -> `ada336d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757302598,
-        "narHash": "sha256-V44YWNb5698djf1RpgIkXQ2HxTR9n2V1dYcL6ijlySU=",
+        "lastModified": 1757308472,
+        "narHash": "sha256-cpOb2XZo6BsOcyA8KOs9XDXo4V4kpMIx5vhS4s/eXoU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "352c4bc0e1499b55bd6e42e10c47e05f25c07015",
+        "rev": "ada336d53a82948493059ff14c187935eca08e7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ada336d5`](https://github.com/nix-community/NUR/commit/ada336d53a82948493059ff14c187935eca08e7a) | `` automatic update `` |
| [`4acd5b22`](https://github.com/nix-community/NUR/commit/4acd5b22b0e2580e3d61953ef8243572d39400da) | `` automatic update `` |
| [`c46f85dc`](https://github.com/nix-community/NUR/commit/c46f85dcf907c62330d73ac1523329dfe13df599) | `` automatic update `` |
| [`619951dd`](https://github.com/nix-community/NUR/commit/619951dd4b146705bb373d961e46daa482c1cbb6) | `` automatic update `` |
| [`9d5d6109`](https://github.com/nix-community/NUR/commit/9d5d61090c3ca5c0f83317442848fd11a3353e5e) | `` automatic update `` |
| [`9561f2dd`](https://github.com/nix-community/NUR/commit/9561f2dd089bc1e8f981a8e2ddc0ae4dcdbf5d02) | `` automatic update `` |