### PR TITLE
chore(flake/nur): `2ec53c79` -> `c0d9b803`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757432460,
-        "narHash": "sha256-4Uy03lH4noSh02yx5bEMRCrPTnu5a090t+RrZWf+nYI=",
+        "lastModified": 1757450710,
+        "narHash": "sha256-tVL/OtgAP+1jqVvSU0a/0tigIYb13lBoQNTNP8KclZQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2ec53c798a5c3705903009612df3f5901ee16145",
+        "rev": "c0d9b80334b67dd702f0383d4c64401418cc5ce1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c0d9b803`](https://github.com/nix-community/NUR/commit/c0d9b80334b67dd702f0383d4c64401418cc5ce1) | `` automatic update `` |
| [`4a052ccf`](https://github.com/nix-community/NUR/commit/4a052ccf5c288af61330774340f514db05efb3f1) | `` automatic update `` |
| [`10a9777a`](https://github.com/nix-community/NUR/commit/10a9777a8e7cd7a2c78fc83cbcb8f19c40a4937f) | `` automatic update `` |
| [`ff5440a9`](https://github.com/nix-community/NUR/commit/ff5440a9518347fd771ef127dd7cc7ba93fca961) | `` automatic update `` |