### PR TITLE
chore(flake/nur): `9c399f8e` -> `710d0433`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1757347588,
-        "narHash": "sha256-tLdkkC6XnsY9EOZW9TlpesTclELy8W7lL2ClL+nma8o=",
+        "lastModified": 1757487488,
+        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b599843bad24621dcaa5ab60dac98f9b0eb1cabe",
+        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757574122,
-        "narHash": "sha256-WVrkLJZ/lavNKTA8wjitC3FfcNCqVs/nLRqndnuNmNM=",
+        "lastModified": 1757592720,
+        "narHash": "sha256-Sb60mh6xiwdneiIvLw0g+5ONXfLr8RllQsyr/JSPfko=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c399f8ee99b7a5980be2f02ef20dede6bcf5224",
+        "rev": "710d043379588daf6ac6cca612edc5840dc666b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`710d0433`](https://github.com/nix-community/NUR/commit/710d043379588daf6ac6cca612edc5840dc666b6) | `` automatic update `` |
| [`de2c6637`](https://github.com/nix-community/NUR/commit/de2c66370b64255fa38bd8bc737f2d79dbe49480) | `` automatic update `` |
| [`a625a24a`](https://github.com/nix-community/NUR/commit/a625a24a40e4a4c21fcb7bbaa5869b0766fc0eab) | `` automatic update `` |
| [`3159cd2c`](https://github.com/nix-community/NUR/commit/3159cd2c71f38bea2114e0e273d44eef8c8c34f5) | `` automatic update `` |
| [`e343b911`](https://github.com/nix-community/NUR/commit/e343b91179bf95452460e616f76bf568dba78858) | `` automatic update `` |
| [`b486a2a4`](https://github.com/nix-community/NUR/commit/b486a2a4a639af4d2d69749f56c1b5f54f7f9d02) | `` automatic update `` |
| [`39a49ed2`](https://github.com/nix-community/NUR/commit/39a49ed27efcce59f40089ee417dd5c26a0fe944) | `` automatic update `` |