### PR TITLE
chore(flake/nur): `2d68f026` -> `8c08ab7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758079359,
-        "narHash": "sha256-YkRiR030SGBU7tLP8YZ18ProRx/WuWHadBJhiN2BiQY=",
+        "lastModified": 1758090586,
+        "narHash": "sha256-6CXur7TWODx21TW5kRovL5usMyvRyjntLO/W5Yy/hfo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d68f026c920ffc6e6cb7010eab4196fa682e70f",
+        "rev": "8c08ab7dbfba494a0c5fdbb8143f41454e1914b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8c08ab7d`](https://github.com/nix-community/NUR/commit/8c08ab7dbfba494a0c5fdbb8143f41454e1914b6) | `` automatic update `` |
| [`e7f85625`](https://github.com/nix-community/NUR/commit/e7f85625fc91e2304464bcfeac568bee8333c2e0) | `` automatic update `` |
| [`af8dcc2b`](https://github.com/nix-community/NUR/commit/af8dcc2b544e2cefa9087fb53687d2ef07c6f8a2) | `` automatic update `` |
| [`0bb5abc7`](https://github.com/nix-community/NUR/commit/0bb5abc78108ea6dbec8f936c7ca3140d936be2c) | `` automatic update `` |
| [`a3ce7a2a`](https://github.com/nix-community/NUR/commit/a3ce7a2aaac86ebcf8ffa3f9a3b0e1b4ff28aad6) | `` automatic update `` |
| [`0d7cc91a`](https://github.com/nix-community/NUR/commit/0d7cc91a2665c82922af6c78a4239b5b858c66ac) | `` automatic update `` |
| [`5743e7d4`](https://github.com/nix-community/NUR/commit/5743e7d4194da06184eb2f4aa65be68ee3d61c7f) | `` automatic update `` |