### PR TITLE
chore(flake/nur): `b8ed69c1` -> `9c4ccef9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757935448,
-        "narHash": "sha256-dIk3hiBlSsHZJViknedzOyTb7VjHFmty6d2P59/DRi4=",
+        "lastModified": 1757946652,
+        "narHash": "sha256-PpPoePu9UIJdjtuaQ1xLM8PVqekI2s9im7r3SWgpVtU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8ed69c1bcb6c358bb1df56e2a2e64323f6572c6",
+        "rev": "9c4ccef96fa4d2411b89a3696d3e871047219b93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9c4ccef9`](https://github.com/nix-community/NUR/commit/9c4ccef96fa4d2411b89a3696d3e871047219b93) | `` automatic update `` |
| [`e4e8cca6`](https://github.com/nix-community/NUR/commit/e4e8cca6d8fb377268c1ff08866bd74baadbdd74) | `` automatic update `` |