### PR TITLE
chore(flake/nixpkgs): `092c565d` -> `9d1fa9fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1757244434,
-        "narHash": "sha256-AeqTqY0Y95K1Fgs6wuT1LafBNcmKxcOkWnm4alD9pqM=",
+        "lastModified": 1757341549,
+        "narHash": "sha256-fRnT+bwP1sB6ne7BLw4aXkVYjr+QCZZ+e4MhbokHyd4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "092c565d333be1e17b4779ac22104338941d913f",
+        "rev": "9d1fa9fa266631335618373f8faad570df6f9ede",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`9d1fa9fa`](https://github.com/NixOS/nixpkgs/commit/9d1fa9fa266631335618373f8faad570df6f9ede) | `` llvmPackages_git: 22.0.0-unstable-2025-08-31 -> 22.0.0-unstable-2025-09-07 ``       |
| [`2fbedb94`](https://github.com/NixOS/nixpkgs/commit/2fbedb9402972f76c8eb6221a88db7ba073df8fc) | `` ci: have `eval.full` return the report as displayed in CI ``                        |
| [`4c4752e9`](https://github.com/NixOS/nixpkgs/commit/4c4752e9a3e0efe8c48a3b88de021167b9102d97) | `` postgresqlPackages.pg_cron: 1.6.6 -> 1.6.7 ``                                       |
| [`447bde70`](https://github.com/NixOS/nixpkgs/commit/447bde708ac622865b782d5c07a415143b7fe556) | `` ollama: 0.11.7 -> 0.11.10 ``                                                        |
| [`5fffc521`](https://github.com/NixOS/nixpkgs/commit/5fffc5210850b389a0fed0a13bba74831827e7bc) | `` ollama: 0.11.4 -> 0.11.7 ``                                                         |
| [`36c667d9`](https://github.com/NixOS/nixpkgs/commit/36c667d9f420b378b9e0a91a2cc996705e20a680) | `` build(deps): bump actions/github-script from 7.0.1 to 8.0.0 ``                      |
| [`0fbe2226`](https://github.com/NixOS/nixpkgs/commit/0fbe22263428ed54ecb21a78358b2a8305f2a284) | `` build(deps): bump actions/labeler from 5.0.0 to 6.0.1 ``                            |
| [`ec3f65fd`](https://github.com/NixOS/nixpkgs/commit/ec3f65fdfdbb193efa8b8844636bd2851154faff) | `` build(deps): bump cachix/install-nix-action from 31.6.0 to 31.6.1 ``                |
| [`8d928d1c`](https://github.com/NixOS/nixpkgs/commit/8d928d1ca5bb65f2f1c31d8cc237736f67e12c6d) | `` linuxKernel.kernels.linux_zen: 6.16.3 -> 6.16.5 ``                                  |
| [`dbdbe34c`](https://github.com/NixOS/nixpkgs/commit/dbdbe34c37bad41a9572bd3ef8c6ccde88171791) | `` maintainers: remove federicoschonborn ``                                            |
| [`b17678fb`](https://github.com/NixOS/nixpkgs/commit/b17678fbbc0475e604784d457ec33946fe0c6f01) | `` xdvdfs-cli: remove federicoschonborn from maintainers ``                            |
| [`0b0b3ea3`](https://github.com/NixOS/nixpkgs/commit/0b0b3ea36b38cbd6b8a774ee780dd1ba8dc1a0aa) | `` surgescript: remove federicoschonborn from maintainers ``                           |
| [`1c93e8db`](https://github.com/NixOS/nixpkgs/commit/1c93e8db76b02ad072027c665b3335defba4edd3) | `` opensurge: remove federicoschonborn from maintainers ``                             |
| [`3db90216`](https://github.com/NixOS/nixpkgs/commit/3db90216b7d4e99d91646a7c3e0a7bee9dedc88b) | `` hugo: remove federicoschonborn from maintainers ``                                  |
| [`5d4b8f0d`](https://github.com/NixOS/nixpkgs/commit/5d4b8f0d3046a363097421648719041e8c3688b6) | `` hedgemodmanager: remove federicoschonborn from maintainers ``                       |
| [`3b0ebbb8`](https://github.com/NixOS/nixpkgs/commit/3b0ebbb85d90c59ba9264ca7b04d56f4f4cfd12d) | `` bluejay: remove federicoschonborn from maintainers ``                               |
| [`229d4b7e`](https://github.com/NixOS/nixpkgs/commit/229d4b7ec071e1d927f7c7ee07ecad627012c3ba) | `` rundeck: 5.14.1 -> 5.15.0 ``                                                        |
| [`f02caa91`](https://github.com/NixOS/nixpkgs/commit/f02caa915c131c199c0c93d7ba45e57aa0c4e0fc) | `` tauno-monitor: 0.2.16 -> 0.2.17 ``                                                  |
| [`bf449eb9`](https://github.com/NixOS/nixpkgs/commit/bf449eb949b017b7702060dfd8f6c6a6ce4957e8) | `` zipline: 4.2.3 -> 4.3.0 ``                                                          |
| [`a67c6e3a`](https://github.com/NixOS/nixpkgs/commit/a67c6e3adc18e1f36d050b9792c29c9daadb5bd4) | `` paretosecurity: 0.3.2 -> 0.3.3 ``                                                   |
| [`19ec2482`](https://github.com/NixOS/nixpkgs/commit/19ec248277b375437d72dd1ba989b75b7e43ab3e) | `` lixPackageSets.lix_2_93: 2.93.2 -> 2.93.3 ``                                        |
| [`f6e74417`](https://github.com/NixOS/nixpkgs/commit/f6e74417eb4654c0bc27d2f035c295fcd96d5a1d) | `` asterisk: 20.15.1 -> 20.15.2 ``                                                     |
| [`2e4f8874`](https://github.com/NixOS/nixpkgs/commit/2e4f8874b66f62e667ed19510929695b70630a29) | `` teamviewer: 15.68.5 -> 15.69.4 ``                                                   |
| [`dfbd1cae`](https://github.com/NixOS/nixpkgs/commit/dfbd1caecaf0583ec728fc90cb806b11a6faccef) | `` tika: apply patch for CVE-2025-54988 ``                                             |
| [`c704772a`](https://github.com/NixOS/nixpkgs/commit/c704772a52b9ca01d05af4ecb19a69aea567e46c) | `` udisks2: 2.10.1 -> 2.10.2 ``                                                        |
| [`b3e4ad0f`](https://github.com/NixOS/nixpkgs/commit/b3e4ad0f551014df9ebd443b16f6cbf3e120cbfc) | `` [BACKPORT 25.05] python3Packages.crewai: init at 0.175.0 ``                         |
| [`9a0dee2e`](https://github.com/NixOS/nixpkgs/commit/9a0dee2e9c26c8288da18b0e975299fd6f314515) | `` nixos/nextcloud: Pass OC_PASS and NC_PASS environment variables to nextcloud-occ `` |