### PR TITLE
chore(flake/nur): `77f16cb2` -> `2e76fc66`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757335911,
-        "narHash": "sha256-SlWCYj5HKEztKQkDKwXp1I3gZp1jdBzRsZSc019F9Qs=",
+        "lastModified": 1757344511,
+        "narHash": "sha256-I22Dl7Xlts2e2d3bwG+FnJnPNl10hQd873Zy5838RUQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "77f16cb22eed7b13ffe53d4331456eb2d6d4f4da",
+        "rev": "2e76fc668bae47086f9d99165e3fc0c3ba3efa68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2e76fc66`](https://github.com/nix-community/NUR/commit/2e76fc668bae47086f9d99165e3fc0c3ba3efa68) | `` automatic update `` |
| [`5bdc1c0f`](https://github.com/nix-community/NUR/commit/5bdc1c0f554e4f2f53ab3ebf25e3585946b6a486) | `` automatic update `` |
| [`544ae959`](https://github.com/nix-community/NUR/commit/544ae9596436eee03ac860456fd97e586de18957) | `` automatic update `` |
| [`490dd18d`](https://github.com/nix-community/NUR/commit/490dd18d4d1fb6fbde3ef5ae55887e2307ce6505) | `` automatic update `` |