### PR TITLE
chore(flake/nur): `9bfd84d2` -> `f1064e2b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757483776,
-        "narHash": "sha256-ex8LlcYW4QNkT+vXRIZyCbY5ziokkZ081PyCKwPg/0M=",
+        "lastModified": 1757494247,
+        "narHash": "sha256-YvDpL6cLHRzR2RA+nUFIkEQ4xY9WeWLjfZnip7SOXcI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9bfd84d21cab10b94b460a4575a3bf90ac618b4c",
+        "rev": "f1064e2b71200acc0f3d684cb4068cad5423dc34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1064e2b`](https://github.com/nix-community/NUR/commit/f1064e2b71200acc0f3d684cb4068cad5423dc34) | `` automatic update `` |
| [`8bf6a7ba`](https://github.com/nix-community/NUR/commit/8bf6a7ba9cbe7a3b21a0452b1bffadc6a1635739) | `` automatic update `` |