### PR TITLE
chore(flake/nur): `759e9f7b` -> `f1d4b004`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757362860,
-        "narHash": "sha256-l1O6ElJg0XJoejyy3ZHE+Wk2Q3rm897NIHURzgY5wjw=",
+        "lastModified": 1757381067,
+        "narHash": "sha256-9PxBxzbzD/vE1EMCiOCkVhtNfQtG3jgHV6zmFXbqS5w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "759e9f7b4353971a1c087eeb44064252efb3ac3b",
+        "rev": "f1d4b004121e16a5d1add7bcc0fc2967dc4795e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1d4b004`](https://github.com/nix-community/NUR/commit/f1d4b004121e16a5d1add7bcc0fc2967dc4795e7) | `` automatic update `` |
| [`6f3d2aea`](https://github.com/nix-community/NUR/commit/6f3d2aeab187e646f54780f71efa77dbd175a5e3) | `` automatic update `` |
| [`6291367b`](https://github.com/nix-community/NUR/commit/6291367b23c38821ca01c64f93c11c5cb56748ad) | `` automatic update `` |