### PR TITLE
chore(flake/nur): `4cd6732b` -> `567f0297`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757709603,
-        "narHash": "sha256-HGmh7k6n8YLFLj2P4w9ka9gaPbpaMIhsdJuArLwJGAo=",
+        "lastModified": 1757726380,
+        "narHash": "sha256-LqbyKrFIcgKJxkQfDenOELErQyugbw2SaQ2A7hkmmYA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4cd6732b742dcd1913c0c8215e2b6bc146c58e25",
+        "rev": "567f0297e5c1fdf9484b30319727e8e587456ce9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`567f0297`](https://github.com/nix-community/NUR/commit/567f0297e5c1fdf9484b30319727e8e587456ce9) | `` automatic update `` |
| [`1d9539de`](https://github.com/nix-community/NUR/commit/1d9539de96b131120dd46831283f2034c97eb70f) | `` automatic update `` |
| [`8ac8a692`](https://github.com/nix-community/NUR/commit/8ac8a6925fd9d78000a2afd622c000741eb021c7) | `` automatic update `` |
| [`e09f3359`](https://github.com/nix-community/NUR/commit/e09f3359b3ea3f82b4403dfcded216bb5ca834af) | `` automatic update `` |
| [`0fe6bc2e`](https://github.com/nix-community/NUR/commit/0fe6bc2ebd5c15cc42f0451e17d8a3e78b27b838) | `` automatic update `` |
| [`45cc9fe3`](https://github.com/nix-community/NUR/commit/45cc9fe39e7f14d95a6f64e757dca7c2fa1bf456) | `` automatic update `` |
| [`111fd847`](https://github.com/nix-community/NUR/commit/111fd8470ae52c2320f50a021cd672d88aaf35ca) | `` automatic update `` |