### PR TITLE
chore(flake/nixpkgs): `d179d77c` -> `8cd5ce82`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1757408970,
-        "narHash": "sha256-aSgK4BLNFFGvDTNKPeB28lVXYqVn8RdyXDNAvgGq+k0=",
+        "lastModified": 1757545623,
+        "narHash": "sha256-mCxPABZ6jRjUQx3bPP4vjA68ETbPLNz9V2pk9tO7pRQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d179d77c139e0a3f5c416477f7747e9d6b7ec315",
+        "rev": "8cd5ce828d5d1d16feff37340171a98fc3bf6526",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`cd524a14`](https://github.com/NixOS/nixpkgs/commit/cd524a1429fe6b65d9823a00e8cb7a1abce41a4f) | `` fbv: 1.0b -> 1.0c ``                                                      |
| [`6c105942`](https://github.com/NixOS/nixpkgs/commit/6c105942cad57e0a4500b0195b478b3d9dfe8418) | `` ci/eval: fix local comparison with baseline ``                            |
| [`29c6f4bd`](https://github.com/NixOS/nixpkgs/commit/29c6f4bd673a8123cf66e5c909c4d61682ad726b) | `` gitlab: 18.3.1 -> 18.3.2 ``                                               |
| [`5fdfa23c`](https://github.com/NixOS/nixpkgs/commit/5fdfa23c346f6cb871d4dc151b2e25cc3cc773e1) | `` fishPlugins.aws: init at 0-unstable-2023-08-03 ``                         |
| [`7a597727`](https://github.com/NixOS/nixpkgs/commit/7a5977277e620a28ec937cb4515a7e580327d92c) | `` fishPlugins.bobthefish: 0-unstable-2023-06-16 -> 0-unstable-2024-09-24 `` |
| [`cb5d9537`](https://github.com/NixOS/nixpkgs/commit/cb5d9537372793a2b0a28325a06d4a34c4fb6a9d) | `` pnpm_10: 10.15.0 -> 10.15.1 ``                                            |
| [`5572df1a`](https://github.com/NixOS/nixpkgs/commit/5572df1ad724ac90e37609547b07002aef8c4201) | `` ddnet 19.3 -> 19.4 ``                                                     |
| [`a1ab6781`](https://github.com/NixOS/nixpkgs/commit/a1ab67810ed5701328be58ad6c3303c52ca7b200) | `` sabnzbd: 4.5.2 -> 4.5.3 ``                                                |
| [`79121895`](https://github.com/NixOS/nixpkgs/commit/79121895fe7ffb3fa3fbedf7ef0311697a7b7ddb) | `` chromium,chromedriver: 140.0.7339.80 -> 140.0.7339.127 ``                 |
| [`4eb5af09`](https://github.com/NixOS/nixpkgs/commit/4eb5af0961b3c50d10249548dc9291f28ba7e606) | `` anytype: add custom update script ``                                      |
| [`8689f86b`](https://github.com/NixOS/nixpkgs/commit/8689f86b6cb93e4b115755cbd9f3c9c7c866a1d6) | `` anytype: add changelog ``                                                 |
| [`e45cedbe`](https://github.com/NixOS/nixpkgs/commit/e45cedbedceace0d8585250aabd6a24cdfda5f81) | `` anytype: use finalAttrs ``                                                |
| [`bc25cc26`](https://github.com/NixOS/nixpkgs/commit/bc25cc26d4c06ae65e17d83e2636cf8f936c9d92) | `` anytype: add kira-bruneau as maintainer ``                                |
| [`6457a776`](https://github.com/NixOS/nixpkgs/commit/6457a776235ad031c3ff300b98227931d3668b8c) | `` anytype-heart: add changelog ``                                           |
| [`c2874070`](https://github.com/NixOS/nixpkgs/commit/c28740700ac080004998259cc12e7c81f0fec7f1) | `` anytype-heart: use finalAttrs ``                                          |
| [`19115f94`](https://github.com/NixOS/nixpkgs/commit/19115f94123d83eb323b806e2c85f0978e995b1b) | `` anytype-heart: add kira-bruneau as maintainer ``                          |
| [`de0a60ce`](https://github.com/NixOS/nixpkgs/commit/de0a60ceac0dd1c0d429cc8730d8f4ac16db2850) | `` tantivy-go: use importCargoLock to simplify adding Cargo.lock ``          |
| [`ad95a66d`](https://github.com/NixOS/nixpkgs/commit/ad95a66dd14971ad300d736662f92a5a9331e801) | `` tantivy-go: add changelog ``                                              |
| [`41d11f30`](https://github.com/NixOS/nixpkgs/commit/41d11f30f1043b52e373e4294d54ac9660f3e1b6) | `` tantivy-go: use finalAttrs ``                                             |
| [`cfbb4ef7`](https://github.com/NixOS/nixpkgs/commit/cfbb4ef7fa3b4b1443004f33376c59830ceca30e) | `` tantivy-go: add kira-bruneau as maintainer ``                             |
| [`b0a1f1b2`](https://github.com/NixOS/nixpkgs/commit/b0a1f1b2fb956e2b293efd80b8de878a391723ee) | `` matrix-synapse: 1.137.0 -> 1.138.0 ``                                     |
| [`53962112`](https://github.com/NixOS/nixpkgs/commit/53962112438f5e7a9f8854875680bfa5ac0c5c56) | `` gitlab-runner: 18.3.0 -> 18.3.1 ``                                        |
| [`97f34f37`](https://github.com/NixOS/nixpkgs/commit/97f34f371e2a585aa106719db4cf20eb0edfe0f4) | `` gitlab-runner: 18.1.3 -> 18.3.0 ``                                        |
| [`1638ca4d`](https://github.com/NixOS/nixpkgs/commit/1638ca4dcd3aeba69d55ad8084faa66c35b444aa) | `` gitlab-runner: 18.1.2 -> 18.1.3 ``                                        |
| [`496c7875`](https://github.com/NixOS/nixpkgs/commit/496c7875e5788c4455ea797f56230d6bdbd0bd1d) | `` linux_xanmod_latest: 6.16.5 -> 6.16.6 ``                                  |
| [`f60760ce`](https://github.com/NixOS/nixpkgs/commit/f60760cee4507ca55212fe2a2b6a0efe42ea9897) | `` linux_xanmod: 6.12.45 -> 6.12.46 ``                                       |
| [`d9dcd4c2`](https://github.com/NixOS/nixpkgs/commit/d9dcd4c2de53083bc3a73637c99d78052b1f69ff) | `` gitlab: 18.2.5 -> 18.3.1 ``                                               |
| [`f47d448f`](https://github.com/NixOS/nixpkgs/commit/f47d448f97ecd892a305d865b46d8ab126bb0ec8) | `` gitaly: fix build with >=18.3 ``                                          |
| [`7fb91435`](https://github.com/NixOS/nixpkgs/commit/7fb914354fffb4ee8e6852d60b1c63bb6cc4239b) | `` linux_5_4: 5.4.298 -> 5.4.299 ``                                          |
| [`f1513f91`](https://github.com/NixOS/nixpkgs/commit/f1513f91cdaef794adfe2cbc82984c8ef8bf2cc5) | `` linux_5_10: 5.10.242 -> 5.10.243 ``                                       |
| [`566a34df`](https://github.com/NixOS/nixpkgs/commit/566a34df4d16f8b26a992b61934ef91edfd32540) | `` linux_5_15: 5.15.191 -> 5.15.192 ``                                       |
| [`b524e29e`](https://github.com/NixOS/nixpkgs/commit/b524e29e5c57a5f78185043b343175d3f3dcd19c) | `` linux_6_1: 6.1.150 -> 6.1.151 ``                                          |
| [`ba3ee5ae`](https://github.com/NixOS/nixpkgs/commit/ba3ee5aea278544f8327022576435450450955f1) | `` linux_6_6: 6.6.104 -> 6.6.105 ``                                          |
| [`23b1e009`](https://github.com/NixOS/nixpkgs/commit/23b1e00924eec66b1fb021530ed8e836a258ca38) | `` linux_6_12: 6.12.45 -> 6.12.46 ``                                         |
| [`f8b4d649`](https://github.com/NixOS/nixpkgs/commit/f8b4d64918907057607983d3591b9a9930094ec7) | `` linux_6_16: 6.16.5 -> 6.16.6 ``                                           |
| [`f081cc40`](https://github.com/NixOS/nixpkgs/commit/f081cc40142203788f4c743e7314a4a6b1589018) | `` linux_testing: 6.17-rc4 -> 6.17-rc5 ``                                    |
| [`f7569540`](https://github.com/NixOS/nixpkgs/commit/f75695404d2835582bd1d1132e71a8b3ab0b7f30) | `` gemini-cli: fix file collisions ``                                        |
| [`2917a17f`](https://github.com/NixOS/nixpkgs/commit/2917a17f858571a074fe82c0d515c4673ece50ca) | `` vintagestory: 1.21.0 -> 1.21.1 ``                                         |
| [`44f19a92`](https://github.com/NixOS/nixpkgs/commit/44f19a926ca198652d3640a2281feff75d3b1164) | `` dokuwiki: apply xss fix ``                                                |
| [`d6326ce0`](https://github.com/NixOS/nixpkgs/commit/d6326ce0bfcbd96afdd86533c8c3ac89b321c316) | `` nixos/canaille: remove HTTP header X-XSS-Protection ``                    |
| [`f31698c5`](https://github.com/NixOS/nixpkgs/commit/f31698c53c9e640c133761f205f3b2c38915a312) | `` tutanota-desktop: 304.250825.0 -> 304.250901.0 ``                         |
| [`a17c7842`](https://github.com/NixOS/nixpkgs/commit/a17c78422c12f493bfddeb024629d1104238ecef) | `` lockbook-desktop: 0.9.26 -> 0.9.27 ``                                     |
| [`f79aa145`](https://github.com/NixOS/nixpkgs/commit/f79aa1453249c0ccc8c4162699d47ec0cef1265d) | `` lockbook: 0.9.26 -> 0.9.27 ``                                             |
| [`4cfb1f0d`](https://github.com/NixOS/nixpkgs/commit/4cfb1f0de6712941d6cde2a8c9c3a454cdaaa19c) | `` zipline: 4.3.0 -> 4.3.1 ``                                                |
| [`238ed234`](https://github.com/NixOS/nixpkgs/commit/238ed234f589c72791eccaa5ee83aca81a86743a) | `` firefox-devedition-unwrapped: 143.0b8 -> 143.0b9 ``                       |
| [`1df2d115`](https://github.com/NixOS/nixpkgs/commit/1df2d115093db3bde11bcc411c702e95e7aaae82) | `` firefox-beta-unwrapped: 143.0b8 -> 143.0b9 ``                             |
| [`32d86529`](https://github.com/NixOS/nixpkgs/commit/32d865294190ebd99d36f88385fdd66e6d343a8a) | `` pkgsCross.aarch64-darwin.discord-canary: 0.0.857 -> 0.0.858 ``            |
| [`5c69452f`](https://github.com/NixOS/nixpkgs/commit/5c69452f7430d423132b2dcf9734918dea5df43d) | `` discord-canary: 0.0.751 -> 0.0.752 ``                                     |
| [`5d8ec6c1`](https://github.com/NixOS/nixpkgs/commit/5d8ec6c1dd76e0f8718429fe4228517242e66a08) | `` epson-inkjet-printer-workforce-840-series: init at 1.0.0 ``               |
| [`885f7f02`](https://github.com/NixOS/nixpkgs/commit/885f7f020649b1768e02f87b534ae1d5a9072105) | `` maintainers: add heichro ``                                               |
| [`04a51d30`](https://github.com/NixOS/nixpkgs/commit/04a51d30378c35a20fa4adcd8e9a8b862dc6819a) | `` ungoogled-chromium: 139.0.7258.154-1 -> 140.0.7339.80-1 ``                |
| [`339d6278`](https://github.com/NixOS/nixpkgs/commit/339d62782656f03e02edbe31d8c4a184e48a442f) | `` firebird_3: 3.0.12 -> 3.0.13 ``                                           |
| [`7f9216ca`](https://github.com/NixOS/nixpkgs/commit/7f9216ca725c4fecac481f309004414bd666deec) | `` thunderbird-140-unwrapped: 140.2.0esr -> 140.2.1esr ``                    |
| [`7f6cd6f9`](https://github.com/NixOS/nixpkgs/commit/7f6cd6f9e5f5fa099d0d280f230cf407af1e3ebc) | `` renovate: fix build failure by pinning to nodejs_20 ``                    |
| [`558845ef`](https://github.com/NixOS/nixpkgs/commit/558845ef913de9f71c5ef5fe899fb26dd79ae635) | `` teams-for-linux: 2.5.1 -> 2.5.3 ``                                        |
| [`cb62aeba`](https://github.com/NixOS/nixpkgs/commit/cb62aeba51e99b34302e43484aeef7730219354a) | `` teams-for-linux: 2.3.0 -> 2.5.1 ``                                        |
| [`1a97788b`](https://github.com/NixOS/nixpkgs/commit/1a97788b60f833f61f4d1b41dd6d3bf94c8a53ec) | `` teams-for-linux: 2.1.4 -> 2.3.0 ``                                        |
| [`73d828ce`](https://github.com/NixOS/nixpkgs/commit/73d828ceb6dea81e1b83de27ab36e6f359f40b13) | `` teams-for-linux: fix aarch64-darwin ``                                    |
| [`df7231ab`](https://github.com/NixOS/nixpkgs/commit/df7231ab2690c8a38f9e48a5b92d7a277ab8c770) | `` teams-for-linux: 2.1.0 -> 2.1.4 ``                                        |
| [`529d0f6b`](https://github.com/NixOS/nixpkgs/commit/529d0f6bfbdeb5a8dd4139cd0f69b9a913eafbe5) | `` python3Packages.yara-x: 0.15.0 -> 1.5.0 ``                                |
| [`9af66e93`](https://github.com/NixOS/nixpkgs/commit/9af66e93e3095bbaf1f7d1996549f1b97cdcbf59) | `` yaziPlugins.recycle-bin: init at 1.0.0 ``                                 |
| [`667c7eb0`](https://github.com/NixOS/nixpkgs/commit/667c7eb03ecd687e6df2646cb0d4e1e266cd17e4) | `` maintainers: add guttermonk ``                                            |