### PR TITLE
chore(flake/nur): `710d0433` -> `5f8b7da2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757592720,
-        "narHash": "sha256-Sb60mh6xiwdneiIvLw0g+5ONXfLr8RllQsyr/JSPfko=",
+        "lastModified": 1757603751,
+        "narHash": "sha256-VwRgcIBYFApi2C0RbbP6aG6TWRm0kvCcisMQxQoTxBw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "710d043379588daf6ac6cca612edc5840dc666b6",
+        "rev": "5f8b7da26191a1e82ad5a3044f140bf3bb938be1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5f8b7da2`](https://github.com/nix-community/NUR/commit/5f8b7da26191a1e82ad5a3044f140bf3bb938be1) | `` automatic update `` |
| [`4e5f0487`](https://github.com/nix-community/NUR/commit/4e5f0487a96a2cadcb75b3a95f16648b8b288b9d) | `` automatic update `` |
| [`b2d4bffa`](https://github.com/nix-community/NUR/commit/b2d4bffacb3cc7641c8af331fe79c2171cd63c5e) | `` automatic update `` |
| [`fd39c46b`](https://github.com/nix-community/NUR/commit/fd39c46ba73ea9dd03b1a8e8dcfc94577421b55f) | `` automatic update `` |
| [`f916b2bb`](https://github.com/nix-community/NUR/commit/f916b2bbde891b5697f821427fbcd686a3642f9b) | `` automatic update `` |