### PR TITLE
chore(flake/nur): `426a853e` -> `c65133bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758185453,
-        "narHash": "sha256-BRoOBaro43+V1ozudkJOMDwcr2zjMY2rcEkqTm7POOc=",
+        "lastModified": 1758199704,
+        "narHash": "sha256-qZA/gw8/Q2vjw44vUiTJm2NAA8GYQb9h38rws4Rzw8o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "426a853e38fa0386793bf6d18aaa7a2f2ce0a5c0",
+        "rev": "c65133bcbc1a44afc0f43eceb64c440f81f6a63e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c65133bc`](https://github.com/nix-community/NUR/commit/c65133bcbc1a44afc0f43eceb64c440f81f6a63e) | `` automatic update `` |
| [`6a9adb2a`](https://github.com/nix-community/NUR/commit/6a9adb2a32f99087a3723a90ba4f82825c80aaba) | `` automatic update `` |
| [`82fb7db6`](https://github.com/nix-community/NUR/commit/82fb7db65972486e5a200af470154b6ad5751307) | `` automatic update `` |
| [`b65ea76b`](https://github.com/nix-community/NUR/commit/b65ea76b988f26cbc4a9325c3acae4736be26461) | `` automatic update `` |
| [`a9d395a6`](https://github.com/nix-community/NUR/commit/a9d395a6a130e3225561181d39330c6479767b0b) | `` automatic update `` |