### PR TITLE
chore(flake/nur): `5f8b7da2` -> `7447c413`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757603751,
-        "narHash": "sha256-VwRgcIBYFApi2C0RbbP6aG6TWRm0kvCcisMQxQoTxBw=",
+        "lastModified": 1757610052,
+        "narHash": "sha256-MH/ihl4FZeqX2OlwAfCu00+gjH9rLu9IX6RrL66A4xg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5f8b7da26191a1e82ad5a3044f140bf3bb938be1",
+        "rev": "7447c41384fc7d69de00642f7e451488f4139a28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7447c413`](https://github.com/nix-community/NUR/commit/7447c41384fc7d69de00642f7e451488f4139a28) | `` automatic update `` |
| [`c41e2348`](https://github.com/nix-community/NUR/commit/c41e23488a8ba793ad982cf7aa271cf5b4f2e15f) | `` automatic update `` |
| [`86fa2e53`](https://github.com/nix-community/NUR/commit/86fa2e53940b838269b2f6fc8add62c6585edeaf) | `` automatic update `` |