### PR TITLE
chore(flake/nur): `c588a3e9` -> `9c399f8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757568702,
-        "narHash": "sha256-SySDHyKaz2KblzY7x0SJFdQCplWmRI4r/25B8p52/gU=",
+        "lastModified": 1757574122,
+        "narHash": "sha256-WVrkLJZ/lavNKTA8wjitC3FfcNCqVs/nLRqndnuNmNM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c588a3e91eecc540120b51bf13db6700e692da01",
+        "rev": "9c399f8ee99b7a5980be2f02ef20dede6bcf5224",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9c399f8e`](https://github.com/nix-community/NUR/commit/9c399f8ee99b7a5980be2f02ef20dede6bcf5224) | `` automatic update `` |
| [`44711d5f`](https://github.com/nix-community/NUR/commit/44711d5f41b2f96549521f83264190b9d93f56d6) | `` automatic update `` |