### PR TITLE
chore(flake/nur): `35feff58` -> `16a8c1b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1757992969,
-        "narHash": "sha256-jEkLXS88V9kmb2UUAGPPBBtK+MMcuJYNR2wqzRe0jWU=",
+        "lastModified": 1758001116,
+        "narHash": "sha256-N4yJD4Rx/EkSovoaYZXAcp+ZO1pMWFlupK2e9kZ6d28=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "35feff5837f1bec08d08363440401c6b6eacfd59",
+        "rev": "16a8c1b2732e63845a09258f07154c357d030b56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`16a8c1b2`](https://github.com/nix-community/NUR/commit/16a8c1b2732e63845a09258f07154c357d030b56) | `` automatic update `` |
| [`e8f07235`](https://github.com/nix-community/NUR/commit/e8f07235b7bd43b7b8cd953fd26d3cb296dc84db) | `` automatic update `` |
| [`4ec082f4`](https://github.com/nix-community/NUR/commit/4ec082f4bd6b871b5818b37e6ac3a003454623ab) | `` automatic update `` |
| [`53397280`](https://github.com/nix-community/NUR/commit/53397280c69a12d9c93ad112a82130640dd1d2de) | `` automatic update `` |
| [`3ef6c29b`](https://github.com/nix-community/NUR/commit/3ef6c29bb71dfbf2359b503305b2f87e0b10c316) | `` automatic update `` |
| [`6619c482`](https://github.com/nix-community/NUR/commit/6619c4829725395bf01405d049ae6463046c3d14) | `` automatic update `` |