### PR TITLE
chore(flake/nur): `a24ff512` -> `f95a3dbe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757968642,
-        "narHash": "sha256-GbL3gG34qKlntzcifoiffLbvOkfKuGSPR+mdsS7erVA=",
+        "lastModified": 1757985713,
+        "narHash": "sha256-MB4ORoxCbdQA4NJ2kfM5RgeQWKIZujnU3kVYAt48tyw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a24ff512e1988d950617b17c8d6ee6fd6c224f8f",
+        "rev": "f95a3dbe35fab8e710405ec56954c3569a9455b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f95a3dbe`](https://github.com/nix-community/NUR/commit/f95a3dbe35fab8e710405ec56954c3569a9455b2) | `` automatic update `` |
| [`db3235d9`](https://github.com/nix-community/NUR/commit/db3235d9d37d8429e14bbdc47d96052bfcc2b0f0) | `` automatic update `` |
| [`1e556543`](https://github.com/nix-community/NUR/commit/1e556543d4f6b875b6a7804fb80b2a579f52e658) | `` automatic update `` |
| [`0451b700`](https://github.com/nix-community/NUR/commit/0451b70035231141093583887a7486dc19e34aa9) | `` automatic update `` |