### PR TITLE
chore(flake/nur): `1b4c76b4` -> `b8cca7a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758038335,
-        "narHash": "sha256-zDIMvKyBM/F4aiS3XVBpwaEBpPwlmvbXGjt22l0H6b0=",
+        "lastModified": 1758056997,
+        "narHash": "sha256-frcue14+NJytCikjQrIqylhV7SzCaYDiBg1LSKriKn8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1b4c76b4c9d3bfeca70dbb6010d0828fc4b0333f",
+        "rev": "b8cca7a6775a9a717a6915d67a98edaeb9dde6ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                  |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`b8cca7a6`](https://github.com/nix-community/NUR/commit/b8cca7a6775a9a717a6915d67a98edaeb9dde6ec) | `` automatic update ``                                   |
| [`b2db9ce3`](https://github.com/nix-community/NUR/commit/b2db9ce3be8c5a38616e34a2c2f94283e8003222) | `` automatic update ``                                   |
| [`b1ab35e7`](https://github.com/nix-community/NUR/commit/b1ab35e7ca9b36f21ea7b306f1943716f391f661) | `` Update cachix/install-nix-action digest to 7be5dee `` |
| [`19d08cf4`](https://github.com/nix-community/NUR/commit/19d08cf44b5d3b732aa43844612a323a8399083a) | `` automatic update ``                                   |
| [`9ba1ab3f`](https://github.com/nix-community/NUR/commit/9ba1ab3f96fc044c3ed1ed7d648ce523634022a3) | `` automatic update ``                                   |
| [`e528e8ea`](https://github.com/nix-community/NUR/commit/e528e8ea812e6195604ad2eb1f1187c253ccbefb) | `` automatic update ``                                   |