### PR TITLE
chore(flake/nur): `f1d4b004` -> `a7c281cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757381067,
-        "narHash": "sha256-9PxBxzbzD/vE1EMCiOCkVhtNfQtG3jgHV6zmFXbqS5w=",
+        "lastModified": 1757388300,
+        "narHash": "sha256-Q6Iz1+CY6HE/ZIjXzVmP+putUn/Kc/LmyDstLns8t7w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f1d4b004121e16a5d1add7bcc0fc2967dc4795e7",
+        "rev": "a7c281cff81efbf0a7c13518e35210d449515ce5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a7c281cf`](https://github.com/nix-community/NUR/commit/a7c281cff81efbf0a7c13518e35210d449515ce5) | `` automatic update `` |
| [`929197a1`](https://github.com/nix-community/NUR/commit/929197a1f0d1dd46ba07e624d884c07198b1f550) | `` automatic update `` |
| [`b67dcc3c`](https://github.com/nix-community/NUR/commit/b67dcc3c9d4c4b1edca874a26b5f5ba7c2b513ef) | `` automatic update `` |
| [`de6a9f1b`](https://github.com/nix-community/NUR/commit/de6a9f1bc390793447e672834201be4110246be8) | `` automatic update `` |
| [`612c0200`](https://github.com/nix-community/NUR/commit/612c0200df6f2ca6a1c06454f11d45e4eab78398) | `` automatic update `` |