### PR TITLE
chore(flake/nur): `a3edb9f5` -> `ae4accde`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758018355,
-        "narHash": "sha256-35cUmHz97F0DpWwKuNTyWNlYnNoR0N1Ax4rnQrpJAJA=",
+        "lastModified": 1758035786,
+        "narHash": "sha256-2dRfZ5U+poM26ppSNClKJ3Y+tjlhFClFa5BdR7py01k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a3edb9f5c3f966b66d77524339d3cf916de9e767",
+        "rev": "ae4accdeb1b0f8bd79864fb9653aa96f50895cff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ae4accde`](https://github.com/nix-community/NUR/commit/ae4accdeb1b0f8bd79864fb9653aa96f50895cff) | `` automatic update `` |
| [`8922be0d`](https://github.com/nix-community/NUR/commit/8922be0d87d41208726670fd9ecab19e85b175b8) | `` automatic update `` |
| [`1ab4bfbc`](https://github.com/nix-community/NUR/commit/1ab4bfbca869b2987376da659482ae758bac101c) | `` automatic update `` |
| [`f534dee3`](https://github.com/nix-community/NUR/commit/f534dee3dc628ceb5b036b174363c1196df5a529) | `` automatic update `` |
| [`36758ec2`](https://github.com/nix-community/NUR/commit/36758ec2a8469cdf1531b242fa8b66224db78f9c) | `` automatic update `` |