### PR TITLE
chore(flake/nur): `b518bfcb` -> `4cd6732b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757701537,
-        "narHash": "sha256-Y7DjR7tOBMzgwfDv0OrWL6aMUSCOcHuqd+p4eYHyk+0=",
+        "lastModified": 1757709603,
+        "narHash": "sha256-HGmh7k6n8YLFLj2P4w9ka9gaPbpaMIhsdJuArLwJGAo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b518bfcb01ccc582b13469bac48f94bd21fbf918",
+        "rev": "4cd6732b742dcd1913c0c8215e2b6bc146c58e25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4cd6732b`](https://github.com/nix-community/NUR/commit/4cd6732b742dcd1913c0c8215e2b6bc146c58e25) | `` automatic update `` |
| [`338f8cc3`](https://github.com/nix-community/NUR/commit/338f8cc3d30bb635459c5198e676eb123b1ff4fe) | `` automatic update `` |
| [`bffdd18e`](https://github.com/nix-community/NUR/commit/bffdd18efd4e580c61a8aad3834603ef1cb81a63) | `` automatic update `` |