### PR TITLE
chore(flake/nur): `22b0e920` -> `e30d26b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757776415,
-        "narHash": "sha256-2/EFd4R9TBI4lXohlOVWECvWpc+vDS868ATdAqu+5oA=",
+        "lastModified": 1757784038,
+        "narHash": "sha256-I1qi3dhfiW8kCEzWfWc1Z8FcrDGmk+LJSD5X/Su6XlI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "22b0e920a2e2b7d61ea7ce57c34f6dda93b601a2",
+        "rev": "e30d26b997f127ac3cdbf0e0b98481d1070a0a21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e30d26b9`](https://github.com/nix-community/NUR/commit/e30d26b997f127ac3cdbf0e0b98481d1070a0a21) | `` automatic update `` |
| [`d87d9007`](https://github.com/nix-community/NUR/commit/d87d9007d2342fca8fe037277abb701c2f4ca53f) | `` automatic update `` |
| [`18fe43ab`](https://github.com/nix-community/NUR/commit/18fe43abcae48d18fadd019899e621fbd631f0b2) | `` automatic update `` |
| [`65ac4256`](https://github.com/nix-community/NUR/commit/65ac4256d05a33f2d1fe18cdc8dda34d177ad0d3) | `` automatic update `` |
| [`80bd5773`](https://github.com/nix-community/NUR/commit/80bd5773bf3c1a74f4543a6de9b0eefdbbea3fb8) | `` automatic update `` |