### PR TITLE
chore(flake/nur): `7b27b7b3` -> `4372ed6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757668427,
-        "narHash": "sha256-by7DMtE6C72BkM1ySegdS0279PYyJ4HO4LyMGc+Ojk8=",
+        "lastModified": 1757680869,
+        "narHash": "sha256-HlTd0SP3Eoh186uHiAx9EizFO7sqYr9pdW6kD5OTvwU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7b27b7b37727ae7fddf1b0265b5e042143a4e7d7",
+        "rev": "4372ed6d3fd522b31dba6fdf22eec399aac59a0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4372ed6d`](https://github.com/nix-community/NUR/commit/4372ed6d3fd522b31dba6fdf22eec399aac59a0a) | `` automatic update `` |
| [`397dc9d0`](https://github.com/nix-community/NUR/commit/397dc9d07114dcea93adf32c6a46b3b912f85ea3) | `` automatic update `` |
| [`9999db6f`](https://github.com/nix-community/NUR/commit/9999db6f29808c46d17984b0ef780ec15845c162) | `` automatic update `` |
| [`7c145672`](https://github.com/nix-community/NUR/commit/7c145672f8d0c8b648aab2c8d211a2441a802cc2) | `` automatic update `` |