### PR TITLE
chore(flake/nur): `ae4accde` -> `1b4c76b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758035786,
-        "narHash": "sha256-2dRfZ5U+poM26ppSNClKJ3Y+tjlhFClFa5BdR7py01k=",
+        "lastModified": 1758038335,
+        "narHash": "sha256-zDIMvKyBM/F4aiS3XVBpwaEBpPwlmvbXGjt22l0H6b0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ae4accdeb1b0f8bd79864fb9653aa96f50895cff",
+        "rev": "1b4c76b4c9d3bfeca70dbb6010d0828fc4b0333f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1b4c76b4`](https://github.com/nix-community/NUR/commit/1b4c76b4c9d3bfeca70dbb6010d0828fc4b0333f) | `` automatic update `` |
| [`a533de9e`](https://github.com/nix-community/NUR/commit/a533de9ef01ea5e7214450d01212e8e401914fab) | `` automatic update `` |
| [`9bb37d8e`](https://github.com/nix-community/NUR/commit/9bb37d8eadbe71aa1bea0a1166af30ed97be2dff) | `` automatic update `` |