### PR TITLE
chore(flake/catppuccin): `cd22197d` -> `d75e3fe6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1756741629,
-        "narHash": "sha256-n+mgH3NoQf8d1jd8cDp/9Mt++hhyuE3LO3ZAxzjWRZw=",
+        "lastModified": 1757320803,
+        "narHash": "sha256-7PUIQOMQSJLkNtV42SAYUDw0mRdbBNl6q8pLN8GViwM=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "cd22197da06df1eb6fabdaa2fc22c170c4f67382",
+        "rev": "d75e3fe67f49728cb5035bc791f4b9065ff3a2c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                     |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`d75e3fe6`](https://github.com/catppuccin/nix/commit/d75e3fe67f49728cb5035bc791f4b9065ff3a2c9) | `` chore(deps): update actions/upload-pages-artifact action to v4 (#720) `` |