### PR TITLE
chore(flake/nur): `5d182ee1` -> `4d74a5db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1757487488,
-        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
+        "lastModified": 1757745802,
+        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
+        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757794915,
-        "narHash": "sha256-WAiiOWfPCOmUuBSlABYkbMmIDrepmcIQc04oAp1cDX0=",
+        "lastModified": 1757814651,
+        "narHash": "sha256-uLqKqHb5Yqa+41ciUWl1hP5AbwOVXevTvnH7px/GLRI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5d182ee144a0c0422b749327745a5673efe9761b",
+        "rev": "4d74a5dbb4bca00730d6215b537d70ce17e0dede",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4d74a5db`](https://github.com/nix-community/NUR/commit/4d74a5dbb4bca00730d6215b537d70ce17e0dede) | `` automatic update `` |
| [`d21e3688`](https://github.com/nix-community/NUR/commit/d21e3688e21fe726df6af48c55a188336b934966) | `` automatic update `` |
| [`39e64d7d`](https://github.com/nix-community/NUR/commit/39e64d7d38ecf78d78c695182480a033e17ed6af) | `` automatic update `` |
| [`1543c6c3`](https://github.com/nix-community/NUR/commit/1543c6c3e143cc0f73410c2ec9aab382e8da3365) | `` automatic update `` |