### PR TITLE
chore(flake/nur): `8c08ab7d` -> `619c1818`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758090586,
-        "narHash": "sha256-6CXur7TWODx21TW5kRovL5usMyvRyjntLO/W5Yy/hfo=",
+        "lastModified": 1758100430,
+        "narHash": "sha256-hmQpn4Jn7C7NLXYYxM5WXL0tNlMFOH4G6hYvdqK0IGs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8c08ab7dbfba494a0c5fdbb8143f41454e1914b6",
+        "rev": "619c18181cc8800620391b039194ed77cbe28a54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`619c1818`](https://github.com/nix-community/NUR/commit/619c18181cc8800620391b039194ed77cbe28a54) | `` automatic update `` |
| [`2f610c4f`](https://github.com/nix-community/NUR/commit/2f610c4f373970eb05cc0427dd84101f57db2605) | `` automatic update `` |
| [`8ddfe16b`](https://github.com/nix-community/NUR/commit/8ddfe16be4f0878ac1efd3d9b72d563da147b348) | `` automatic update `` |
| [`fd8b7a0a`](https://github.com/nix-community/NUR/commit/fd8b7a0aabea9b76780c309a534e9737978c6338) | `` automatic update `` |
| [`5d2e99bd`](https://github.com/nix-community/NUR/commit/5d2e99bd13c56536be8598b77adb5a1e005504dc) | `` automatic update `` |