### PR TITLE
chore(flake/nur): `7820797d` -> `087c74cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757873808,
-        "narHash": "sha256-634v78BF9vA9yb7KQUsNmygZwSVRoqp1fZuPKHaVIq0=",
+        "lastModified": 1757879066,
+        "narHash": "sha256-EHZWQe3a04DvOlUR2j7LwGCaGqYTStYExpstYezfq3c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7820797dd8e2dcf4e02e6336e12d28e819510885",
+        "rev": "087c74cd9cc63e44dd20f1dcc5cdb4e5fddc9e14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`087c74cd`](https://github.com/nix-community/NUR/commit/087c74cd9cc63e44dd20f1dcc5cdb4e5fddc9e14) | `` automatic update `` |
| [`e45253e4`](https://github.com/nix-community/NUR/commit/e45253e4255c8d43f1b50f94a796b88d393b0516) | `` automatic update `` |