### PR TITLE
chore(flake/nur): `cb79d21a` -> `c588a3e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757561652,
-        "narHash": "sha256-yTOFexhJJNh4kZgM85fJambzZVG3tTDDWoSraaD/HTU=",
+        "lastModified": 1757568702,
+        "narHash": "sha256-SySDHyKaz2KblzY7x0SJFdQCplWmRI4r/25B8p52/gU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cb79d21a434c16b351b36acbcc0baa0c112dcad1",
+        "rev": "c588a3e91eecc540120b51bf13db6700e692da01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c588a3e9`](https://github.com/nix-community/NUR/commit/c588a3e91eecc540120b51bf13db6700e692da01) | `` automatic update `` |
| [`88d5e3ee`](https://github.com/nix-community/NUR/commit/88d5e3eed7558fc6d8894ee965d6158e988f2ed6) | `` automatic update `` |
| [`ed9b9bb5`](https://github.com/nix-community/NUR/commit/ed9b9bb5839f34ccd12d61e68977a7240922c742) | `` automatic update `` |