### PR TITLE
chore(flake/chaotic): `e32807b0` -> `0c5dbb01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1757420626,
-        "narHash": "sha256-yO5rbx4+x6XfieilZvQkT04DHfEkKfzDiEWe8/yUwrw=",
+        "lastModified": 1757436326,
+        "narHash": "sha256-V4w0k9CZ9G+BidPI9LM8T6EbbHkrbpbacZKkPpZQeIg=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "e32807b0451ad68d4263778690a2837f702d4417",
+        "rev": "0c5dbb01f3d493918d36e21768339e9f6c949057",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                               |
| ----------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`0c5dbb01`](https://github.com/chaotic-cx/nyx/commit/0c5dbb01f3d493918d36e21768339e9f6c949057) | `` linux-cachyos-lts: init (#1186) `` |
| [`07a4b435`](https://github.com/chaotic-cx/nyx/commit/07a4b435ee8a11ff1bf175e51d64dfcb7b1dc58d) | `` failures: update aarch64-darwin `` |
| [`1c7975d4`](https://github.com/chaotic-cx/nyx/commit/1c7975d49b8f6091a651d432f3546563205e4835) | `` failures: update aarch64-linux ``  |