### PR TITLE
chore(flake/nur): `7447c413` -> `29a13e9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757610052,
-        "narHash": "sha256-MH/ihl4FZeqX2OlwAfCu00+gjH9rLu9IX6RrL66A4xg=",
+        "lastModified": 1757623447,
+        "narHash": "sha256-B/Q2e2MJ4jQursNN/V1mpQCT+7UcxX7Qfy2UL5dZU3I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7447c41384fc7d69de00642f7e451488f4139a28",
+        "rev": "29a13e9a3aec0d3be0dd5526d0d461d402a0d5d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`29a13e9a`](https://github.com/nix-community/NUR/commit/29a13e9a3aec0d3be0dd5526d0d461d402a0d5d7) | `` automatic update `` |
| [`fc5342ed`](https://github.com/nix-community/NUR/commit/fc5342ed19923c8a2d8864f3acd69e838223a999) | `` automatic update `` |
| [`03e674ee`](https://github.com/nix-community/NUR/commit/03e674eeebcdd82b10241b7d331ff03b0794c858) | `` automatic update `` |