### PR TITLE
chore(flake/nixpkgs): `7ff83701` -> `e9b7f2ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1757941119,
-        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
+        "lastModified": 1758070117,
+        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
+        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                      |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`bcd5a96c`](https://github.com/NixOS/nixpkgs/commit/bcd5a96c47ddd05a56dd1ac6c442fdfb432d6736) | `` maintainers: rename drakon64 ``                           |
| [`c486053b`](https://github.com/NixOS/nixpkgs/commit/c486053b0074df8fa281ac453240e1f388e84847) | `` nixfmt: 1.0.0 → 1.0.1 ``                                  |
| [`ff076fe0`](https://github.com/NixOS/nixpkgs/commit/ff076fe0ab1820f5f2ff573d84e3e84b4984dffa) | `` ocsp-server: 0.6.0 -> 0.6.1 ``                            |
| [`5892f607`](https://github.com/NixOS/nixpkgs/commit/5892f607b2de72dfa062be31a7503186e4d17a7b) | `` nix-required-mounts: support new versions of Nix ``       |
| [`3a065135`](https://github.com/NixOS/nixpkgs/commit/3a065135a8517d5130c299ba4b0b1d113872dcc0) | `` element-desktop: 1.11.111 -> 1.11.112 ``                  |
| [`a9f6bb9d`](https://github.com/NixOS/nixpkgs/commit/a9f6bb9d7f598b84aadab082d0a38ffb0385b243) | `` element-web-unwrapped: 1.11.111 -> 1.11.112 ``            |
| [`fbf43397`](https://github.com/NixOS/nixpkgs/commit/fbf43397e6278072ef9b8c09e575929cf2913682) | `` rspamd: add option to use hyperscan or vectorscan ``      |
| [`0989e9e4`](https://github.com/NixOS/nixpkgs/commit/0989e9e44d9d2fa99f7b47f9391a0f92eb7515d1) | `` buildMozillaMach: use nss 3.115 for 143, 3.116 for 144 `` |
| [`472efdf1`](https://github.com/NixOS/nixpkgs/commit/472efdf15424072cb83cb75c2f9ac17e68b2f2cd) | `` nss_3_115: init at 3.115.1 ``                             |
| [`69f01f4f`](https://github.com/NixOS/nixpkgs/commit/69f01f4f16ca35132640ab89723344395cdc1897) | `` nss_latest: 3.115.1 -> 3.116 ``                           |
| [`c5a80709`](https://github.com/NixOS/nixpkgs/commit/c5a8070976f5815a3a5f5776f2c41ab1c7920449) | `` osquery: 5.18.1 -> 5.19.0 ``                              |
| [`1791973e`](https://github.com/NixOS/nixpkgs/commit/1791973eb0effc0d35b548d0cd0b7ce538c1cace) | `` firefox-esr-140-unwrapped: 140.2.0esr -> 140.3.0esr ``    |
| [`11725316`](https://github.com/NixOS/nixpkgs/commit/11725316f631a4ba3ff13fe4efc38efcd26d6c16) | `` firefox-bin-unwrapped: 142.0.1 -> 143.0 ``                |
| [`721a2575`](https://github.com/NixOS/nixpkgs/commit/721a2575b0e03901fda2f8e016f1234a41c43f0c) | `` firefox-unwrapped: 142.0.1 -> 143.0 ``                    |
| [`8125e43c`](https://github.com/NixOS/nixpkgs/commit/8125e43c204ce89a3e6460e7ee98bfe17fad8eb3) | `` mastodon: 4.3.11 -> 4.3.12 ``                             |
| [`9e583408`](https://github.com/NixOS/nixpkgs/commit/9e583408baf42776f87f994348ba59ac4a9a1eb4) | `` firefox-beta-unwrapped: 143.0b9 -> 144.0b1 ``             |
| [`c785f719`](https://github.com/NixOS/nixpkgs/commit/c785f7198533dc35af6765dff40d4959d5b439e1) | `` firefox-devedition-unwrapped: 143.0b9 -> 144.0b1 ``       |
| [`648ca7ab`](https://github.com/NixOS/nixpkgs/commit/648ca7ab82ab3999b092f369890b2928736155a9) | `` alt-tab-macos: 7.27.0 -> 7.28.0 ``                        |
| [`22b5279f`](https://github.com/NixOS/nixpkgs/commit/22b5279f61b0123ca8fb07924238d1fe7d7ac0ab) | `` raycast: 1.102.7 -> 1.103.0 ``                            |
| [`cc86a59d`](https://github.com/NixOS/nixpkgs/commit/cc86a59d0702914aea893eff1b1597a4666ca0d1) | `` iina: 1.3.5 -> 1.4.0 ``                                   |
| [`4494b420`](https://github.com/NixOS/nixpkgs/commit/4494b42079bbe1c7de026817fad1ca7b89cceec9) | `` dolibarr: 22.0.0 -> 22.0.1 ``                             |
| [`9617c56e`](https://github.com/NixOS/nixpkgs/commit/9617c56e45f4048d91def7b0bac3a800d39c3a89) | `` nixos/invoiceplane: block access to ipconfig.php ``       |
| [`29aefc2f`](https://github.com/NixOS/nixpkgs/commit/29aefc2f6bde1eedbe512eaaab9a59917c90a818) | `` dua: 2.31.0 -> 2.32.0 ``                                  |
| [`94600779`](https://github.com/NixOS/nixpkgs/commit/946007790977dd9df23dd2aadf7cd0c435048e75) | `` percona-server: 8.4.5-5 -> 8.4.6-6 ``                     |
| [`d3abf0b0`](https://github.com/NixOS/nixpkgs/commit/d3abf0b070043d5e4ce5b259b16cdd3eaa71ac2a) | `` deltachat-desktop: 2.10.0 -> 2.11.0 ``                    |
| [`04b8cea7`](https://github.com/NixOS/nixpkgs/commit/04b8cea7d92ec7372ff04d23d1844913cdd406fc) | `` p2pool: 4.9.1 -> 4.10.1 ``                                |
| [`529ea781`](https://github.com/NixOS/nixpkgs/commit/529ea78173f8f19528df6f989c351a414523e628) | `` deltachat-desktop: 1.60.1 -> 2.10.0 ``                    |
| [`8058ffe7`](https://github.com/NixOS/nixpkgs/commit/8058ffe71cc00cf7cdf100b71dd99f1194ec29e2) | `` nixosTests.simple: drop minimal profile ``                |
| [`91eb7b64`](https://github.com/NixOS/nixpkgs/commit/91eb7b64091916c584014535cf4e117b68e69904) | `` ci/eval/compare: add 10.rebuild-nixos-tests label ``      |
| [`b1fe20fd`](https://github.com/NixOS/nixpkgs/commit/b1fe20fd04b9c828cde4b42ca39c1deed433ed07) | `` ci/eval: eval nixosTests.simple ``                        |
| [`cd6f92a2`](https://github.com/NixOS/nixpkgs/commit/cd6f92a28271d0eb17a4ccb5b07870275113a10a) | `` lxqt-wayland-session: add passthru.providedSessions ``    |
| [`b4c63a96`](https://github.com/NixOS/nixpkgs/commit/b4c63a96d8c785c6df834132416e9bf0855c48d5) | `` libdigidocpp: 4.2.0 -> 4.2.1 ``                           |
| [`5a3a53e5`](https://github.com/NixOS/nixpkgs/commit/5a3a53e545aaf92c9134dc795d3cb98e1fac59e5) | `` gclient2nix: update, fix for electron_38 ``               |
| [`8ae5d83c`](https://github.com/NixOS/nixpkgs/commit/8ae5d83c16e7bf4275122f93b3261710290de88c) | `` electron-chromedriver_38: init at 38.0.0 ``               |
| [`e6f8308a`](https://github.com/NixOS/nixpkgs/commit/e6f8308a32598e6c92b68c8bf6df50f85194aaf9) | `` electron_38-bin: init at 38.0.0 ``                        |
| [`e503ed1c`](https://github.com/NixOS/nixpkgs/commit/e503ed1cec1d37d72cd9e42ba29f19f2fcf985d9) | `` electron-source.electron_38: init at 38.0.0 ``            |
| [`2ed2627a`](https://github.com/NixOS/nixpkgs/commit/2ed2627a450f64acc9b1585b9126441291cf19ab) | `` immersed: 10.6.0 -> 10.9.0 ``                             |
| [`f6584535`](https://github.com/NixOS/nixpkgs/commit/f65845357466040bcfc3069ead7872ae1eb277e5) | `` immersed: add sources to passthru ``                      |
| [`bfefde1a`](https://github.com/NixOS/nixpkgs/commit/bfefde1afa2840f793d4b7e384603af135f94feb) | `` tuned: patch profile scripts ``                           |
| [`96339f45`](https://github.com/NixOS/nixpkgs/commit/96339f4520ba5ffeb6c1ec9702174b7f6f185eb6) | `` tuned: 2.25.1 -> 2.26.0 ``                                |