### PR TITLE
chore(flake/nur): `faa6db03` -> `b8ed69c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757926294,
-        "narHash": "sha256-WwxEPPSjT+NuHQ9KKnHjXB3kCA+8GJUKLAZtKpM5hMo=",
+        "lastModified": 1757935448,
+        "narHash": "sha256-dIk3hiBlSsHZJViknedzOyTb7VjHFmty6d2P59/DRi4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "faa6db03cf4dde29cb562afc0dcd8dd2a018506b",
+        "rev": "b8ed69c1bcb6c358bb1df56e2a2e64323f6572c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b8ed69c1`](https://github.com/nix-community/NUR/commit/b8ed69c1bcb6c358bb1df56e2a2e64323f6572c6) | `` automatic update `` |
| [`862837e1`](https://github.com/nix-community/NUR/commit/862837e18858ee00735f8268faed6db8010289ac) | `` automatic update `` |
| [`0f5e4ecb`](https://github.com/nix-community/NUR/commit/0f5e4ecbdfd50a2deb75f344a03e5cfa22b97bcb) | `` automatic update `` |