### PR TITLE
chore(flake/nur): `2b84a186` -> `d0c3a61b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757468074,
-        "narHash": "sha256-48ryC9uBExCG+3Wza6TqWJICx53n3JGSl9xySmosu98=",
+        "lastModified": 1757474833,
+        "narHash": "sha256-CbYt3mvSZUcKybZ4Zl6LT8cOLdjfgBY0MRjkiZylvmk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2b84a1862584dccb22b0bbab3aa73776ec97ad74",
+        "rev": "d0c3a61bff5b80431dac6fcf26e0967d1ec744ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d0c3a61b`](https://github.com/nix-community/NUR/commit/d0c3a61bff5b80431dac6fcf26e0967d1ec744ff) | `` automatic update `` |
| [`333227f5`](https://github.com/nix-community/NUR/commit/333227f5b1b5c6d114cf0afb07a3cdafc4031337) | `` automatic update `` |
| [`3376cd7f`](https://github.com/nix-community/NUR/commit/3376cd7f2721c01a4186ff0ff861c0d3e991e4a9) | `` automatic update `` |
| [`514bec0b`](https://github.com/nix-community/NUR/commit/514bec0bf8182024ddc4719c3ece9d4fb7631f09) | `` automatic update `` |
| [`84cea18b`](https://github.com/nix-community/NUR/commit/84cea18b9ab5fc4f4dd862e6ee5c5e8980eb7eb3) | `` automatic update `` |
| [`ee994b80`](https://github.com/nix-community/NUR/commit/ee994b8087a6ffe31110b4184b9ee471b8a0d068) | `` automatic update `` |