### PR TITLE
chore(flake/nixpkgs): `8cd5ce82` -> `9a094440`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1757545623,
-        "narHash": "sha256-mCxPABZ6jRjUQx3bPP4vjA68ETbPLNz9V2pk9tO7pRQ=",
+        "lastModified": 1757810152,
+        "narHash": "sha256-Vp9K5ol6h0J90jG7Rm4RWZsCB3x7v5VPx588TQ1dkfs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8cd5ce828d5d1d16feff37340171a98fc3bf6526",
+        "rev": "9a094440e02a699be5c57453a092a8baf569bdad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`1f90656c`](https://github.com/NixOS/nixpkgs/commit/1f90656cac215393f711228c62ea0993fcd21913) | `` gnomeExtensions.gsconnect: 62 -> 66 ``                                                      |
| [`62d44d52`](https://github.com/NixOS/nixpkgs/commit/62d44d52df2f91eefbf1c34ee5956230dd5fd016) | `` gnomeExtensions.gsconnect: use finalAttrs ``                                                |
| [`25afb42a`](https://github.com/NixOS/nixpkgs/commit/25afb42a5dfb8e5c065de3ec9cc2ba88af991e9f) | `` gnomeExtensions.gsconnect: no with lib; in meta ``                                          |
| [`8c9e93bd`](https://github.com/NixOS/nixpkgs/commit/8c9e93bd5e5c8285d92288e8065a93823d763181) | `` taskwarrior3: add Necior to maintainers ``                                                  |
| [`f75ca93c`](https://github.com/NixOS/nixpkgs/commit/f75ca93c366f8e80176d16113b7c7719ebe729a9) | `` raycast: 1.102.5 -> 1.102.7 ``                                                              |
| [`b7338ccd`](https://github.com/NixOS/nixpkgs/commit/b7338ccd189a2d05e7d870dae449323423667b9d) | `` nixos/nextcloud: remove X-XSS-Protection ``                                                 |
| [`60b0f9f6`](https://github.com/NixOS/nixpkgs/commit/60b0f9f6e84a8e307424b68540c842b65773fd15) | `` sarasa-gothic: 1.0.31 -> 1.0.32 ``                                                          |
| [`0d1d0b00`](https://github.com/NixOS/nixpkgs/commit/0d1d0b0057349fe99d529ba8c2b9732db93c93f8) | `` postgresqlPackages.vectorchord: remove useFetchCargoVendor ``                               |
| [`279610c7`](https://github.com/NixOS/nixpkgs/commit/279610c7f74d74e77540be02a99e29d63a905b71) | `` dotnetCorePackages.dotnet_10.vmr: 10.0.0-preview.7 -> 10.0.0-rc.1 ``                        |
| [`8b49846a`](https://github.com/NixOS/nixpkgs/commit/8b49846a76fb645bbacbb1b8dce06de0ec99467b) | `` dotnetCorePackages.sdk_10_0-bin: 10.0.100-preview.7.25380.108 -> 10.0.100-rc.1.25451.107 `` |
| [`c4a8fc65`](https://github.com/NixOS/nixpkgs/commit/c4a8fc65fe5828c7aca862ac2e7e24ae877d2d00) | `` dotnetCorePackages.dotnet_9.vmr: 9.0.8 -> 9.0.9 ``                                          |
| [`c05e3eea`](https://github.com/NixOS/nixpkgs/commit/c05e3eeaf6677368f95212b8ef3ae41a49667c2c) | `` dotnetCorePackages.sdk_9_0-bin: 9.0.304 -> 9.0.305 ``                                       |
| [`7f27bdd5`](https://github.com/NixOS/nixpkgs/commit/7f27bdd58d82c20489414dee7fc4df483a831a37) | `` dotnetCorePackages.dotnet_8.vmr: 8.0.19 -> 8.0.20 ``                                        |
| [`7d082377`](https://github.com/NixOS/nixpkgs/commit/7d082377c97e75a8487c5aed6afd550671efacde) | `` dotnetCorePackages.sdk_8_0-bin: 8.0.413 -> 8.0.414 ``                                       |
| [`8c1e8092`](https://github.com/NixOS/nixpkgs/commit/8c1e80927b9ca5d2af7dd57220b253e30ed54610) | `` sarasa-gothic: 1.0.30 -> 1.0.31 ``                                                          |
| [`20af8214`](https://github.com/NixOS/nixpkgs/commit/20af82149ec6e6eec588e448a056568b8f16c660) | `` tests.cross.sanity: fix eval ``                                                             |
| [`9bbd0e57`](https://github.com/NixOS/nixpkgs/commit/9bbd0e570e67ea428aa0735e0846b526718d587e) | `` osu-lazer-bin: 2025.816.0 -> 2025.912.0 ``                                                  |
| [`3f82ec5d`](https://github.com/NixOS/nixpkgs/commit/3f82ec5d510d6b954de3d558fa5d36a4d5177f88) | `` osu-lazer: 2025.816.0 -> 2025.912.0 ``                                                      |
| [`ad539dc0`](https://github.com/NixOS/nixpkgs/commit/ad539dc007f2d808e2aef733ce90554cfb4a91ad) | `` fish: disable test that fails on x86_64-darwin ``                                           |
| [`a2741f7b`](https://github.com/NixOS/nixpkgs/commit/a2741f7b82624bd1a4319eeb729da50087a453c7) | `` fish: 4.0.2 -> 4.0.6 ``                                                                     |
| [`1c19667f`](https://github.com/NixOS/nixpkgs/commit/1c19667f3cf391c89bc024423afa7547d5ae227d) | `` nixos/all-tests: keep-sorted ``                                                             |
| [`a2db8298`](https://github.com/NixOS/nixpkgs/commit/a2db8298a0b279d6260de48092528e9e031859f3) | `` maintainers/team-list: keep-sorted ``                                                       |
| [`0a19751c`](https://github.com/NixOS/nixpkgs/commit/0a19751cfc673447c1b4021a1615f2c98c64b463) | `` linux_xanmod_latest: 6.16.6 -> 6.16.7 ``                                                    |
| [`96ac11c6`](https://github.com/NixOS/nixpkgs/commit/96ac11c6ba0fe1e532d10ace449827ad7f2acfc7) | `` linux_xanmod: 6.12.46 -> 6.12.47 ``                                                         |
| [`da1ae97e`](https://github.com/NixOS/nixpkgs/commit/da1ae97e53f108c540ffc4690bb2f2d9f7016899) | `` sigil: 2.6.0 -> 2.6.2 ``                                                                    |
| [`b837427e`](https://github.com/NixOS/nixpkgs/commit/b837427e895f176f9130dca39de1a2a3b9ecf99c) | `` sigil: wrap qt app ``                                                                       |
| [`487020a5`](https://github.com/NixOS/nixpkgs/commit/487020a594792e3e9bdd4d9c2ae102d0982753f1) | `` sigil: 2.5.2 -> 2.6.0 ``                                                                    |
| [`030670fc`](https://github.com/NixOS/nixpkgs/commit/030670fc283e3b7afaa9c664b78668551901ab70) | `` sigil: 2.5.1 -> 2.5.2 ``                                                                    |
| [`6db7a666`](https://github.com/NixOS/nixpkgs/commit/6db7a6666a43ecbc469a283ea12133d987782089) | `` sigil: 2.4.2 -> 2.5.1 ``                                                                    |
| [`4e28e775`](https://github.com/NixOS/nixpkgs/commit/4e28e7754ca7248fa550b3d4c42ded41af193e37) | `` rtorrent: Add option to build with Lua support ``                                           |
| [`8fb83a79`](https://github.com/NixOS/nixpkgs/commit/8fb83a79884d45f6be322001aa689265083a7bda) | `` rtorrent: 0.15.4 -> 0.15.5 ``                                                               |
| [`4a9a46f9`](https://github.com/NixOS/nixpkgs/commit/4a9a46f94d30d2c0e7a1e8a778c71a3204acba5c) | `` libtorrent: 0.15.4 -> 0.15.5 ``                                                             |
| [`bb0cd0a4`](https://github.com/NixOS/nixpkgs/commit/bb0cd0a40efd3600ae6ab7ab810c198feb635dbb) | `` libtorrent: remove autoconf-archive ``                                                      |
| [`38e5912f`](https://github.com/NixOS/nixpkgs/commit/38e5912ffe1235b7a25eb3621d595dad881055b6) | `` rtorrent: 0.15.1 -> 0.15.4 ``                                                               |
| [`4fd2d6d3`](https://github.com/NixOS/nixpkgs/commit/4fd2d6d3fcd91f8c964bdfcbfc45ee6bbb9f3cde) | `` libtorrent: 0.15.1 -> 0.15.4 ``                                                             |
| [`48581958`](https://github.com/NixOS/nixpkgs/commit/485819580b6e65be5d2269139b7a4ec44275800b) | `` vivaldi: 7.5.3735.66 -> 7.5.3735.74 ``                                                      |
| [`68aa1c69`](https://github.com/NixOS/nixpkgs/commit/68aa1c69dee2f3e7782dab0266b744e10b1aefe5) | `` discord-ptb: 0.0.159 -> 0.0.160 ``                                                          |
| [`8144f1ad`](https://github.com/NixOS/nixpkgs/commit/8144f1adc5158e69b8e73b8496865235fffb2516) | `` paretosecurity: 0.3.3 -> 0.3.4 ``                                                           |
| [`f97c3af4`](https://github.com/NixOS/nixpkgs/commit/f97c3af42d7c5bfc07503800e96d73dcee48c57f) | `` xrizer: support aarch64-linux and i686-linux ``                                             |
| [`3ae9ad84`](https://github.com/NixOS/nixpkgs/commit/3ae9ad849601c5ae881c1bf6bd93e584af0db2c3) | `` xrizer: 0.2 -> 0.3 ``                                                                       |
| [`e7f06e95`](https://github.com/NixOS/nixpkgs/commit/e7f06e95712001c5da25daff8df2bdaa947cf873) | `` signal-desktop: 7.68.0 -> 7.70.0 ``                                                         |
| [`83e6c2fe`](https://github.com/NixOS/nixpkgs/commit/83e6c2fee3c9805365b8551d1fffd7884cc5b1a8) | `` microsoft-edge: add maintainer iedame ``                                                    |
| [`f3765c44`](https://github.com/NixOS/nixpkgs/commit/f3765c449e0bb8f6f37da1d801fe5cb2ef276019) | `` maintainers: add iedame ``                                                                  |
| [`e4741272`](https://github.com/NixOS/nixpkgs/commit/e4741272eb54fad13f4128d3b854f161528df51d) | `` microsoft-edge: 139.0.3405.125 -> 140.0.3485.66 ``                                          |
| [`9d5cc0ef`](https://github.com/NixOS/nixpkgs/commit/9d5cc0ef001881d8cf1447406aa832fcc38c4493) | `` element-desktop: 1.11.110 -> 1.11.111 ``                                                    |
| [`63d812b9`](https://github.com/NixOS/nixpkgs/commit/63d812b912f115961a491beb2b7c31934088b1c8) | `` element-web-unwrapped: 1.11.110 -> 1.11.111 ``                                              |
| [`a5658d1f`](https://github.com/NixOS/nixpkgs/commit/a5658d1f601d8449bb3ac0f2d52e8d9339e75a93) | `` linux_5_10: 5.10.243 -> 5.10.244 ``                                                         |
| [`a3bb6433`](https://github.com/NixOS/nixpkgs/commit/a3bb6433685d61c1463177260bdf1c4442a0d197) | `` linux_5_15: 5.15.192 -> 5.15.193 ``                                                         |
| [`d37c2cae`](https://github.com/NixOS/nixpkgs/commit/d37c2caef9f08ff71f06a0fb24d1b4231ee62107) | `` linux_6_1: 6.1.151 -> 6.1.152 ``                                                            |
| [`9d21c2f2`](https://github.com/NixOS/nixpkgs/commit/9d21c2f202a6f2299908b0321d549912608c0b30) | `` linux_6_6: 6.6.105 -> 6.6.106 ``                                                            |
| [`ed1b904c`](https://github.com/NixOS/nixpkgs/commit/ed1b904c4a11b7f9aee70889c673ea7a08b343a6) | `` linux_6_12: 6.12.46 -> 6.12.47 ``                                                           |
| [`c54c7d84`](https://github.com/NixOS/nixpkgs/commit/c54c7d84616cc56564aae38433d46b1e52bbe141) | `` linux_6_16: 6.16.6 -> 6.16.7 ``                                                             |
| [`0e52d37a`](https://github.com/NixOS/nixpkgs/commit/0e52d37a0008b1c0a68e576831d6c00f8b111f71) | `` google-chrome: 140.0.7339.80 -> 140.0.7339.127 ``                                           |
| [`b32c4803`](https://github.com/NixOS/nixpkgs/commit/b32c480301c97bf675daff2c96bdeefddf1cf039) | `` moonlight: 1.3.27 -> 1.3.28 ``                                                              |
| [`ad0c831d`](https://github.com/NixOS/nixpkgs/commit/ad0c831d6076f1e1838179320bcf6d4cff8ea34a) | `` ungoogled-chromium: 140.0.7339.80-1 -> 140.0.7339.127-1 ``                                  |
| [`aec2d51e`](https://github.com/NixOS/nixpkgs/commit/aec2d51e7e6f4dfaff23725e847f70f412a0f531) | `` ci/eval: fix local full eval ``                                                             |
| [`b9b3f64b`](https://github.com/NixOS/nixpkgs/commit/b9b3f64b869e0836c28006e07dfaedf679d0dcaf) | `` scx.cscheds: patch build_bpftool meson script explicitly ``                                 |
| [`16bdf24b`](https://github.com/NixOS/nixpkgs/commit/16bdf24b9a94a9b9251c153d61488bb351bad64f) | `` scx.full: 1.0.15 -> 1.0.16 ``                                                               |
| [`833ab3d9`](https://github.com/NixOS/nixpkgs/commit/833ab3d95af5947f1a810b9493bfa7a1497c2433) | `` scx.rustscheds: restore RUSTFLAGS ``                                                        |
| [`ff5cb295`](https://github.com/NixOS/nixpkgs/commit/ff5cb2956b022bac45801645790aa5bcbca36b0d) | `` scx.full: 1.0.14 -> 1.0.15 ``                                                               |
| [`2ca9b4dd`](https://github.com/NixOS/nixpkgs/commit/2ca9b4dd0e858929df36b63bff37cbbfecb886d6) | `` scx.cscheds: direct use of bash ``                                                          |
| [`9b29a46f`](https://github.com/NixOS/nixpkgs/commit/9b29a46f96fd43bf684eef97ad57d29224ad7f6c) | `` workflows/{merge_group,pr}: fail status check explicitly ``                                 |
| [`1fe961ab`](https://github.com/NixOS/nixpkgs/commit/1fe961ab4c45cdbb3307ececbf52aac6f038d0ca) | `` python3Packages.stackprinter: init at 0.2.12 ``                                             |
| [`683585ec`](https://github.com/NixOS/nixpkgs/commit/683585ecbcaa5a0b902df05734d207dd40020631) | `` erlang_28: 28.0.3 -> 28.0.4 ``                                                              |
| [`5f59c51a`](https://github.com/NixOS/nixpkgs/commit/5f59c51a6330ab86e866132b08559e102775f8e1) | `` erlang_28: 28.0.2 -> 28.0.3 ``                                                              |
| [`a2ea4cf7`](https://github.com/NixOS/nixpkgs/commit/a2ea4cf7ecd8924b2bc44a3a377cc1458347b998) | `` erlang_27: 27.3.4.2 -> 27.3.4.3 ``                                                          |
| [`1330c47e`](https://github.com/NixOS/nixpkgs/commit/1330c47ea025bd045f49056e8b9e844bdebfeb8b) | `` erlang_26: 26.2.5.14 -> 26.2.5.15 ``                                                        |
| [`162fd211`](https://github.com/NixOS/nixpkgs/commit/162fd2111cbf16faf5f022b4f6999c6b0667f42b) | `` pyfa: 2.63.1 -> 2.64.1 ``                                                                   |
| [`4b8f6636`](https://github.com/NixOS/nixpkgs/commit/4b8f663634c1ce9f57ab6164eb5db1aaa601596d) | `` iterm2: 3.5.11 -> 3.5.14 ``                                                                 |
| [`0fa99ffd`](https://github.com/NixOS/nixpkgs/commit/0fa99ffdb6d91ae1f35f736e91b18cf947d319ab) | `` brave: 1.81.137 -> 1.82.166 ``                                                              |
| [`eddbbb38`](https://github.com/NixOS/nixpkgs/commit/eddbbb387b0aa84bdff063a0a87e0a8ee6b138e2) | `` envoy-bin: add katexochen as maintainer ``                                                  |
| [`240c979e`](https://github.com/NixOS/nixpkgs/commit/240c979e17dc443961e5f8898045911976133dac) | `` envoy-bin: 1.34.6 -> 1.34.7 ``                                                              |
| [`f817b3dd`](https://github.com/NixOS/nixpkgs/commit/f817b3ddbec65653988f5fd6c0b832e330f83825) | `` guile-git: 0.9.0 -> 0.10.0 ``                                                               |
| [`f6fd7105`](https://github.com/NixOS/nixpkgs/commit/f6fd7105b5abe86345a2cdb7fede22e1c55dbc5f) | `` xen: patch with XSA-473 ``                                                                  |
| [`fbc146f3`](https://github.com/NixOS/nixpkgs/commit/fbc146f31e226237f12b7451a4dfdab7aa908a4d) | `` xen: patch with XSA-472 ``                                                                  |
| [`674734f5`](https://github.com/NixOS/nixpkgs/commit/674734f59768276f827a084b3828140570a8c2cb) | `` teleport_16: 16.5.14 -> 16.5.15 ``                                                          |
| [`d32c25ef`](https://github.com/NixOS/nixpkgs/commit/d32c25ef77ac7269d5e710414da84a6391664012) | `` teleport_17: 17.7.0 -> 17.7.3 ``                                                            |
| [`c5f31425`](https://github.com/NixOS/nixpkgs/commit/c5f31425ce237445cb02ad508cafb7e112b37a2c) | `` teleport_18: 18.1.1 -> 18.2.0 ``                                                            |
| [`f1982a4b`](https://github.com/NixOS/nixpkgs/commit/f1982a4b8c299ddc94879e9c4efe3999b461bb32) | `` teleport: rename references to rdp library to `librdpclient.h` ``                           |
| [`48e58b28`](https://github.com/NixOS/nixpkgs/commit/48e58b28b4ec80d8c6bab538ddbb7684c6704dfa) | `` teleport_17: 17.5.4 -> 17.7.0 ``                                                            |
| [`6dc0ee43`](https://github.com/NixOS/nixpkgs/commit/6dc0ee4377591fd7fe03ddbb26555e680b6da567) | `` teleport_16: 16.5.13 -> 16.5.14 ``                                                          |
| [`21037c0b`](https://github.com/NixOS/nixpkgs/commit/21037c0b4c8f5aeec1cc633bdb4e11229837fe53) | `` teleport_18: init at 18.1.1 ``                                                              |
| [`25ef88b4`](https://github.com/NixOS/nixpkgs/commit/25ef88b40f85c3a10e9bdb88dc8808439fb8a86c) | `` wasm-bindgen-cli_0_2_99: init at 0.2.99 ``                                                  |
| [`1fcc1274`](https://github.com/NixOS/nixpkgs/commit/1fcc12742d8788b475d3f6d9ec3b1a1119010de7) | `` teleport: migrate to new buildTeleport ``                                                   |
| [`a147c05f`](https://github.com/NixOS/nixpkgs/commit/a147c05fd0198d8f45724c64d92f5ba1e7d2e005) | `` gotosocial: 0.19.1 -> 0.19.2 ``                                                             |
| [`d1c01cf0`](https://github.com/NixOS/nixpkgs/commit/d1c01cf0f8a22b70b0c78047dadff6efafaa91cf) | `` uvwasi: 0.0.21 -> 0.0.23 ``                                                                 |
| [`2e735c82`](https://github.com/NixOS/nixpkgs/commit/2e735c8243a4f737911d86e35c0f2b1fe7c4aaec) | `` python3Packages.deepdiff: 8.5.0 -> 8.6.1 ``                                                 |
| [`2874a9a4`](https://github.com/NixOS/nixpkgs/commit/2874a9a46943760ca11520b56b15b6144f2a95bb) | `` python313Packages.deepdiff: 8.4.1 -> 8.5.0 ``                                               |
| [`a2e9e351`](https://github.com/NixOS/nixpkgs/commit/a2e9e351dda993e3b43c76e96ff239d0f732bd50) | `` signal-desktop: 7.66.0 -> 7.68.0 ``                                                         |
| [`3841ea2c`](https://github.com/NixOS/nixpkgs/commit/3841ea2cf7d47adc1642b90c4cfcba2b39484dc5) | `` exiv2: 0.28.5 -> 0.28.7 ``                                                                  |
| [`0927abaf`](https://github.com/NixOS/nixpkgs/commit/0927abaf60a2e63d9b9a29afe761164cba54a1eb) | `` geph: fix rust E0559 ``                                                                     |
| [`4e38668a`](https://github.com/NixOS/nixpkgs/commit/4e38668a1b3c36f5fe919364ec26e7978e5ce85f) | `` tailscale: add philiptaron as maintainer ``                                                 |
| [`95dd1df7`](https://github.com/NixOS/nixpkgs/commit/95dd1df7cb8bb9dfb4cf0b5b026957c998060a1d) | `` tailscale: use finalAttrs style ``                                                          |
| [`0408cc3a`](https://github.com/NixOS/nixpkgs/commit/0408cc3ac5e67c750b7428b26c6cb783fe273108) | `` qt-material: modernize, fix ``                                                              |
| [`aaa14e77`](https://github.com/NixOS/nixpkgs/commit/aaa14e7725c8f938060c18dcc9033973d1ce71e3) | `` python3Packages.qt-material: 2.14 -> 2.17 ``                                                |
| [`bf0a32da`](https://github.com/NixOS/nixpkgs/commit/bf0a32da53d0325341c6f038653adcb3c5610531) | `` Revert "h2o: apply patch for CVE-2025-8671" ``                                              |
| [`9a0acc8a`](https://github.com/NixOS/nixpkgs/commit/9a0acc8a0560fc245c39c4c74cb748adde836025) | `` h2o: 2.3.0-untagged-2025-08-14 → 2.3.0-rolling-2025-08-22 ``                                |
| [`5d82502b`](https://github.com/NixOS/nixpkgs/commit/5d82502b721fe11c555e3ddbe6aa99effaf10a62) | `` h2o: src.sha256 → src.hash ``                                                               |
| [`73d8297d`](https://github.com/NixOS/nixpkgs/commit/73d8297d716412a960e7c9efe61fdf30ce04d4f4) | `` h2o: 2.3.0-untagged-2025-08-13 → 2.3.0-untagged-2025-08-14 ``                               |
| [`2d03e530`](https://github.com/NixOS/nixpkgs/commit/2d03e530e9025d8f1f3fbaa7cd6a81c29c7b1216) | `` h2o: 2.3.0.20250717 → 2.3.0-untagged-2025-08-13 ``                                          |
| [`d8aa1c1b`](https://github.com/NixOS/nixpkgs/commit/d8aa1c1be2caf8a99999d745cb3d3a4c1ef7779c) | `` h2o: 2.3.0.20250716 → 2.3.0.20250717 ``                                                     |
| [`b585767c`](https://github.com/NixOS/nixpkgs/commit/b585767ce75eefb050ca25e7cccff22ef161d4bd) | `` h2o: 2.3.0.20250519 → 2.3.0.20250716 ``                                                     |
| [`ec27e405`](https://github.com/NixOS/nixpkgs/commit/ec27e40552cb0a16c4d791845ea1f990b76702fb) | `` h2o: 2.3.0.20250430 → 2.3.0.20250519 ``                                                     |
| [`d1a6992b`](https://github.com/NixOS/nixpkgs/commit/d1a6992b95e761c16e2c6dbbddd8720c814e40d8) | `` dependabot-cli: 1.68.0 -> 1.71.0 ``                                                         |
| [`6e9d4942`](https://github.com/NixOS/nixpkgs/commit/6e9d4942da830b78dd72f9bb968f69c9152bb69f) | `` dependabot-cli: 1.67.1 -> 1.68.0 ``                                                         |
| [`a6b15da8`](https://github.com/NixOS/nixpkgs/commit/a6b15da80f78d0d712c9c18ae4e98cf4a9b4d6de) | `` dependabot-cli: 1.66.0 -> 1.67.1 ``                                                         |
| [`dbb743cb`](https://github.com/NixOS/nixpkgs/commit/dbb743cb0a1ee302b7651499228df39a5c0045ee) | `` dependabot-cli: 1.65.0 -> 1.66.0 ``                                                         |
| [`d954ff07`](https://github.com/NixOS/nixpkgs/commit/d954ff07e95c2cece4b167cc89f6ceeaed56fe68) | `` dependabot-cli: add philiptaron as a maintainer ``                                          |
| [`25b0ec83`](https://github.com/NixOS/nixpkgs/commit/25b0ec83bf7df03d44e18146808d9a97aedf56cf) | `` dependabot-cli: only run dependabot in order to get completions if supported ``             |
| [`34a6d202`](https://github.com/NixOS/nixpkgs/commit/34a6d20202eed663df3d50e6991800edf9ba2416) | `` dependabot-cli: 1.64.0 -> 1.65.0 ``                                                         |
| [`3a5f633f`](https://github.com/NixOS/nixpkgs/commit/3a5f633f0ac690c7e2557ab8844fa324f51c4fcc) | `` dependabot-cli: add update script which updates the withDockerImages variant ``             |
| [`970330e6`](https://github.com/NixOS/nixpkgs/commit/970330e6524d95f758f9d19422c5b10a561af692) | `` dependabot-cli: Remove myself as maintainer ``                                              |
| [`f0e21906`](https://github.com/NixOS/nixpkgs/commit/f0e21906153d8a190b48a70de80b8fe9773e7b3f) | `` dependabot-cli: 1.63.0 -> 1.64.0 ``                                                         |
| [`497cff44`](https://github.com/NixOS/nixpkgs/commit/497cff444426cac0d8872d91d9ea44f05024ce6e) | `` geph: 0.2.77 -> 0.2.82 ``                                                                   |
| [`c9946f93`](https://github.com/NixOS/nixpkgs/commit/c9946f9364e543afc79e06e291b617d8f843e81a) | `` vectorchord: update for rust 1.88.0 ``                                                      |
| [`779a85d6`](https://github.com/NixOS/nixpkgs/commit/779a85d69d6c233ea08a208734ca1ce209b7c205) | `` postgresqlPackages.vectorchord: init at 0.4.2 ``                                            |
| [`d9c43548`](https://github.com/NixOS/nixpkgs/commit/d9c435487945b687c956a0e10314036adda4950c) | `` cargo-pgrx_0_14_1: init ``                                                                  |
| [`b5db1a37`](https://github.com/NixOS/nixpkgs/commit/b5db1a3769bd00a6fdf385a73fea6daf0e6df418) | `` rust_1_88: init ``                                                                          |