### PR TITLE
chore(flake/disko): `c8a0e78d` -> `146f45be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1757255839,
-        "narHash": "sha256-XH33B1X888Xc/xEXhF1RPq/kzKElM0D5C9N6YdvOvIc=",
+        "lastModified": 1757508292,
+        "narHash": "sha256-7lVWL5bC6xBIMWWDal41LlGAG+9u2zUorqo3QCUL4p4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "c8a0e78d86b12ea67be6ed0f7cae7f9bfabae75a",
+        "rev": "146f45bee02b8bd88812cfce6ffc0f933788875a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                            |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`146f45be`](https://github.com/nix-community/disko/commit/146f45bee02b8bd88812cfce6ffc0f933788875a) | `` feat: add flake-parts module `` |