### PR TITLE
chore(flake/nur): `f1ee8889` -> `2d644af2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758263370,
-        "narHash": "sha256-Nh7wGoyLqHIK1e9HOcmeuwu8wTmwm2tLh2hFqD+NqxU=",
+        "lastModified": 1758273929,
+        "narHash": "sha256-8ZhQaoeWOcCpe14PLgJ7ZEhWFFISA2qcVuXTGlNZGgU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f1ee8889e667e4c206fdfcf0de45ccb32fd4568c",
+        "rev": "2d644af21cc32d53594b9d17fa167c4eec6431cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d644af2`](https://github.com/nix-community/NUR/commit/2d644af21cc32d53594b9d17fa167c4eec6431cd) | `` automatic update `` |
| [`5f48e0b5`](https://github.com/nix-community/NUR/commit/5f48e0b5e61151acbca4f03d4c2853993eb72262) | `` automatic update `` |
| [`25758d43`](https://github.com/nix-community/NUR/commit/25758d433497b2adab46ed3e481a3c136a4329cf) | `` automatic update `` |
| [`67bc010b`](https://github.com/nix-community/NUR/commit/67bc010b0b244c6fb0e24700bd5d4c32bc9ff5bc) | `` automatic update `` |
| [`9e2efe4c`](https://github.com/nix-community/NUR/commit/9e2efe4c536d1821fcb2252e5205d78458e0e573) | `` automatic update `` |