### PR TITLE
chore(flake/nur): `7c730acb` -> `f1ee8889`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758251467,
-        "narHash": "sha256-1woI75+GWU+zK/9hDmlMPf7VnmrSQqZhrCvI8Uwlj6o=",
+        "lastModified": 1758263370,
+        "narHash": "sha256-Nh7wGoyLqHIK1e9HOcmeuwu8wTmwm2tLh2hFqD+NqxU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7c730acb9ffd4638273a7d3125e7ec51e5fef929",
+        "rev": "f1ee8889e667e4c206fdfcf0de45ccb32fd4568c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1ee8889`](https://github.com/nix-community/NUR/commit/f1ee8889e667e4c206fdfcf0de45ccb32fd4568c) | `` automatic update `` |
| [`0c542bbb`](https://github.com/nix-community/NUR/commit/0c542bbbd8fe18b031fd8587c891b793647472b8) | `` automatic update `` |
| [`4432b525`](https://github.com/nix-community/NUR/commit/4432b525d3019e55c0c18a25d85b051790d03f48) | `` automatic update `` |