### PR TITLE
chore(flake/catppuccin): `d75e3fe6` -> `039cd593`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1757320803,
-        "narHash": "sha256-7PUIQOMQSJLkNtV42SAYUDw0mRdbBNl6q8pLN8GViwM=",
+        "lastModified": 1757929733,
+        "narHash": "sha256-dzKGtCdGbW7v95MS6pxb97u025JP24QsqCLE5bHAumI=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "d75e3fe67f49728cb5035bc791f4b9065ff3a2c9",
+        "rev": "039cd59357bc6fdd8d9848717069fbc9ee609a73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                             |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`039cd593`](https://github.com/catppuccin/nix/commit/039cd59357bc6fdd8d9848717069fbc9ee609a73) | `` feat(wezterm): set flavor and accent as plugin options (#714) `` |