### PR TITLE
chore(flake/nur): `329170b1` -> `2d68f026`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758072065,
-        "narHash": "sha256-Jb611WVlzAH15TedErg4KolSf+HIPC/NdBAvx/qNBDI=",
+        "lastModified": 1758079359,
+        "narHash": "sha256-YkRiR030SGBU7tLP8YZ18ProRx/WuWHadBJhiN2BiQY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "329170b1c9a5e0953c5880b7c539c16f6b795440",
+        "rev": "2d68f026c920ffc6e6cb7010eab4196fa682e70f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d68f026`](https://github.com/nix-community/NUR/commit/2d68f026c920ffc6e6cb7010eab4196fa682e70f) | `` automatic update `` |
| [`3d1ff80d`](https://github.com/nix-community/NUR/commit/3d1ff80d622f7fb0db062fb0e116931afbf8253b) | `` automatic update `` |
| [`67e8b0f1`](https://github.com/nix-community/NUR/commit/67e8b0f19ffc94d3ed0a7f7b95d71e54658a3379) | `` automatic update `` |