### PR TITLE
chore(flake/nur): `ea8c4288` -> `ff7a8c10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758217552,
-        "narHash": "sha256-K0R4HL3qk36l7pnRg0xYTMBa7GqY5op34RK+SJiaLzM=",
+        "lastModified": 1758230132,
+        "narHash": "sha256-DoB92xa+sC0mrEzU3g1gcsCbA5VCkxvVP1972tQaa8g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ea8c4288ca2e18bf307ff8a4003971b05c3b9c23",
+        "rev": "ff7a8c1049479ff485f5e79f8f335bac58613746",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                      |
| -------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`ff7a8c10`](https://github.com/nix-community/NUR/commit/ff7a8c1049479ff485f5e79f8f335bac58613746) | `` automatic update ``       |
| [`ca1d9635`](https://github.com/nix-community/NUR/commit/ca1d96350c964229ef1391d8660c7381d030cf83) | `` add juxgd repository ``   |
| [`d7592803`](https://github.com/nix-community/NUR/commit/d7592803b705df7b1b7c68aea27d4881e605bfbe) | `` add dmfrpro repository `` |
| [`1113830c`](https://github.com/nix-community/NUR/commit/1113830c10a7531dc83b93168200332f7b0268b8) | `` automatic update ``       |
| [`b731f513`](https://github.com/nix-community/NUR/commit/b731f513724a4168d3d5d3b9ccf0505570beb152) | `` automatic update ``       |
| [`ed07b729`](https://github.com/nix-community/NUR/commit/ed07b72916e851cdf138502cad68468c5f9158cc) | `` automatic update ``       |
| [`af04692c`](https://github.com/nix-community/NUR/commit/af04692c6c979bea3325b8b60a1413ed3ce46c2a) | `` automatic update ``       |
| [`49d02e75`](https://github.com/nix-community/NUR/commit/49d02e75216fe69a7b71e15c87abc8db349983d2) | `` automatic update ``       |