### PR TITLE
chore(flake/nur): `1db115a4` -> `0b3eab92`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758109308,
-        "narHash": "sha256-4AdIQNIxQkOjeOZ0ALsM6f2PA/vDG2rUVqhEGWpZFEE=",
+        "lastModified": 1758122475,
+        "narHash": "sha256-7EDWjY5h4Z7+GqXdk8gmzESKT9A1lDNKUFm+PQIcdro=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1db115a421a7cf95bd700b49482b63dcf9d9e80e",
+        "rev": "0b3eab9274f36edc45a0e8fe25f1dd0643fd3ba8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0b3eab92`](https://github.com/nix-community/NUR/commit/0b3eab9274f36edc45a0e8fe25f1dd0643fd3ba8) | `` automatic update `` |
| [`75db73fa`](https://github.com/nix-community/NUR/commit/75db73fa583b779c4605e963ff27238f3515e89f) | `` automatic update `` |
| [`958d2ac3`](https://github.com/nix-community/NUR/commit/958d2ac30171494df975b22d1364502560307bdf) | `` automatic update `` |