### PR TITLE
chore(flake/nur): `4372ed6d` -> `5c8a5818`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757680869,
-        "narHash": "sha256-HlTd0SP3Eoh186uHiAx9EizFO7sqYr9pdW6kD5OTvwU=",
+        "lastModified": 1757690104,
+        "narHash": "sha256-vAHVs3+yW5bs6WtbTjsdeczz532edZyGOaKPj4T+dgc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4372ed6d3fd522b31dba6fdf22eec399aac59a0a",
+        "rev": "5c8a581830580a77b2391e1e0832c632d6865331",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5c8a5818`](https://github.com/nix-community/NUR/commit/5c8a581830580a77b2391e1e0832c632d6865331) | `` automatic update `` |
| [`9a51a51a`](https://github.com/nix-community/NUR/commit/9a51a51a77903d4b673e1de1a8e674b2ea0fcc3a) | `` automatic update `` |