### PR TITLE
chore(flake/nur): `1c88ffb1` -> `97efd62e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757503472,
-        "narHash": "sha256-VhLleHb0EcsgPcYpRiI22mWdEf1sO6tc5J8ypyYy2gY=",
+        "lastModified": 1757515664,
+        "narHash": "sha256-/fxYDIlhmQfXomeg2SMR7beZvdlq9u1p9hNQptiYd8w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1c88ffb1b4eb2275860ea54101c1109993e81ca6",
+        "rev": "97efd62e7b2cd2dadf610e0c5d350e7129e203d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`97efd62e`](https://github.com/nix-community/NUR/commit/97efd62e7b2cd2dadf610e0c5d350e7129e203d0) | `` automatic update `` |
| [`ff560ea4`](https://github.com/nix-community/NUR/commit/ff560ea4f649277b2a85f0f9cff57a2305dfa292) | `` automatic update `` |
| [`d719cfd1`](https://github.com/nix-community/NUR/commit/d719cfd11348193d24596b1877925bd5d42e5020) | `` automatic update `` |
| [`340373bf`](https://github.com/nix-community/NUR/commit/340373bfc192ea69ee1a3c452d45e080db2c875a) | `` automatic update `` |