### PR TITLE
chore(flake/nur): `d93d53a6` -> `cb79d21a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757553834,
-        "narHash": "sha256-abUawydrTGhYl5czEOOyfJQPVTw/KM/mrNJcQvtDMbE=",
+        "lastModified": 1757561652,
+        "narHash": "sha256-yTOFexhJJNh4kZgM85fJambzZVG3tTDDWoSraaD/HTU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d93d53a6a8691fdedacb77e75054b8a0f08486e6",
+        "rev": "cb79d21a434c16b351b36acbcc0baa0c112dcad1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cb79d21a`](https://github.com/nix-community/NUR/commit/cb79d21a434c16b351b36acbcc0baa0c112dcad1) | `` automatic update `` |
| [`53683e2c`](https://github.com/nix-community/NUR/commit/53683e2c5619a84dd9b877f65ce5a4fdabb52934) | `` automatic update `` |
| [`b87bb2b5`](https://github.com/nix-community/NUR/commit/b87bb2b55332599c58d03403fe57ab64d766aef4) | `` automatic update `` |
| [`b200f25b`](https://github.com/nix-community/NUR/commit/b200f25bcead4a57f6580b5f293487ba374be5a2) | `` automatic update `` |