### PR TITLE
chore(flake/nur): `9009f3b9` -> `759e9f7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757345656,
-        "narHash": "sha256-ZvNfl8pu1iwJW0uUZKV8XHIM7JqJxoZX+EqzjayMDqU=",
+        "lastModified": 1757362860,
+        "narHash": "sha256-l1O6ElJg0XJoejyy3ZHE+Wk2Q3rm897NIHURzgY5wjw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9009f3b97f820b7b5c2732d423a08bb8d82d179a",
+        "rev": "759e9f7b4353971a1c087eeb44064252efb3ac3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`759e9f7b`](https://github.com/nix-community/NUR/commit/759e9f7b4353971a1c087eeb44064252efb3ac3b) | `` automatic update `` |
| [`631207a3`](https://github.com/nix-community/NUR/commit/631207a3f8d3cad9d1f45c5c5659b0b43a0c62b7) | `` automatic update `` |
| [`4ffc663c`](https://github.com/nix-community/NUR/commit/4ffc663c33c1c2c1164a58d7a2617ec4a2393f34) | `` automatic update `` |