### PR TITLE
chore(flake/nur): `d0c3a61b` -> `9bfd84d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757474833,
-        "narHash": "sha256-CbYt3mvSZUcKybZ4Zl6LT8cOLdjfgBY0MRjkiZylvmk=",
+        "lastModified": 1757483776,
+        "narHash": "sha256-ex8LlcYW4QNkT+vXRIZyCbY5ziokkZ081PyCKwPg/0M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d0c3a61bff5b80431dac6fcf26e0967d1ec744ff",
+        "rev": "9bfd84d21cab10b94b460a4575a3bf90ac618b4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9bfd84d2`](https://github.com/nix-community/NUR/commit/9bfd84d21cab10b94b460a4575a3bf90ac618b4c) | `` automatic update `` |
| [`93eb1798`](https://github.com/nix-community/NUR/commit/93eb17983401759ad8f12f4443156c9681c4d2eb) | `` automatic update `` |
| [`c819001d`](https://github.com/nix-community/NUR/commit/c819001dfb3d86e71c1e0d018320769ad6480d42) | `` automatic update `` |
| [`25144181`](https://github.com/nix-community/NUR/commit/251441815f20f4ce7a46e25ae62bf902cfae690c) | `` automatic update `` |