### PR TITLE
chore(flake/nur): `8c3d56d5` -> `26af345a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757526419,
-        "narHash": "sha256-5HaMkE+5un3cEGC++HxYK+I3kbCd3i58KQTJfLTyqns=",
+        "lastModified": 1757537166,
+        "narHash": "sha256-xSDRr+oyZ7GMDViX4Spj6+ouEFptz5KIhJ/pv5gIYLE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8c3d56d5eb01a6c8f79baeec9d91f1f5159836ec",
+        "rev": "26af345a615eb8739a0ee9f98822e8b11a188821",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`26af345a`](https://github.com/nix-community/NUR/commit/26af345a615eb8739a0ee9f98822e8b11a188821) | `` automatic update `` |
| [`07572ad4`](https://github.com/nix-community/NUR/commit/07572ad40c2fbb494861c29e97156cf8464dd7fc) | `` automatic update `` |
| [`419cae6b`](https://github.com/nix-community/NUR/commit/419cae6b649eedeab52d989077e2bb121d625576) | `` automatic update `` |
| [`6267abb7`](https://github.com/nix-community/NUR/commit/6267abb748a40a91703be07e92c2b34edb2373ae) | `` automatic update `` |