### PR TITLE
chore(flake/nur): `2fdfe405` -> `87a1579b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757830298,
-        "narHash": "sha256-301/qIpg1Vojh/wxxxDOFnWRPB4lqiJcUvI7UuWCydk=",
+        "lastModified": 1757839624,
+        "narHash": "sha256-ihH8nIJ5FNFH5UKTcnHzQyO/CfcG7P2l5kA7saWSezs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2fdfe405cdaf0f10601d91208f1e6bf4ce49e822",
+        "rev": "87a1579b2bff6f90d102433020fff698fec07c9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`87a1579b`](https://github.com/nix-community/NUR/commit/87a1579b2bff6f90d102433020fff698fec07c9b) | `` automatic update `` |
| [`7a21866e`](https://github.com/nix-community/NUR/commit/7a21866ea37347e06e03e6ac8a766d155b33d30d) | `` automatic update `` |
| [`25ca7f34`](https://github.com/nix-community/NUR/commit/25ca7f344cb20df6ccbc01ba3e0fd9d6c14ef8ac) | `` automatic update `` |
| [`9c750a83`](https://github.com/nix-community/NUR/commit/9c750a83934d6b0b2ddedbd1e52241f948cb352c) | `` automatic update `` |