### PR TITLE
chore(flake/nixpkgs): `9a094440` -> `7ff83701`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1757810152,
-        "narHash": "sha256-Vp9K5ol6h0J90jG7Rm4RWZsCB3x7v5VPx588TQ1dkfs=",
+        "lastModified": 1757941119,
+        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9a094440e02a699be5c57453a092a8baf569bdad",
+        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`ead4753b`](https://github.com/NixOS/nixpkgs/commit/ead4753b4dd4ac087fa60ef3e6f7264512378a29) | `` build(deps): bump actions/create-github-app-token from 2.1.1 to 2.1.4 `` |
| [`6024fc69`](https://github.com/NixOS/nixpkgs/commit/6024fc6987919771dc420dbeb7a05c83362f711d) | `` ci/github-script/labels: don't add stale if issue was mentioned ``       |
| [`0dcfeb89`](https://github.com/NixOS/nixpkgs/commit/0dcfeb89478818f3536066e2f1fb0a5a25b079d4) | `` bcachefs-tools: 1.25.3 -> 1.31.0 ``                                      |
| [`fa8c0686`](https://github.com/NixOS/nixpkgs/commit/fa8c0686f6910f2616d0e9bef0fdbdc45ccd46f0) | `` bcachefs-tools: 1.25.2 -> 1.25.3 ``                                      |
| [`86f63746`](https://github.com/NixOS/nixpkgs/commit/86f63746e4b0a1058d5ce79234720a50a11777c3) | `` nixos/bcachefs, bcachefs: add johnrtitor as maintainer ``                |
| [`fe7bd477`](https://github.com/NixOS/nixpkgs/commit/fe7bd4778f0a7648ef57798318888fd0eab980aa) | `` bcachefs-tools: 1.25.1 -> 1.25.2 ``                                      |
| [`b3f02c9a`](https://github.com/NixOS/nixpkgs/commit/b3f02c9a60c68696fda6d2d61bb5eaae85f59c3d) | `` nixos/bind: add extraArgs option for command-line arguments ``           |
| [`4f2d8275`](https://github.com/NixOS/nixpkgs/commit/4f2d8275f9efd64780b8103d969a598fe446ee41) | `` podman: patch CVE-2025-9566 ``                                           |
| [`e878f761`](https://github.com/NixOS/nixpkgs/commit/e878f761d426c466acfb010d0f2f4b3799577c5e) | `` freetube: 0.23.8 -> 0.23.9 ``                                            |
| [`d9e6a29c`](https://github.com/NixOS/nixpkgs/commit/d9e6a29ccf9b7bb9c5635381bb47cba14db35a9a) | `` lighttpd: 1.4.81 -> 1.4.82 ``                                            |
| [`1d7dd0fa`](https://github.com/NixOS/nixpkgs/commit/1d7dd0faaa0f987535c9c1828dc7eb8c4b8b58f7) | `` [Backport release-25.05] vscodium: 1.100.13210 -> 1.104.06114 ``         |
| [`77209bd9`](https://github.com/NixOS/nixpkgs/commit/77209bd9037dfd4cf1c3e2f66744c509e67d3733) | `` vscode: 1.103.2 -> 1.104.0 ``                                            |
| [`72ab9afc`](https://github.com/NixOS/nixpkgs/commit/72ab9afc1f09b08119c5eb4f8315aac0642d90b0) | `` python3Packages.mandown: 1.12.1 -> 1.12.2 ``                             |
| [`a83ef279`](https://github.com/NixOS/nixpkgs/commit/a83ef279d96cf8b9d90573893f77e4a05fe84b8c) | `` llvmPackages_20: 20.1.6 -> 20.1.8 ``                                     |
| [`e6876322`](https://github.com/NixOS/nixpkgs/commit/e687632294ded83a1e8ad441b2cabb75eaecf58c) | `` invidious: 2.20250504.0 -> 2.20250913.0 ``                               |
| [`5e91b93f`](https://github.com/NixOS/nixpkgs/commit/5e91b93f59df436461f5674e86fcdfc294ed97a7) | `` sarasa-gothic: 1.0.32 -> 1.0.33 ``                                       |
| [`130ae62f`](https://github.com/NixOS/nixpkgs/commit/130ae62f938a8aeb7ff586086cf067f0cbac48ff) | `` uradvd: init at 0-unstable-2025-08-16 ``                                 |
| [`da689a5f`](https://github.com/NixOS/nixpkgs/commit/da689a5f39e1c4645ba2a74e5c8fc0390336c03b) | `` maintainers: add aiyion ``                                               |
| [`fe1438c4`](https://github.com/NixOS/nixpkgs/commit/fe1438c4897614d9574ac15da704410cebd7d961) | `` perlPackages.CpanelJSONXS: Patch for CVE-2025-40929 ``                   |
| [`5c66b621`](https://github.com/NixOS/nixpkgs/commit/5c66b6215d59d14da8efeb9fc1e9d1cdb11cafd2) | `` perlPackages.JSONXS: Patch for CVE-2025-40928 ``                         |
| [`9dd33108`](https://github.com/NixOS/nixpkgs/commit/9dd33108c92e9bb685d434dd798e1a350a0d1b36) | `` twitch-cli: add shell completions ``                                     |
| [`89c7dc17`](https://github.com/NixOS/nixpkgs/commit/89c7dc17a8485d171f6fd3f801aed65c6197a23b) | `` ddev: 1.24.6 -> 1.24.7 ``                                                |
| [`0e17953a`](https://github.com/NixOS/nixpkgs/commit/0e17953a2ad9e69fdb44bafa06d916600e4f2685) | `` ddev: 1.24.5 -> 1.24.6 ``                                                |
| [`16e96ec2`](https://github.com/NixOS/nixpkgs/commit/16e96ec29c43be8d45e066641c5210e9f4eb89f7) | `` nano: 8.5 -> 8.6 ``                                                      |
| [`c4705bed`](https://github.com/NixOS/nixpkgs/commit/c4705bede3dacafba6feb104fbc48f12763eddaf) | `` nano: unbreak on darwin ``                                               |
| [`5057aae4`](https://github.com/NixOS/nixpkgs/commit/5057aae493a45186abee0c74d48e8aebb8026dab) | `` nano: 8.4 -> 8.5 ``                                                      |