### PR TITLE
chore(flake/nur): `814a665d` -> `faa6db03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757912195,
-        "narHash": "sha256-UFT/AUKT8MDrOjVlapNA5BgEcj37CFjnPVnMLr9citM=",
+        "lastModified": 1757926294,
+        "narHash": "sha256-WwxEPPSjT+NuHQ9KKnHjXB3kCA+8GJUKLAZtKpM5hMo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "814a665dec85168be24b9b95f58a86ca9e3b18b3",
+        "rev": "faa6db03cf4dde29cb562afc0dcd8dd2a018506b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`faa6db03`](https://github.com/nix-community/NUR/commit/faa6db03cf4dde29cb562afc0dcd8dd2a018506b) | `` automatic update `` |
| [`ea777b8d`](https://github.com/nix-community/NUR/commit/ea777b8da72d16f8b145cd9bf45f6790d482870c) | `` automatic update `` |
| [`580fb81d`](https://github.com/nix-community/NUR/commit/580fb81de55289fcfb13b6de744706efcc483139) | `` automatic update `` |
| [`ef33d6c1`](https://github.com/nix-community/NUR/commit/ef33d6c1b7f367a7ccd08039b81940d40019d980) | `` automatic update `` |