### PR TITLE
chore(flake/nixpkgs): `9d1fa9fa` -> `d179d77c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1757341549,
-        "narHash": "sha256-fRnT+bwP1sB6ne7BLw4aXkVYjr+QCZZ+e4MhbokHyd4=",
+        "lastModified": 1757408970,
+        "narHash": "sha256-aSgK4BLNFFGvDTNKPeB28lVXYqVn8RdyXDNAvgGq+k0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9d1fa9fa266631335618373f8faad570df6f9ede",
+        "rev": "d179d77c139e0a3f5c416477f7747e9d6b7ec315",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`8bb3b72d`](https://github.com/NixOS/nixpkgs/commit/8bb3b72d538728af7f30e63bf34bca7e5fe04de0) | `` ci/eval/README.md: adjust wording ``                                        |
| [`ebe9db65`](https://github.com/NixOS/nixpkgs/commit/ebe9db6538e05e82b06179500ee757a54eb17b0e) | `` ci/github-script/labels: keep "needs reviewer" if only automated reviews `` |
| [`e21d8c34`](https://github.com/NixOS/nixpkgs/commit/e21d8c34524cfa1178bab30c65fedbc2ef9ae0cc) | `` yt-dlp: 2025.08.27 -> 2025.09.05 ``                                         |
| [`3932819b`](https://github.com/NixOS/nixpkgs/commit/3932819b0a33eea9b2e4961f4390ec363f7cb3db) | `` ed-odyssey-materials-helper: 2.243 -> 2.247 ``                              |
| [`b9c56653`](https://github.com/NixOS/nixpkgs/commit/b9c56653a445975de76855f374f7e1b746e350e2) | `` nodejs_20: 20.19.4 -> 20.19.5 ``                                            |
| [`bc8fcb18`](https://github.com/NixOS/nixpkgs/commit/bc8fcb18875992ae028642415e4f25c520bc5ead) | `` anytype: mark as broken on darwin ``                                        |
| [`3fb3c0ac`](https://github.com/NixOS/nixpkgs/commit/3fb3c0acb38340e168bcb76c35df11091076c3c0) | `` anytype: 0.46.5 -> 0.49.2 ``                                                |
| [`3364bfae`](https://github.com/NixOS/nixpkgs/commit/3364bfaef298c421d287b1be91b39f9505b38206) | `` anytype-heart: 0.40.21 -> 0.43.0-rc02 ``                                    |
| [`c513e8d0`](https://github.com/NixOS/nixpkgs/commit/c513e8d0583e4c79d8ad1bf606895ad7be6ca91b) | `` tantivy-go: 1.0.1 -> 1.0.4 ``                                               |
| [`23a6e07e`](https://github.com/NixOS/nixpkgs/commit/23a6e07e3f4c3853c7cf23f7d3c4f923b82aed68) | `` pgadmin: 9.7 -> 9.8 ``                                                      |
| [`18b358c9`](https://github.com/NixOS/nixpkgs/commit/18b358c97729b55b6790553918d098a60275d8a2) | `` pgadmin: 9.6 -> 9.7 ``                                                      |
| [`62a639d5`](https://github.com/NixOS/nixpkgs/commit/62a639d55519cae2a2f725d64dbdfbd97c7b52f4) | `` pgadmin4: move to by-name ``                                                |
| [`dfe6a4a4`](https://github.com/NixOS/nixpkgs/commit/dfe6a4a4ff10a4f138843edc70448275ee343b35) | `` pgadmin: 9.5 -> 9.6 ``                                                      |
| [`1d64478f`](https://github.com/NixOS/nixpkgs/commit/1d64478f56162fd0881c66910881f1167e154568) | `` pgadmin: 9.4 -> 9.5 ``                                                      |
| [`86b53e28`](https://github.com/NixOS/nixpkgs/commit/86b53e28480ccb963eacebdebd8764b37f32c23e) | `` pgadmin: 9.3 -> 9.4 ``                                                      |
| [`4c4905ec`](https://github.com/NixOS/nixpkgs/commit/4c4905ecea9d044bd9d8e2c0cb7f1a0501a4397d) | `` lmstudio: 0.3.24.6 -> 0.3.25.2 ``                                           |