### PR TITLE
chore(flake/nur): `c548e146` -> `4f5000d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757409189,
-        "narHash": "sha256-pLVU3q9mhCYqUU/N2HkJkn0aV7+7if/jvry02rFmAFw=",
+        "lastModified": 1757413569,
+        "narHash": "sha256-XORw3KEQfa40MRcp5bMatTZ98nXUMMFZe+Yo4WlB74w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c548e1468535e330663efe392247ea7604210138",
+        "rev": "4f5000d7fed2bc4574552ce27bb22b7c97f53039",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f5000d7`](https://github.com/nix-community/NUR/commit/4f5000d7fed2bc4574552ce27bb22b7c97f53039) | `` automatic update `` |
| [`6cbe18c8`](https://github.com/nix-community/NUR/commit/6cbe18c86febbb94970ccc2b7c4649131c5c9509) | `` automatic update `` |