### PR TITLE
chore(flake/nur): `c65133bc` -> `fa0fea4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758199704,
-        "narHash": "sha256-qZA/gw8/Q2vjw44vUiTJm2NAA8GYQb9h38rws4Rzw8o=",
+        "lastModified": 1758206553,
+        "narHash": "sha256-+OPTaKntwjNKT/XZ+oJFoiU+3vV5p1EaanEIG6+uGaQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c65133bcbc1a44afc0f43eceb64c440f81f6a63e",
+        "rev": "fa0fea4ae6d742ea7220572f1f260a0fccc312eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fa0fea4a`](https://github.com/nix-community/NUR/commit/fa0fea4ae6d742ea7220572f1f260a0fccc312eb) | `` automatic update `` |
| [`403ff116`](https://github.com/nix-community/NUR/commit/403ff116d6e752f31888aceb281b944dc469aa2b) | `` automatic update `` |
| [`38eba84c`](https://github.com/nix-community/NUR/commit/38eba84c4a94ecd15937191f29b9dcfd5ad21180) | `` automatic update `` |