### PR TITLE
chore(flake/nixpkgs): `fe83bbdd` -> `092c565d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1757020766,
-        "narHash": "sha256-PLoSjHRa2bUbi1x9HoXgTx2AiuzNXs54c8omhadyvp0=",
+        "lastModified": 1757244434,
+        "narHash": "sha256-AeqTqY0Y95K1Fgs6wuT1LafBNcmKxcOkWnm4alD9pqM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe83bbdde2ccdc2cb9573aa846abe8363f79a97a",
+        "rev": "092c565d333be1e17b4779ac22104338941d913f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`2802c768`](https://github.com/NixOS/nixpkgs/commit/2802c7688fdb6bac1d4a69faea572addc5deaeae) | `` pkgsCross.aarch64-darwin.discord-canary: 0.0.844 -> 0.0.857 ``                       |
| [`e9f0fab8`](https://github.com/NixOS/nixpkgs/commit/e9f0fab876f576215e2186e2f4281e96948f6aa0) | `` pkgsCross.aarch64-darwin.discord-ptb: 0.0.186 -> 0.0.190 ``                          |
| [`03857a16`](https://github.com/NixOS/nixpkgs/commit/03857a16f629a1397327462da0c81d1178766380) | `` pkgsCross.aarch64-darwin.discord: 0.0.356 -> 0.0.359 ``                              |
| [`f511dc1e`](https://github.com/NixOS/nixpkgs/commit/f511dc1e2c1842532abf48d0d092ba5f335f7b54) | `` discord-development: 0.0.84 -> 0.0.85 ``                                             |
| [`39bede1b`](https://github.com/NixOS/nixpkgs/commit/39bede1bf2b583febc1f286cee7cf134980a8913) | `` discord-canary: 0.0.748 -> 0.0.751 ``                                                |
| [`b5213ebc`](https://github.com/NixOS/nixpkgs/commit/b5213ebc53fa3e663dc84f07d7162138588a8b17) | `` discord-ptb: 0.0.158 -> 0.0.159 ``                                                   |
| [`aae69def`](https://github.com/NixOS/nixpkgs/commit/aae69deffdbe475bf39034f1d3366df4f9e98a7b) | `` discord: 0.0.107 -> 0.0.108 ``                                                       |
| [`cac3c1ca`](https://github.com/NixOS/nixpkgs/commit/cac3c1ca6e0d2d07ec2758f2f51985780cd48eb1) | `` bind: 9.20.11 -> 9.20.12 ``                                                          |
| [`f2150e98`](https://github.com/NixOS/nixpkgs/commit/f2150e9896701fe43859a9188426d2fee4d56d83) | `` matomo: 5.3.2 -> 5.4.0 ``                                                            |
| [`de5d9a58`](https://github.com/NixOS/nixpkgs/commit/de5d9a584cade9d22276ca9d6169ad17dde9d196) | `` yt-dlp: 2025.08.22 -> 2025.08.27 ``                                                  |
| [`be3a3409`](https://github.com/NixOS/nixpkgs/commit/be3a340988964bcfc756fb40f1718c352d43c79c) | `` outline: 0.86.1 -> 0.87.3 ``                                                         |
| [`308a2b29`](https://github.com/NixOS/nixpkgs/commit/308a2b293806e986ffa4a2a86ff5dee87743f623) | `` lightway: init at 0-unstable-2025-09-04 ``                                           |
| [`cdaafcba`](https://github.com/NixOS/nixpkgs/commit/cdaafcba039648345596f533ceb20c2fd58055e0) | `` maintainers: add dustyhorizon ``                                                     |
| [`d9c3a244`](https://github.com/NixOS/nixpkgs/commit/d9c3a244bfafe636ebead6e0acd1b20ba11a4b56) | `` forgejo-lts: 11.0.4 -> 11.0.5 ``                                                     |
| [`6e5475b9`](https://github.com/NixOS/nixpkgs/commit/6e5475b9d43f0c3c388cd3a2dbcba9443fff7af6) | `` forgejo: 12.0.2 -> 12.0.3 ``                                                         |
| [`078e17c0`](https://github.com/NixOS/nixpkgs/commit/078e17c0be74cc0e46b2efb91542f04ec868ffcf) | `` [Backport release-25.05] nixos/kerberos_server: add extraKDCArgs option (#440187) `` |
| [`779ea333`](https://github.com/NixOS/nixpkgs/commit/779ea3331e15c6d6585809ae86d3bc4d9102e7db) | `` firefox-beta-unwrapped: 143.0b7 -> 143.0b8 ``                                        |
| [`85a829db`](https://github.com/NixOS/nixpkgs/commit/85a829dbdd768f81fe8131e9c408cc567aaa5687) | `` firefox-devedition-unwrapped: 143.0b7 -> 143.0b8 ``                                  |
| [`45383f94`](https://github.com/NixOS/nixpkgs/commit/45383f94363163e40d0dbb23df91011e331557be) | `` linuxKernel.kernels.linux_lqx: 6.16.3 -> 6.16.5 ``                                   |
| [`ad5ddadc`](https://github.com/NixOS/nixpkgs/commit/ad5ddadcb2cc2a00dc4461bf501e497297e294f4) | `` grav: 1.7.49.2 -> 1.7.49.4 ``                                                        |
| [`ae008b1f`](https://github.com/NixOS/nixpkgs/commit/ae008b1fd3c2e48768f39239981e5038a7d9232b) | `` python3Packages.internetarchive: 5.4.0 -> 5.5.1 ``                                   |
| [`d6803995`](https://github.com/NixOS/nixpkgs/commit/d68039954931bee93c30d217e09d580308bc05b7) | `` webkitgtk_6_0: 2.48.5 → 2.48.6 ``                                                    |
| [`80b7a0cf`](https://github.com/NixOS/nixpkgs/commit/80b7a0cf62b5addb4be2e0552a8b54cae9ebfcfc) | `` postfix-tlspol: 1.8.16 -> 1.8.18 (#440499) ``                                        |
| [`86e8c353`](https://github.com/NixOS/nixpkgs/commit/86e8c3537a966193927516d7f860c7e83a39cfaa) | `` editorconfig-checker: 3.3.0 -> 3.4.0 ``                                              |
| [`80302a49`](https://github.com/NixOS/nixpkgs/commit/80302a496ae7732863a1143ffcc5833a26ead6c5) | `` radicle-desktop: init at 0.8.0 ``                                                    |
| [`46c64ae8`](https://github.com/NixOS/nixpkgs/commit/46c64ae8d4b3e8fc00dc1d21b0661e30a6696407) | `` maintainers: bloxx12 -> faukah; treewide: rename bloxx12 to faukah ``                |
| [`c633f031`](https://github.com/NixOS/nixpkgs/commit/c633f03176e034dbe944d8ecec74ca49ebe11c28) | `` vintagestory: 1.21.0-rc.7 -> 1.21.0 ``                                               |
| [`cd6ac003`](https://github.com/NixOS/nixpkgs/commit/cd6ac0031fedb039cf726f15fc839e52e8097ef9) | `` vintagestory: 1.20.12 -> 1.21.0-rc.7 ``                                              |
| [`3f446bcc`](https://github.com/NixOS/nixpkgs/commit/3f446bcc494b0cc9e9eaed2a58b7398341211ca2) | `` doxx: init at 0-unstable-2025-08-18 (#434616) ``                                     |
| [`c7b9a2db`](https://github.com/NixOS/nixpkgs/commit/c7b9a2db1d20aa78fc2aac2868507f76c3dbf73e) | `` maintainers: add yiyu ``                                                             |
| [`94a37bd8`](https://github.com/NixOS/nixpkgs/commit/94a37bd8dbde37d9fe2de3e050cbb826cb93fa5f) | `` warp-terminal: 0.2025.08.27.08.11.stable_04 -> 0.2025.09.03.08.11.stable_03 ``       |
| [`594220ff`](https://github.com/NixOS/nixpkgs/commit/594220ffd60cf1ed622940099ac4e769b960d245) | `` linux_xanmod_latest: 6.16.4 -> 6.16.5 ``                                             |
| [`1dbb5083`](https://github.com/NixOS/nixpkgs/commit/1dbb508308348048d37b818667723ef9ff418e56) | `` linux_xanmod: 6.12.44 -> 6.12.45 ``                                                  |
| [`c16cbd42`](https://github.com/NixOS/nixpkgs/commit/c16cbd4282396f9afd3f748f96537e8a7f804f82) | `` haskell.packages.integer-simple: remove unused includes ``                           |
| [`368727ae`](https://github.com/NixOS/nixpkgs/commit/368727ae6be162eb2a4b50b8ecb1fdca5f49977b) | `` haskell.packages.native-bignum: exclude recurseForDerivations ``                     |
| [`3261432f`](https://github.com/NixOS/nixpkgs/commit/3261432fe3ac35edfcd32c4d2873096ca00eab69) | `` google-chrome: 139.0.7258.154 -> 140.0.7339.80 ``                                    |
| [`81fd3bcb`](https://github.com/NixOS/nixpkgs/commit/81fd3bcb18b9786440f9ca68bf9183479da2b710) | `` matrix-alertmanager-receiver: 2025.8.27 -> 2025.9.3 ``                               |
| [`bb7c2bf8`](https://github.com/NixOS/nixpkgs/commit/bb7c2bf89f6e955e3c75c39cad1f8bbd31b35ebb) | `` ncps: Add support for the --cache-temp-path flag ``                                  |
| [`258e3e3b`](https://github.com/NixOS/nixpkgs/commit/258e3e3bac906d93799657ada84b1fc83464eacc) | `` ncps: Add support for the --prometheus-enabled flag ``                               |
| [`b347afe9`](https://github.com/NixOS/nixpkgs/commit/b347afe9d99adc7d4ce3f0ee59614d26b090c15b) | `` ncps: enable race testing ``                                                         |
| [`c684ea3f`](https://github.com/NixOS/nixpkgs/commit/c684ea3f20508ecf461fc64d6c1ac85031556e3c) | `` ncps: remove subPackages to build and check all sub-packages ``                      |
| [`1f3b0fd7`](https://github.com/NixOS/nixpkgs/commit/1f3b0fd71802b41321422f6db32154b4e2e5844e) | `` ncps: 0.2.0 -> 0.3.0 ``                                                              |
| [`6639bebd`](https://github.com/NixOS/nixpkgs/commit/6639bebdc2393d60b61d1122f9cbaeb8e2ec8949) | `` nss_3_114: 3.114 -> 3.114.1 ``                                                       |
| [`d0d639f7`](https://github.com/NixOS/nixpkgs/commit/d0d639f7e9aa5ab235dbbe8b4cb704d91673d1ed) | `` nss_latest: 3.115 -> 3.115.1 ``                                                      |
| [`5b339b07`](https://github.com/NixOS/nixpkgs/commit/5b339b078dc817a67aaacb3b18775cfaa73cd3aa) | `` nss: implement automated updates using nix-update-script ``                          |
| [`00ef8d87`](https://github.com/NixOS/nixpkgs/commit/00ef8d871cd0a255b9259759cc93d5286a096638) | `` linux_5_4: 5.4.297 -> 5.4.298 ``                                                     |
| [`5660a3e5`](https://github.com/NixOS/nixpkgs/commit/5660a3e5b1aa3255dac3d2a99f6e52d461728b70) | `` linux_5_10: 5.10.241 -> 5.10.242 ``                                                  |
| [`047652ae`](https://github.com/NixOS/nixpkgs/commit/047652ae19bbc71edebb8b428d7c2b185bbdc370) | `` linux_5_15: 5.15.190 -> 5.15.191 ``                                                  |
| [`ab8e6bb3`](https://github.com/NixOS/nixpkgs/commit/ab8e6bb3ddea485ff56b7a5ceb1b58ef8e357189) | `` linux_6_1: 6.1.149 -> 6.1.150 ``                                                     |
| [`8bd011e4`](https://github.com/NixOS/nixpkgs/commit/8bd011e4d80e1e8ae2df8df021e3754e02ac14ef) | `` linux_6_6: 6.6.103 -> 6.6.104 ``                                                     |
| [`f3c3959b`](https://github.com/NixOS/nixpkgs/commit/f3c3959b0c9c82615e5f51fb2a07d82ed5c3015e) | `` linux_6_12: 6.12.44 -> 6.12.45 ``                                                    |
| [`a9349514`](https://github.com/NixOS/nixpkgs/commit/a93495143ceda37d5d29b0575b87dd6e03179f34) | `` linux_6_16: 6.16.4 -> 6.16.5 ``                                                      |
| [`15259c3a`](https://github.com/NixOS/nixpkgs/commit/15259c3a94fe0b5c69a8f712ff0dcd9939bb3731) | `` thunderbird-esr-bin-unwrapped: 140.2.0esr -> 140.2.1esr ``                           |
| [`fc432219`](https://github.com/NixOS/nixpkgs/commit/fc432219ea741efce59912cfb2a51ad9820c291d) | `` waybar: 0.13.0 -> 0.14.0 ``                                                          |
| [`98f7229a`](https://github.com/NixOS/nixpkgs/commit/98f7229a734b6972d4339cea32b02f645c82c5d7) | `` nixVersions.nix_2_28: 2.28.4 -> 2.28.5 ``                                            |
| [`b2acd60d`](https://github.com/NixOS/nixpkgs/commit/b2acd60d48ad603d4a4f01aa5787b66a9f9af0e1) | `` imagemagick: 7.1.2-2 -> 7.1.2-3 ``                                                   |
| [`4b1b3538`](https://github.com/NixOS/nixpkgs/commit/4b1b3538ccd08be1b46c2e00ac669c93adfd1401) | `` immich: 1.138.1 -> 1.140.1 ``                                                        |
| [`d2500226`](https://github.com/NixOS/nixpkgs/commit/d2500226b2ec4b321bc7b5573d88070de17609b4) | `` lunatask: 2.1.5 -> 2.1.6 ``                                                          |
| [`25020b83`](https://github.com/NixOS/nixpkgs/commit/25020b836288125d42486effd6b25d5d177b0f8e) | `` LycheeSlicer: fix missing libxshmfence ``                                            |
| [`5e9bdf92`](https://github.com/NixOS/nixpkgs/commit/5e9bdf922f940ab35c8c6fe28d6ff00006a9ed80) | `` tageditor: switch to using Qt6 ``                                                    |
| [`acfd355f`](https://github.com/NixOS/nixpkgs/commit/acfd355f30125c6e1fb3e03ad802b55cf96c9355) | `` opkssh: 0.8.0 -> 0.9.0 ``                                                            |
| [`f036a585`](https://github.com/NixOS/nixpkgs/commit/f036a585e7cb9ef80bfb1241755f9bc748444f29) | `` opkssh: 0.7.0 -> 0.8.0 ``                                                            |
| [`4999a074`](https://github.com/NixOS/nixpkgs/commit/4999a074b5756b403352b9b1f177332e2d3249c6) | `` opkssh: 0.6.1 -> 0.7.0 ``                                                            |
| [`85e2a8bc`](https://github.com/NixOS/nixpkgs/commit/85e2a8bcb9fd1433b3f0a91cb6a57bae6ef99758) | `` linuxPackages.rtw88: 0-unstable-2025-07-13 -> 0-unstable-2025-08-09 ``               |
| [`6f997051`](https://github.com/NixOS/nixpkgs/commit/6f9970510d797e30ee354355252d0863daa84fdd) | `` linuxPackages.rtw88: 0-unstable-2025-06-26 -> 0-unstable-2025-07-13 ``               |
| [`1dd839b5`](https://github.com/NixOS/nixpkgs/commit/1dd839b56e67747f8c76edd9ff4d28fb53ed4d1f) | `` linuxPackages.rtw88: 0-unstable-2025-05-08 -> 0-unstable-2025-06-26 ``               |
| [`c5172b8e`](https://github.com/NixOS/nixpkgs/commit/c5172b8eb8f877bc1bd7162f4b0ed19613392c75) | `` vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.29.2 -> 0.29.3 ``                   |
| [`6a692d3d`](https://github.com/NixOS/nixpkgs/commit/6a692d3dd1c2e5cf3543e7a0424e2ed34b909ce8) | `` slimevr: 0.16.0 -> 0.16.2 ``                                                         |