### PR TITLE
chore(flake/nur): `ff7a8c10` -> `3da45486`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758230132,
-        "narHash": "sha256-DoB92xa+sC0mrEzU3g1gcsCbA5VCkxvVP1972tQaa8g=",
+        "lastModified": 1758244057,
+        "narHash": "sha256-OMrHLDeM2mHmg5EF6Cn4v0RlvWUlfBaRoQHseeQ5914=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ff7a8c1049479ff485f5e79f8f335bac58613746",
+        "rev": "3da45486f0756911371961d8cacb2a71f61aeb01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3da45486`](https://github.com/nix-community/NUR/commit/3da45486f0756911371961d8cacb2a71f61aeb01) | `` automatic update `` |
| [`9db5734b`](https://github.com/nix-community/NUR/commit/9db5734b74c5a3742f63ae1d5301ac763df1afa7) | `` automatic update `` |
| [`0c1197bf`](https://github.com/nix-community/NUR/commit/0c1197bfe9c426827e4e2658c834e92cc3e209ce) | `` automatic update `` |