### PR TITLE
chore(flake/nur): `3332e091` -> `d3a2c81d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757736493,
-        "narHash": "sha256-lZ9GQ2ZbRsggjvyXWzVAcxFHT2LGiCergEZRUvtxyH0=",
+        "lastModified": 1757755200,
+        "narHash": "sha256-UM/V9vMgvfXaIqxXekniWcpAxg5AiZyw1bgweKPPUkA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3332e0914da238ef6ec3091cb1dfcae2aac81286",
+        "rev": "d3a2c81d187f6e61db57e8fd4f78eaec648328a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d3a2c81d`](https://github.com/nix-community/NUR/commit/d3a2c81d187f6e61db57e8fd4f78eaec648328a9) | `` automatic update `` |
| [`29af2c5e`](https://github.com/nix-community/NUR/commit/29af2c5edbedf501922c04735f9a975b0b35f417) | `` automatic update `` |
| [`492f636f`](https://github.com/nix-community/NUR/commit/492f636fe5eb9f4bff47c37b9e17418a4ce003b4) | `` automatic update `` |