### PR TITLE
chore(flake/nur): `a7c281cf` -> `cca9d159`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757388300,
-        "narHash": "sha256-Q6Iz1+CY6HE/ZIjXzVmP+putUn/Kc/LmyDstLns8t7w=",
+        "lastModified": 1757399382,
+        "narHash": "sha256-ZsSUkHMkjHoFnxqeXYApZUg/WIm3bBjGuRuvF4vmpQA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a7c281cff81efbf0a7c13518e35210d449515ce5",
+        "rev": "cca9d1592e280f66f5f840c0b5cc66d37fbd7e91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cca9d159`](https://github.com/nix-community/NUR/commit/cca9d1592e280f66f5f840c0b5cc66d37fbd7e91) | `` automatic update `` |
| [`a41e365d`](https://github.com/nix-community/NUR/commit/a41e365dbf1db17c04171e23ac17f3be5618930b) | `` automatic update `` |
| [`b00c1df9`](https://github.com/nix-community/NUR/commit/b00c1df989806aab3f604658a36103cff5d218d2) | `` automatic update `` |
| [`a6acf981`](https://github.com/nix-community/NUR/commit/a6acf9812b755b0e82b1d9d5e7ef03b719d97c46) | `` automatic update `` |
| [`4ddc7fd8`](https://github.com/nix-community/NUR/commit/4ddc7fd8b67af954a529a3cf3023394a25d330bc) | `` automatic update `` |
| [`897ae325`](https://github.com/nix-community/NUR/commit/897ae325613d8141b210513912f53c9988d06a1e) | `` automatic update `` |
| [`b8416f45`](https://github.com/nix-community/NUR/commit/b8416f45ad2bd7ad174f196139a2581f069fa03e) | `` automatic update `` |
| [`e18c94d0`](https://github.com/nix-community/NUR/commit/e18c94d051c60c72b23481535ba6bf5b34bb6c60) | `` automatic update `` |
| [`eca627bd`](https://github.com/nix-community/NUR/commit/eca627bd7a7fe195c2b125eb10393ed71e11c78d) | `` automatic update `` |