### PR TITLE
chore(flake/nur): `1c80e034` -> `77f16cb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757321609,
-        "narHash": "sha256-A4du+LQpHlOOYTSb6ou5o7lqAHbj5uDP/m9TzmPbRyE=",
+        "lastModified": 1757335911,
+        "narHash": "sha256-SlWCYj5HKEztKQkDKwXp1I3gZp1jdBzRsZSc019F9Qs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1c80e034216cb6bf356ac431020ef62f4975c5c4",
+        "rev": "77f16cb22eed7b13ffe53d4331456eb2d6d4f4da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`77f16cb2`](https://github.com/nix-community/NUR/commit/77f16cb22eed7b13ffe53d4331456eb2d6d4f4da) | `` automatic update `` |
| [`637d0527`](https://github.com/nix-community/NUR/commit/637d052727a923852698e5f06a71ec22a9112778) | `` automatic update `` |
| [`2dc9f17b`](https://github.com/nix-community/NUR/commit/2dc9f17b0811b6d02af5a59ea3d5b320b0cc940d) | `` automatic update `` |
| [`cb6a6cc6`](https://github.com/nix-community/NUR/commit/cb6a6cc67424653e0f049f8f2cfea874477d64b6) | `` automatic update `` |