### PR TITLE
chore(flake/nur): `c0d9b803` -> `2b84a186`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757450710,
-        "narHash": "sha256-tVL/OtgAP+1jqVvSU0a/0tigIYb13lBoQNTNP8KclZQ=",
+        "lastModified": 1757468074,
+        "narHash": "sha256-48ryC9uBExCG+3Wza6TqWJICx53n3JGSl9xySmosu98=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c0d9b80334b67dd702f0383d4c64401418cc5ce1",
+        "rev": "2b84a1862584dccb22b0bbab3aa73776ec97ad74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2b84a186`](https://github.com/nix-community/NUR/commit/2b84a1862584dccb22b0bbab3aa73776ec97ad74) | `` automatic update `` |
| [`94ddd87b`](https://github.com/nix-community/NUR/commit/94ddd87b6423bc58a775fa6bc10c9459b1fc372e) | `` automatic update `` |