### PR TITLE
chore(flake/nur): `f95a3dbe` -> `35feff58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757985713,
-        "narHash": "sha256-MB4ORoxCbdQA4NJ2kfM5RgeQWKIZujnU3kVYAt48tyw=",
+        "lastModified": 1757992969,
+        "narHash": "sha256-jEkLXS88V9kmb2UUAGPPBBtK+MMcuJYNR2wqzRe0jWU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f95a3dbe35fab8e710405ec56954c3569a9455b2",
+        "rev": "35feff5837f1bec08d08363440401c6b6eacfd59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`35feff58`](https://github.com/nix-community/NUR/commit/35feff5837f1bec08d08363440401c6b6eacfd59) | `` automatic update `` |
| [`8712423b`](https://github.com/nix-community/NUR/commit/8712423b8f4fde40d1cc0abd54ae5ce2ec874645) | `` automatic update `` |
| [`8fe460a9`](https://github.com/nix-community/NUR/commit/8fe460a987fa426e9e3b3df6866906c465ddcc86) | `` automatic update `` |
| [`8cbf345c`](https://github.com/nix-community/NUR/commit/8cbf345cb0543cbcc37d4ce55e46bb54e3c3d405) | `` automatic update `` |
| [`ebee56ec`](https://github.com/nix-community/NUR/commit/ebee56ecf49af3f694708e988cce0fc66063329e) | `` automatic update `` |