### PR TITLE
chore(flake/nur): `ef767aa2` -> `3cd368e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757647720,
-        "narHash": "sha256-qf/utP3d1qBDl5R4yWUCt7E7CHTkw2NY8BEsS7lJ0dc=",
+        "lastModified": 1757651504,
+        "narHash": "sha256-wrQntrFtrbWfWuCCFWT4N669OFFhs1j81KoGq+PrhV0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ef767aa25f9f917fe25d3848051f0e54ae42349f",
+        "rev": "3cd368e5c9dd1fa8208801239045050b19ed1ed4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3cd368e5`](https://github.com/nix-community/NUR/commit/3cd368e5c9dd1fa8208801239045050b19ed1ed4) | `` automatic update `` |
| [`7a68fe3a`](https://github.com/nix-community/NUR/commit/7a68fe3acaf11b71fe62bd927df4fb692113b702) | `` automatic update `` |
| [`b1893e40`](https://github.com/nix-community/NUR/commit/b1893e4022f43372375d902eac7d9a679a3df05d) | `` automatic update `` |
| [`7ee8683d`](https://github.com/nix-community/NUR/commit/7ee8683dcd76151499ebc6470a4215dfef990141) | `` automatic update `` |