### PR TITLE
chore(flake/nur): `dbba7336` -> `05b990a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757850257,
-        "narHash": "sha256-iGPeHG9/pPsQkhbgoxl6JAHaLT1LriJKM5jZ8o4EO1k=",
+        "lastModified": 1757862847,
+        "narHash": "sha256-THqVjPFLT2ntKfRepG3Vq/gvKyeFt6BJJVxO9QhR1Ok=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dbba733604535685d3f5b6ece3d1168f7b4565aa",
+        "rev": "05b990a1b8356c89589574c9c7ef4d59ee0dccb6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`05b990a1`](https://github.com/nix-community/NUR/commit/05b990a1b8356c89589574c9c7ef4d59ee0dccb6) | `` automatic update `` |
| [`aae89b33`](https://github.com/nix-community/NUR/commit/aae89b330e492c4dba811d36a5ead884a29bff89) | `` automatic update `` |
| [`3bb955f0`](https://github.com/nix-community/NUR/commit/3bb955f07a4d15f109a3dd25af7d36e6d34c682e) | `` automatic update `` |