### PR TITLE
chore(flake/nur): `567f0297` -> `8a93aa24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757726380,
-        "narHash": "sha256-LqbyKrFIcgKJxkQfDenOELErQyugbw2SaQ2A7hkmmYA=",
+        "lastModified": 1757733608,
+        "narHash": "sha256-k8k4VpFuMMiRGBKaut2YIUCJsu0DR/QDV9058C96/Xw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "567f0297e5c1fdf9484b30319727e8e587456ce9",
+        "rev": "8a93aa245ea5190634a6eaaa0e6a4faaba850f69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8a93aa24`](https://github.com/nix-community/NUR/commit/8a93aa245ea5190634a6eaaa0e6a4faaba850f69) | `` automatic update `` |
| [`ad3bc202`](https://github.com/nix-community/NUR/commit/ad3bc2020e9139ff9ac79dd1d2f698dca07e4bcb) | `` automatic update `` |