### PR TITLE
chore(flake/nur): `ada336d5` -> `1c80e034`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757308472,
-        "narHash": "sha256-cpOb2XZo6BsOcyA8KOs9XDXo4V4kpMIx5vhS4s/eXoU=",
+        "lastModified": 1757321609,
+        "narHash": "sha256-A4du+LQpHlOOYTSb6ou5o7lqAHbj5uDP/m9TzmPbRyE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ada336d53a82948493059ff14c187935eca08e7a",
+        "rev": "1c80e034216cb6bf356ac431020ef62f4975c5c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1c80e034`](https://github.com/nix-community/NUR/commit/1c80e034216cb6bf356ac431020ef62f4975c5c4) | `` automatic update `` |
| [`e19fd491`](https://github.com/nix-community/NUR/commit/e19fd491c4e291af05d149c00609329b1210ec28) | `` automatic update `` |
| [`a3903d01`](https://github.com/nix-community/NUR/commit/a3903d0122b8b33feb0894e38c68807c7905ebfd) | `` automatic update `` |
| [`d3366717`](https://github.com/nix-community/NUR/commit/d33667172bc065aba5b81a9f7149f8d035a34b5b) | `` automatic update `` |
| [`a01800a2`](https://github.com/nix-community/NUR/commit/a01800a2eda52d63cec98078f7cb1d9b96a3e6b6) | `` automatic update `` |
| [`a2dda0d4`](https://github.com/nix-community/NUR/commit/a2dda0d432fe67d20016ae35e2ca5fcbdbbd3fe4) | `` automatic update `` |
| [`46040913`](https://github.com/nix-community/NUR/commit/460409132a6159e9aaf19b55c7e23f2c5b647641) | `` automatic update `` |
| [`bb70f2f4`](https://github.com/nix-community/NUR/commit/bb70f2f42742c5eee06b4574fc913cab956d4fa2) | `` automatic update `` |