### PR TITLE
chore(flake/nur): `e30d26b9` -> `5d182ee1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757784038,
-        "narHash": "sha256-I1qi3dhfiW8kCEzWfWc1Z8FcrDGmk+LJSD5X/Su6XlI=",
+        "lastModified": 1757794915,
+        "narHash": "sha256-WAiiOWfPCOmUuBSlABYkbMmIDrepmcIQc04oAp1cDX0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e30d26b997f127ac3cdbf0e0b98481d1070a0a21",
+        "rev": "5d182ee144a0c0422b749327745a5673efe9761b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5d182ee1`](https://github.com/nix-community/NUR/commit/5d182ee144a0c0422b749327745a5673efe9761b) | `` automatic update `` |
| [`503b43c8`](https://github.com/nix-community/NUR/commit/503b43c8930ebfea451b1e617a1e99bf6d5894ab) | `` automatic update `` |
| [`4332660b`](https://github.com/nix-community/NUR/commit/4332660bff00fbfab9c33cf85f59ade4521c9ca5) | `` automatic update `` |