### PR TITLE
chore(flake/nixos-hardware): `11b2a10c` -> `f89c620d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -289,11 +289,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1757103352,
-        "narHash": "sha256-PtT7ix43ss8PONJ1VJw3f6t2yAoGH+q462Sn8lrmWmk=",
+        "lastModified": 1757775351,
+        "narHash": "sha256-xWsxmNHwt9jV/yFJqzsNeilpH4BR8MPe44Yt0eaGAIM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "11b2a10c7be726321bb854403fdeec391e798bf0",
+        "rev": "f89c620d3d6e584d98280b48f0af7be4f8506ab5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`e049c10c`](https://github.com/NixOS/nixos-hardware/commit/e049c10c3e9f9e48e6f984c7993c7bd447395fb6) | `` treewide: set intel cpu variant to legacy where newer versions are not supported `` |
| [`4100cffd`](https://github.com/NixOS/nixos-hardware/commit/4100cffdbee7980e18ab013dd709d155acec767d) | `` common/gpu: add option to choose intel-compute-runtime variant ``                   |
| [`a98f1a2b`](https://github.com/NixOS/nixos-hardware/commit/a98f1a2b75cf5fc934db11a8818e266360234238) | `` Drop some unused inputs ``                                                          |
| [`536ac3ab`](https://github.com/NixOS/nixos-hardware/commit/536ac3ab4b6cf09aa4a831b25ce4fea94ae79740) | `` common/cpu/intel/comet-lake: drop gpu option ``                                     |