### PR TITLE
chore(flake/nur): `8a93aa24` -> `3332e091`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757733608,
-        "narHash": "sha256-k8k4VpFuMMiRGBKaut2YIUCJsu0DR/QDV9058C96/Xw=",
+        "lastModified": 1757736493,
+        "narHash": "sha256-lZ9GQ2ZbRsggjvyXWzVAcxFHT2LGiCergEZRUvtxyH0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8a93aa245ea5190634a6eaaa0e6a4faaba850f69",
+        "rev": "3332e0914da238ef6ec3091cb1dfcae2aac81286",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3332e091`](https://github.com/nix-community/NUR/commit/3332e0914da238ef6ec3091cb1dfcae2aac81286) | `` automatic update `` |
| [`9c63893f`](https://github.com/nix-community/NUR/commit/9c63893fcc79eb93caf37b3d7eff209897b16a61) | `` automatic update `` |