### PR TITLE
chore(flake/nur): `1dba3036` -> `2fdfe405`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757820671,
-        "narHash": "sha256-t8kioSPxcqbxpDyjcG0Cw0OpHn6XvKXlGh1YN3VyYls=",
+        "lastModified": 1757830298,
+        "narHash": "sha256-301/qIpg1Vojh/wxxxDOFnWRPB4lqiJcUvI7UuWCydk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1dba3036b4b095ac231cdb978674c651cef5b70f",
+        "rev": "2fdfe405cdaf0f10601d91208f1e6bf4ce49e822",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2fdfe405`](https://github.com/nix-community/NUR/commit/2fdfe405cdaf0f10601d91208f1e6bf4ce49e822) | `` automatic update `` |
| [`5cb8a920`](https://github.com/nix-community/NUR/commit/5cb8a9201971d7da5f7574b5caee7317189952b1) | `` automatic update `` |
| [`d12cb9e4`](https://github.com/nix-community/NUR/commit/d12cb9e4f3217be622949faec2c08d578de4d97c) | `` automatic update `` |
| [`11de5631`](https://github.com/nix-community/NUR/commit/11de5631c5714167f1e3d224385045d41617043a) | `` automatic update `` |