### PR TITLE
chore(flake/nur): `05b990a1` -> `7820797d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757862847,
-        "narHash": "sha256-THqVjPFLT2ntKfRepG3Vq/gvKyeFt6BJJVxO9QhR1Ok=",
+        "lastModified": 1757873808,
+        "narHash": "sha256-634v78BF9vA9yb7KQUsNmygZwSVRoqp1fZuPKHaVIq0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "05b990a1b8356c89589574c9c7ef4d59ee0dccb6",
+        "rev": "7820797dd8e2dcf4e02e6336e12d28e819510885",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7820797d`](https://github.com/nix-community/NUR/commit/7820797dd8e2dcf4e02e6336e12d28e819510885) | `` automatic update `` |
| [`700ec978`](https://github.com/nix-community/NUR/commit/700ec978f20788e8a6bc17d42cbb3294b0d7cc7b) | `` automatic update `` |
| [`8de27b67`](https://github.com/nix-community/NUR/commit/8de27b6789546d3278ebfab3b74dbf8951fdea1e) | `` automatic update `` |