### PR TITLE
chore(flake/nur): `ed551cfa` -> `ef767aa2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757640044,
-        "narHash": "sha256-yCT3LRuwIqZGZ/o66JP+Wbv8dO6YFQjQ53M8bhWrOJI=",
+        "lastModified": 1757647720,
+        "narHash": "sha256-qf/utP3d1qBDl5R4yWUCt7E7CHTkw2NY8BEsS7lJ0dc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed551cfa6022de7399dee1d31a0c95295683b3e7",
+        "rev": "ef767aa25f9f917fe25d3848051f0e54ae42349f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ef767aa2`](https://github.com/nix-community/NUR/commit/ef767aa25f9f917fe25d3848051f0e54ae42349f) | `` automatic update `` |
| [`3885a0d7`](https://github.com/nix-community/NUR/commit/3885a0d7685f703b20fe060c3cf80b8fe5577426) | `` automatic update `` |
| [`9fb70660`](https://github.com/nix-community/NUR/commit/9fb706606212ed07015a3b923232a85fd8e11186) | `` automatic update `` |