### PR TITLE
chore(flake/nur): `939422c1` -> `a24ff512`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757954034,
-        "narHash": "sha256-7FNvbjOeFcIBdh0EKonuDqpZTFKIIQtvfnZzF6bVZ+A=",
+        "lastModified": 1757968642,
+        "narHash": "sha256-GbL3gG34qKlntzcifoiffLbvOkfKuGSPR+mdsS7erVA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "939422c175697c2b18c35402e2dd7f7c956d0b0f",
+        "rev": "a24ff512e1988d950617b17c8d6ee6fd6c224f8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a24ff512`](https://github.com/nix-community/NUR/commit/a24ff512e1988d950617b17c8d6ee6fd6c224f8f) | `` automatic update `` |
| [`804e60f9`](https://github.com/nix-community/NUR/commit/804e60f931721c78ed8a3574e08367848cf9b2d3) | `` automatic update `` |
| [`3d990ad3`](https://github.com/nix-community/NUR/commit/3d990ad3e435665985501136542430129557c982) | `` automatic update `` |
| [`595d1949`](https://github.com/nix-community/NUR/commit/595d194911a8af218758c9c0e6c799d659b04635) | `` automatic update `` |
| [`ae12f600`](https://github.com/nix-community/NUR/commit/ae12f600b1e5917b49c703c25bdf3411296a9578) | `` automatic update `` |