### PR TITLE
chore(flake/nixpkgs-unstable): `c23193b9` -> `8d4ddb19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
+        "lastModified": 1758035966,
+        "narHash": "sha256-qqIJ3yxPiB0ZQTT9//nFGQYn8X/PBoJbofA7hRKZnmE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
+        "rev": "8d4ddb19d03c65a36ad8d189d001dc32ffb0306b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`35eac3f2`](https://github.com/NixOS/nixpkgs/commit/35eac3f2b7f1ff137dd8b9e70dba7977b7fb53d4) | `` saunafs: 4.11.0 -> 5.1.2 ``                                                                   |
| [`f14c1d1e`](https://github.com/NixOS/nixpkgs/commit/f14c1d1e20e81f756129affd7b9baaa13b02f23d) | `` nixos/services.qdrant: add options to override packages ``                                    |
| [`9ae041d5`](https://github.com/NixOS/nixpkgs/commit/9ae041d530bbefcf890a765c6ec9ecb645d65a2f) | `` metal-cli: remove nshalman as maintainer ``                                                   |
| [`8f310550`](https://github.com/NixOS/nixpkgs/commit/8f310550408391919a3b85e2ea8cf94eb1886153) | `` intel-compute-runtime: 25.31.34666.3 -> 25.35.35096.9 ``                                      |
| [`3f042353`](https://github.com/NixOS/nixpkgs/commit/3f042353584960781931ea4736e97564c7ee14f2) | `` coqPackages.validsdp: init at 1.1.0 ``                                                        |
| [`48d5f731`](https://github.com/NixOS/nixpkgs/commit/48d5f731fa041cc6991940a31905608f7f1b1458) | `` cinnamon: 6.4.11 -> 6.4.12 ``                                                                 |
| [`159b1200`](https://github.com/NixOS/nixpkgs/commit/159b1200d4cdae1c5794a93cfccc9029cc36088e) | `` firefox-esr-140-unwrapped: 140.2.0esr -> 140.3.0esr ``                                        |
| [`1770adc1`](https://github.com/NixOS/nixpkgs/commit/1770adc165163966476de07b042b2bd1acab3965) | `` firefox-bin-unwrapped: 142.0.1 -> 143.0 ``                                                    |
| [`91d4d94c`](https://github.com/NixOS/nixpkgs/commit/91d4d94c3cc5c892575c2b2228d06388f30dd196) | `` firefox-unwrapped: 142.0.1 -> 143.0 ``                                                        |
| [`6a12eaf5`](https://github.com/NixOS/nixpkgs/commit/6a12eaf522a4c457acc99dd390fade8d62795c2b) | `` pgscv: 0.14.2 -> 0.15.0 ``                                                                    |
| [`354e6f4f`](https://github.com/NixOS/nixpkgs/commit/354e6f4fd1a79f62540ef2a01b3f89880b6cdb9c) | `` nemo-seahorse: Remove update script & cmake, simplify ``                                      |
| [`48d3d99f`](https://github.com/NixOS/nixpkgs/commit/48d3d99fe5e379a164378a731c0db2f3f031e571) | `` xemu: 0.8.97 -> 0.8.98 ``                                                                     |
| [`79feab6c`](https://github.com/NixOS/nixpkgs/commit/79feab6cff53917a2fd40be55547faf68ea0eee5) | `` pkgs/top-level/metrics.nix: use -print0 to insulate us from spaces in find ``                 |
| [`32c68bb4`](https://github.com/NixOS/nixpkgs/commit/32c68bb46e8d51f5833830750af8bbb078299949) | `` pkgs/top-level/metrics.nix: use the configure, build, and install phases ``                   |
| [`4e464488`](https://github.com/NixOS/nixpkgs/commit/4e464488d16b6aabbfc0a06b28d0b1ef4b8e5ff4) | `` watchlog: 1.248.0 -> 1.250.0 ``                                                               |
| [`fda7cefc`](https://github.com/NixOS/nixpkgs/commit/fda7cefcdbd5e50052dfd3bf9b97ae5cc32d8cf9) | `` pkgs/top-level/metrics.nix: pass --no-gc-warning so that no spew about --add-root shows up `` |
| [`8ac12754`](https://github.com/NixOS/nixpkgs/commit/8ac12754cecbfffadeb97178a32584f9342df04b) | `` pkgs/top-level/metrics.nix: turn off aliases in the evaluation ``                             |
| [`4973d534`](https://github.com/NixOS/nixpkgs/commit/4973d53405faece1e5394cc9616fca610641d117) | `` pkgs/top-level/metrics.nix: use the latest Nix version, just like CI ``                       |
| [`251dff3a`](https://github.com/NixOS/nixpkgs/commit/251dff3a3e2a057cb7c3f8e46e15e1d95211c012) | `` pkgs/top-level/metrics.nix: save the raw files, compressing the output ``                     |
| [`dfd90bf4`](https://github.com/NixOS/nixpkgs/commit/dfd90bf4c07b6eb3d101190c2ad2369c92ea52d5) | `` pkgs/top-level/metrics.nix: just run nix-env -qa once ``                                      |
| [`40e003d0`](https://github.com/NixOS/nixpkgs/commit/40e003d0623bb9e5b97e1740d9d28e6b3bbd455c) | `` dnscontrol: 4.24.0 -> 4.25.0 ``                                                               |
| [`146c6b9a`](https://github.com/NixOS/nixpkgs/commit/146c6b9aadc712723370be6ecee8d28fc8f60331) | `` pkgs/top-level/metrics.nix: use json, not XML ``                                              |
| [`e35ab562`](https://github.com/NixOS/nixpkgs/commit/e35ab56228ac9027e54c3eae9267fab48aaccd95) | `` pkgs/top-level/metrics.nix: use the eval-system parameter to target a specific system ``      |
| [`b9519e2c`](https://github.com/NixOS/nixpkgs/commit/b9519e2c0af72fe953c48cfa8e941d558219cfa2) | `` pkgs/top-level/metrics.nix: log out the statistics using jq with a header ``                  |
| [`94f1da56`](https://github.com/NixOS/nixpkgs/commit/94f1da567e4717c81fc28195a6eb301e720303b6) | `` pkgs/top-level/metrics.nix: convince the time command to output JSON ``                       |
| [`b2331161`](https://github.com/NixOS/nixpkgs/commit/b2331161b3aeb84a9a0be008cb1547cb3d34cb56) | `` pkgs/top-level/metrics.nix: remove the aggressive variants ``                                 |
| [`29db1d32`](https://github.com/NixOS/nixpkgs/commit/29db1d32be1964eefd223a974f733f261f32ec55) | `` pkgs/top-level/metrics.nix: use __structuredAttrs ``                                          |
| [`a34bbb6b`](https://github.com/NixOS/nixpkgs/commit/a34bbb6b9cd5f511fb5d5cff7d2ceb12d927cffb) | `` pkgs/top-level/metrics.nix: tidy up variables and quoting ``                                  |
| [`c3f0ef37`](https://github.com/NixOS/nixpkgs/commit/c3f0ef37ebf21bfea5c17a7ef7d53afc39f711bc) | `` pkgs/top-level/metrics.nix: add meta explaining this file ``                                  |
| [`f87776bd`](https://github.com/NixOS/nixpkgs/commit/f87776bd7c3cc67de6155ed8c9fd32ebda4bfdb0) | `` pkgs/top-level/metrics.nix: use stdenvNoCC.mkDerivation instead of runCommand ``              |
| [`2b5004ce`](https://github.com/NixOS/nixpkgs/commit/2b5004ce52225000d109ba1cfb97d6c1bd0cae4f) | `` maintainers: add gpg key for jasonxue1 ``                                                     |
| [`f1c94d46`](https://github.com/NixOS/nixpkgs/commit/f1c94d46ebfca36cb29d93204253951493f81fdc) | `` firefox-beta-unwrapped: 143.0b9 -> 144.0b1 ``                                                 |
| [`38f1f27d`](https://github.com/NixOS/nixpkgs/commit/38f1f27d5799ea314318d77852f47414aaf835b7) | `` ghostfolio: 2.193.0 -> 2.199.0 ``                                                             |
| [`92a54ec2`](https://github.com/NixOS/nixpkgs/commit/92a54ec20a7b5eb2021fb7c0ef90900ea40f842e) | `` Revert "nss_latest: 3.115.1 -> 3.116" ``                                                      |
| [`45d5f669`](https://github.com/NixOS/nixpkgs/commit/45d5f669f16e8087da83585d2749d5ece9c89730) | `` raycast: 1.102.7 -> 1.103.0 ``                                                                |
| [`15522090`](https://github.com/NixOS/nixpkgs/commit/155220903f5b20d857cd6222c37f63280517537c) | `` gam 6.58 -> 7.21.01 ``                                                                        |
| [`81cc1213`](https://github.com/NixOS/nixpkgs/commit/81cc12139c8af49f36bb377728e1d3b0bf73b82c) | `` firefox-devedition-unwrapped: 143.0b9 -> 144.0b1 ``                                           |
| [`5bdecea1`](https://github.com/NixOS/nixpkgs/commit/5bdecea140af91896fdf31ddef70183a94b12765) | `` nixos/ollama: add network-online.target to ollama-model-loader.service ``                     |
| [`c0d59d7b`](https://github.com/NixOS/nixpkgs/commit/c0d59d7be2e448b0002da5602c770613747625a4) | `` artichoke: 0-unstable-2025-08-18 -> 0-unstable-2025-09-07 ``                                  |
| [`460b5904`](https://github.com/NixOS/nixpkgs/commit/460b5904a6cdf06f971c5a4d145f26a15f84d979) | `` corestore: 7.4.5 -> 7.4.7 ``                                                                  |
| [`42379efb`](https://github.com/NixOS/nixpkgs/commit/42379efbd4a69f6ec7a664b24ec02c77b7ab177b) | `` ipopt: adopt ``                                                                               |
| [`2d9f87fd`](https://github.com/NixOS/nixpkgs/commit/2d9f87fd8e6522eb9dcd47f9e001e515d35a90c2) | `` claude-code: 1.0.113 -> 1.0.115 ``                                                            |
| [`f6f862c7`](https://github.com/NixOS/nixpkgs/commit/f6f862c70072fbac565633c407809d9739d5f934) | `` iina: 1.3.5 -> 1.4.0 ``                                                                       |
| [`b573b224`](https://github.com/NixOS/nixpkgs/commit/b573b2247dc67843d430a4b57fb011ba0c2d6d02) | `` alt-tab-macos: 7.27.0 -> 7.28.0 ``                                                            |
| [`28b8ab47`](https://github.com/NixOS/nixpkgs/commit/28b8ab477d538ce6e5acd56342141d1e714d6715) | `` adw-gtk3: 6.2 -> 6.3 ``                                                                       |
| [`36fc2725`](https://github.com/NixOS/nixpkgs/commit/36fc2725f2580c0c135d17de617713a119d9497c) | `` zsh-vi-mode: 0.11.0 -> 0.12.0 ``                                                              |
| [`d0cbfc24`](https://github.com/NixOS/nixpkgs/commit/d0cbfc24c23b2aa72e5fc442a9616a1fdd346fed) | `` ghstack: 0.11.0 -> 0.12.0 ``                                                                  |
| [`944ed42d`](https://github.com/NixOS/nixpkgs/commit/944ed42d8862bdfa8448d3edacfa151957e39f85) | `` pyradio: 0.9.3.11.16 -> 0.9.3.11.18 ``                                                        |
| [`e1e937c1`](https://github.com/NixOS/nixpkgs/commit/e1e937c16d0d35b75b976d604b7589e859f20fd6) | `` libretro.dosbox-pure: 0-unstable-2025-09-04 -> 0-unstable-2025-09-14 ``                       |
| [`782981b1`](https://github.com/NixOS/nixpkgs/commit/782981b163250a6418f87b8b0a0ec954a311c424) | `` yaziPlugins.recycle-bin: 0-unstable-2025-09-08 → 0-unstable-2025-09-15 ``                     |
| [`dcc218ab`](https://github.com/NixOS/nixpkgs/commit/dcc218ab3d37572b604ff98cb0585f39fda06c7e) | `` luaPackages: update on 2025-09-16 ``                                                          |
| [`263fc11c`](https://github.com/NixOS/nixpkgs/commit/263fc11c5b06d43b829953fc846794ce9e379134) | `` vimPlugins.nvim-treesitter: update grammars ``                                                |
| [`0821971e`](https://github.com/NixOS/nixpkgs/commit/0821971eccf0bee32d3dd635f0dd67800d72f337) | `` vimPlugins: update on 2025-09-16 ``                                                           |
| [`907237de`](https://github.com/NixOS/nixpkgs/commit/907237de15ee525b7af411ff63c39c00dd62dc49) | `` luau: 0.690 -> 0.691 ``                                                                       |
| [`f20d1087`](https://github.com/NixOS/nixpkgs/commit/f20d10875f4f8e6fc716388fad13b13855e85f8e) | `` snx-rs: 4.7.0 -> 4.8.0 ``                                                                     |
| [`798a52c3`](https://github.com/NixOS/nixpkgs/commit/798a52c35c680c65fa509091da68da7c8a036e55) | `` yaml-cpp: backport patch for CMake 4 ``                                                       |
| [`b214834c`](https://github.com/NixOS/nixpkgs/commit/b214834cb4356d56964a6e822cd1b89de63731f3) | `` yaml-cpp: move to `by-name` ``                                                                |
| [`a7b76dbe`](https://github.com/NixOS/nixpkgs/commit/a7b76dbe5a0b0df38c159df72fcf9e9ecf4731a8) | `` yaml-cpp_0_3: drop ``                                                                         |
| [`5fc1d432`](https://github.com/NixOS/nixpkgs/commit/5fc1d4322e3ea2374c0a9e3e04aee33af2c7fdf2) | `` proj: move to `by-name` ``                                                                    |
| [`61b477f6`](https://github.com/NixOS/nixpkgs/commit/61b477f6726e915b19b33e445d20f33ff8a2b743) | `` proj_7: drop ``                                                                               |
| [`5ec16659`](https://github.com/NixOS/nixpkgs/commit/5ec1665962fd5a7a3572a642e57c536a185712ee) | `` osm2xmap: drop ``                                                                             |
| [`1d56920e`](https://github.com/NixOS/nixpkgs/commit/1d56920ef790267c99fd3d9262dfc6ffdc7c7236) | `` libtap: drop ``                                                                               |
| [`bfa1361a`](https://github.com/NixOS/nixpkgs/commit/bfa1361ad136bc405a3a289aa37f3e7f3dc76af9) | `` freecell-solver: remove unused `libtap` dependency ``                                         |
| [`8b2b6233`](https://github.com/NixOS/nixpkgs/commit/8b2b6233df75ef979c82af5a9c8aaf238522ffda) | `` libmusicbrainz: 5.1.0 -> 5.1.0-unstable-2025-07-12 ``                                         |
| [`443539a9`](https://github.com/NixOS/nixpkgs/commit/443539a91c246cbbf76cca57fdbb9cbb20b78be6) | `` libmusicbrainz: move to `by-name` ``                                                          |
| [`e5d6c617`](https://github.com/NixOS/nixpkgs/commit/e5d6c617cf5673b6f66da328c46cde954047c672) | `` libmusicbrainz5: move to aliases ``                                                           |
| [`bb35c2a6`](https://github.com/NixOS/nixpkgs/commit/bb35c2a6b7fccc90d3e02b24e76da2e3bbd7dd07) | `` treewide: libmusicbrainz5 -> libmusicbrainz ``                                                |
| [`7ae890f1`](https://github.com/NixOS/nixpkgs/commit/7ae890f16ea7f3b3b8e709da921d003b25a7379c) | `` libmusicbrainz3: drop ``                                                                      |
| [`4196905d`](https://github.com/NixOS/nixpkgs/commit/4196905d20a47a8cbe31473a2bc40a72a36be9b2) | `` libmusicbrainz: libmusicbrainz_3 -> libmusicbrainz_5 ``                                       |
| [`ac2a8330`](https://github.com/NixOS/nixpkgs/commit/ac2a83303b83b91f7b9d0c584ce70fd2ad713c5f) | `` noto-fonts-color-emoji: 2.048 -> 2.051 ``                                                     |
| [`65b0da63`](https://github.com/NixOS/nixpkgs/commit/65b0da63a357fbf03de75f2dc1e0e6298f836d66) | `` llama-cpp: 6442 -> 6479 ``                                                                    |
| [`0686782a`](https://github.com/NixOS/nixpkgs/commit/0686782a7d7d439ada0bffec02cb87ee22229f97) | `` mint-l-theme: 2.0.1 -> 2.0.2 ``                                                               |
| [`27bbe639`](https://github.com/NixOS/nixpkgs/commit/27bbe639ae20c89a081a4ab0d9f8e83ae9dd9e2d) | `` codeberg-cli: 0.4.11 -> 0.5.0 ``                                                              |
| [`4ad5afa8`](https://github.com/NixOS/nixpkgs/commit/4ad5afa8f13aa2bdbf7591cc3131d6e79688a66b) | `` spidermonkey_140: 140.2.0 -> 140.3.0 ``                                                       |
| [`e5dd233b`](https://github.com/NixOS/nixpkgs/commit/e5dd233b0c526a743136eb548898e9df8aefef1f) | `` eask-cli: 0.11.7 -> 0.11.8 ``                                                                 |
| [`bb733d67`](https://github.com/NixOS/nixpkgs/commit/bb733d678d5129c6bac07765aa304d0d8f7da334) | `` calibre: prevent ninja build ``                                                               |
| [`1d4e7fe6`](https://github.com/NixOS/nixpkgs/commit/1d4e7fe6953ab278310abeb3e3c61bc2158b757e) | `` python3Packages.qtconsole: 5.6.1 -> 5.7.0 ``                                                  |
| [`37552f07`](https://github.com/NixOS/nixpkgs/commit/37552f074ac3404632abc8eb9ce8c02825e76742) | `` python3Packages.onnxmltools: fix by removing outdated patch ``                                |
| [`f7a05100`](https://github.com/NixOS/nixpkgs/commit/f7a0510047928d781f8548640c3ccc009371d5d1) | `` swift: don’t build LLVM tools ``                                                              |
| [`0a3ce757`](https://github.com/NixOS/nixpkgs/commit/0a3ce757a8e45abdc89142077addeb7cd7ac6556) | `` python3Packages.cleanlab: mark as broken (incompatible with datasets 4.0.0) ``                |
| [`f4051a29`](https://github.com/NixOS/nixpkgs/commit/f4051a29d2e3f73045d38160585c859c6f21913a) | `` ddev: use versionCheckHook ``                                                                 |
| [`f68891f1`](https://github.com/NixOS/nixpkgs/commit/f68891f1c05930ef02b561c9ac93bce34dc3c1e2) | `` python3Packages.crewai: 0.175.0 -> 0.186.1 ``                                                 |
| [`caddb361`](https://github.com/NixOS/nixpkgs/commit/caddb361966e9cc390a6527842374b579e3dd633) | `` nixosTests.lxd: remove references to removed test ``                                          |
| [`49c5cfd3`](https://github.com/NixOS/nixpkgs/commit/49c5cfd30723951a35d570f54b2c6277e3effa8b) | `` ijq: 1.1.2 -> 1.2.0 ``                                                                        |
| [`171131fd`](https://github.com/NixOS/nixpkgs/commit/171131fdd24e0e69cce39cc06fa817a33f9a37d8) | `` taterclient-ddnet: 10.5.0 -> 10.5.2 ``                                                        |
| [`403ef9ab`](https://github.com/NixOS/nixpkgs/commit/403ef9abb3e984661c2778198cca830e902e47c8) | `` dmenu-rs: Fix build failure ``                                                                |
| [`5c980855`](https://github.com/NixOS/nixpkgs/commit/5c980855c5e0f67593a6fae39678fca3f1f77917) | `` python3Packages.onnxconverter-common: 1.15.0 -> 0.16.0 ``                                     |
| [`a3b8cc13`](https://github.com/NixOS/nixpkgs/commit/a3b8cc13e02e5304d0f46531ec01fadcbeb2bbce) | `` python3Packages.onnxruntime: remove commented dependencies ``                                 |
| [`1a29ea37`](https://github.com/NixOS/nixpkgs/commit/1a29ea3780b398b27fa166780e301532a2da9923) | `` python3Packages.onnxslim: 0.1.62 -> 0.1.68 ``                                                 |
| [`0a622049`](https://github.com/NixOS/nixpkgs/commit/0a6220495c292f37799b687d8e7fd151765ce165) | `` python3Packages.onnxruntime-tools: cleanup ``                                                 |
| [`62b9d54f`](https://github.com/NixOS/nixpkgs/commit/62b9d54f7824824c2681b924eef07b6718b464ff) | `` python3Packages.onnx: 1.18.0 -> 1.19.0 ``                                                     |
| [`aa5693fc`](https://github.com/NixOS/nixpkgs/commit/aa5693fc1933a4452ba04efd68373996aca43483) | `` onnxruntime: 1.22.0 -> 1.22.2 ``                                                              |
| [`318f5b6c`](https://github.com/NixOS/nixpkgs/commit/318f5b6c91ecf071f6bae8240a7c845e8e529f53) | `` dolibarr: 22.0.0 -> 22.0.1 ``                                                                 |
| [`14841895`](https://github.com/NixOS/nixpkgs/commit/14841895e581672be04a0e71f19242464f21f6bc) | `` mpv: add `StartupNotify=false` to umpv.desktop ``                                             |
| [`6f6d35e6`](https://github.com/NixOS/nixpkgs/commit/6f6d35e618a51f95d9dcd5db980ad5cefc5f0f4e) | `` goperf: 0-unstable-2025-08-13 -> 0-unstable-2025-09-09 ``                                     |
| [`ba0dce59`](https://github.com/NixOS/nixpkgs/commit/ba0dce59a2bd9773bd215ce4b6266076eee86472) | `` n8n: 1.109.2 -> 1.111.0 ``                                                                    |
| [`1f43dd1a`](https://github.com/NixOS/nixpkgs/commit/1f43dd1afe7b2b4b0eeee2c80e90b4284c56eb54) | `` cloudflare-cli: 5.0.5 -> 5.1.0 ``                                                             |
| [`a3b4c88a`](https://github.com/NixOS/nixpkgs/commit/a3b4c88a030d61190b481339e6f9a2849cd4cae1) | `` apparmor-parser: use full path for aa-status ``                                               |
| [`4fa3ecb2`](https://github.com/NixOS/nixpkgs/commit/4fa3ecb2ed79a0ad5e9fea8d47d05d8bf137e895) | `` nix-search-tv: 2.2.0 -> 2.2.1 ``                                                              |
| [`7aaa8cd5`](https://github.com/NixOS/nixpkgs/commit/7aaa8cd56007913f1876296c7ff46b7f96dc89e1) | `` codex: 0.34.0 -> 0.36.0 ``                                                                    |
| [`b3fd043d`](https://github.com/NixOS/nixpkgs/commit/b3fd043d72839a569a085784e03e332fcd222358) | `` ghostty-bin: 1.1.3 -> 1.2.0 ``                                                                |
| [`539a8b7c`](https://github.com/NixOS/nixpkgs/commit/539a8b7cd027b667fd01ec763dff2fbb1d585908) | `` ghostty: 1.1.3 -> 1.2.0 ``                                                                    |
| [`8a67c5a5`](https://github.com/NixOS/nixpkgs/commit/8a67c5a5baafae948e19aaa5f757cd8aff369700) | `` hyprlandPlugins.hy3: fix update script pattern matching ``                                    |
| [`7b68a993`](https://github.com/NixOS/nixpkgs/commit/7b68a993ad79a2024a75751128c1220d1bfdbf90) | `` vimPlugins.blink-cmp: 1.6.0 -> 1.7.0 ``                                                       |
| [`eb497d15`](https://github.com/NixOS/nixpkgs/commit/eb497d15d4ceccb38e0610a81bb71ee99bac7770) | `` onedrivegui: 1.2.1 -> 1.2.2 ``                                                                |