### PR TITLE
chore(flake/chaotic): `08bff060` -> `dc4ba8b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1757267471,
-        "narHash": "sha256-ThyzQzi0uQn5Ui8jFRcjpWOWpjX00utBegHhMfBKyZE=",
+        "lastModified": 1757332942,
+        "narHash": "sha256-tew9nur/P2qC08OgvaMMLdIq+rD539C+GloCQYwi26o=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "08bff060191426d82e0cb95fc6a328e632087744",
+        "rev": "dc4ba8b14671326b3cad2652d8028d3379b675bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                   |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`dc4ba8b1`](https://github.com/chaotic-cx/nyx/commit/dc4ba8b14671326b3cad2652d8028d3379b675bb) | `` proton-cachyos_x86_64_v{2,4}: init at 10.0.20250905 `` |
| [`24ee0dd2`](https://github.com/chaotic-cx/nyx/commit/24ee0dd25528c809250782f456ad39585b773d44) | `` failures: update aarch64-darwin ``                     |
| [`6ce91909`](https://github.com/chaotic-cx/nyx/commit/6ce91909eb3ef6ece9ab2ed24fc69928883c5b68) | `` failures: update aarch64-linux ``                      |