### PR TITLE
chore(flake/nur): `39a50048` -> `814a665d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757907064,
-        "narHash": "sha256-uY4eVR5rhaljJ2e0n73TCObR5A9Be0a8oM755x/ZpNM=",
+        "lastModified": 1757912195,
+        "narHash": "sha256-UFT/AUKT8MDrOjVlapNA5BgEcj37CFjnPVnMLr9citM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "39a500481ef506eaa9ee2a1b334e98442cef7313",
+        "rev": "814a665dec85168be24b9b95f58a86ca9e3b18b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`814a665d`](https://github.com/nix-community/NUR/commit/814a665dec85168be24b9b95f58a86ca9e3b18b3) | `` automatic update `` |
| [`ae5c59b5`](https://github.com/nix-community/NUR/commit/ae5c59b5579fdcf43a408a59fe1d572c612ff21a) | `` automatic update `` |
| [`8a0c9c76`](https://github.com/nix-community/NUR/commit/8a0c9c76f6349a9be46687120b4c079ed083dbec) | `` automatic update `` |
| [`04f04e2e`](https://github.com/nix-community/NUR/commit/04f04e2e06c1f333f7e02e80fbc934c7c9a5947e) | `` automatic update `` |