### PR TITLE
chore(flake/nur): `97efd62e` -> `8c3d56d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757515664,
-        "narHash": "sha256-/fxYDIlhmQfXomeg2SMR7beZvdlq9u1p9hNQptiYd8w=",
+        "lastModified": 1757526419,
+        "narHash": "sha256-5HaMkE+5un3cEGC++HxYK+I3kbCd3i58KQTJfLTyqns=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "97efd62e7b2cd2dadf610e0c5d350e7129e203d0",
+        "rev": "8c3d56d5eb01a6c8f79baeec9d91f1f5159836ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8c3d56d5`](https://github.com/nix-community/NUR/commit/8c3d56d5eb01a6c8f79baeec9d91f1f5159836ec) | `` automatic update `` |
| [`86baead0`](https://github.com/nix-community/NUR/commit/86baead033f925f8ae5cab89311ea46f970015e2) | `` automatic update `` |