### PR TITLE
chore(flake/nur): `fa0fea4a` -> `ea8c4288`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758206553,
-        "narHash": "sha256-+OPTaKntwjNKT/XZ+oJFoiU+3vV5p1EaanEIG6+uGaQ=",
+        "lastModified": 1758217552,
+        "narHash": "sha256-K0R4HL3qk36l7pnRg0xYTMBa7GqY5op34RK+SJiaLzM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fa0fea4ae6d742ea7220572f1f260a0fccc312eb",
+        "rev": "ea8c4288ca2e18bf307ff8a4003971b05c3b9c23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                        |
| -------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`ea8c4288`](https://github.com/nix-community/NUR/commit/ea8c4288ca2e18bf307ff8a4003971b05c3b9c23) | `` automatic update ``         |
| [`c246863e`](https://github.com/nix-community/NUR/commit/c246863eec092ba5b183fe028c5ed9ed5597bf87) | `` automatic update ``         |
| [`ef4877b4`](https://github.com/nix-community/NUR/commit/ef4877b498ab68459f0284692ef9c03372f65921) | `` automatic update ``         |
| [`4983ecb0`](https://github.com/nix-community/NUR/commit/4983ecb03879577c9d81dfb3e90a933986be0057) | `` qchem: remove repository `` |
| [`2bfd52bc`](https://github.com/nix-community/NUR/commit/2bfd52bc62846023a8bcd891eca77e281904936b) | `` remove nolith repository `` |