### PR TITLE
chore(flake/nur): `f1064e2b` -> `1c88ffb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757494247,
-        "narHash": "sha256-YvDpL6cLHRzR2RA+nUFIkEQ4xY9WeWLjfZnip7SOXcI=",
+        "lastModified": 1757503472,
+        "narHash": "sha256-VhLleHb0EcsgPcYpRiI22mWdEf1sO6tc5J8ypyYy2gY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f1064e2b71200acc0f3d684cb4068cad5423dc34",
+        "rev": "1c88ffb1b4eb2275860ea54101c1109993e81ca6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1c88ffb1`](https://github.com/nix-community/NUR/commit/1c88ffb1b4eb2275860ea54101c1109993e81ca6) | `` automatic update `` |
| [`356f3a0c`](https://github.com/nix-community/NUR/commit/356f3a0c8a844ca237d144bf8a58cf8ad706cf16) | `` automatic update `` |
| [`cc9ad809`](https://github.com/nix-community/NUR/commit/cc9ad80961d9ea8e3f157e17771913efe1fc676b) | `` automatic update `` |