### PR TITLE
chore(flake/nixpkgs): `e9b7f2ff` -> `d2ed9964`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1758070117,
-        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "lastModified": 1758216857,
+        "narHash": "sha256-h1BW2y7CY4LI9w61R02wPaOYfmYo82FyRqHIwukQ6SY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "rev": "d2ed99647a4b195f0bcc440f76edfa10aeb3b743",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                           |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
| [`4de8ee7a`](https://github.com/NixOS/nixpkgs/commit/4de8ee7ab3a4907c27862f161d6b626bc44c8087) | `` ci.eval.compare: split out equivalent values into their own table ``                                           |
| [`8004d8c3`](https://github.com/NixOS/nixpkgs/commit/8004d8c3a1a3073ff391fa964baf32608c4a002c) | `` ci.eval.compare: explain the various metrics under the --explain flag ``                                       |
| [`44b98f20`](https://github.com/NixOS/nixpkgs/commit/44b98f2061a3383a7deb965ea949886d58a3f836) | `` ci.eval.compare: remove the duplicate cpuTime key ``                                                           |
| [`0bd4b919`](https://github.com/NixOS/nixpkgs/commit/0bd4b9198ea49a31dbc1dbdd303a09eb107bf719) | `` ci.eval.compare: put things with counts together ``                                                            |
| [`b76a3c88`](https://github.com/NixOS/nixpkgs/commit/b76a3c88b56477fb30c09ae2a915495c121e19ff) | `` ci.eval.compare: put things with bytes together ``                                                             |
| [`b6920555`](https://github.com/NixOS/nixpkgs/commit/b692055537d667cbcc0dee957a36d8322b3eb7a1) | `` ci.eval.compare: make the table format using tabulate not manually ``                                          |
| [`c84ffaef`](https://github.com/NixOS/nixpkgs/commit/c84ffaef49e1761c5a043b0e3efbce1460717aa0) | `` ci.eval.compare: sort time metrics first, then GC metrics, then everything else ``                             |
| [`17decc04`](https://github.com/NixOS/nixpkgs/commit/17decc0429dd7fdd875f4ea50eff192bb87f7827) | `` ci.eval.compare: assert types in flatten_data ``                                                               |
| [`c9156ea2`](https://github.com/NixOS/nixpkgs/commit/c9156ea2633ba427ee427e085572435563d44cf3) | `` ci.eval.compare: delete unreferenced global ``                                                                 |
| [`59b03676`](https://github.com/NixOS/nixpkgs/commit/59b03676e9b5ccc51f9950c1281e04cfc05ff546) | `` ci.eval.compare: instead of manually tabulating, use tabulate ``                                               |
| [`87aef29e`](https://github.com/NixOS/nixpkgs/commit/87aef29e197e531a95355e42b88a8a23dda51ca1) | `` ci.eval.compare: support passing single files to cmp-stats ``                                                  |
| [`8352e6a4`](https://github.com/NixOS/nixpkgs/commit/8352e6a4f587b2998283501db09b06b3cd4cac18) | `` ci.eval.compare: allow before_vals == 1 but avoid the t-test ``                                                |
| [`24386eb5`](https://github.com/NixOS/nixpkgs/commit/24386eb55905b1fb041867f59b7d2c864bc0240e) | `` ci.eval.compare: require the directories to exist (they always should) ``                                      |
| [`6183797e`](https://github.com/NixOS/nixpkgs/commit/6183797e12aba5ef813053df4d2984d7d5ad6f49) | `` ci.eval.compare: use argument parsing instead of environment variables to pass before/after to cmp-stats.py `` |
| [`bca0af63`](https://github.com/NixOS/nixpkgs/commit/bca0af6384badaa410ed8e4b638ecb91fa8b77b9) | `` ci.eval.compare: extract a derivation for cmp-stats ``                                                         |
| [`647f2050`](https://github.com/NixOS/nixpkgs/commit/647f2050572fd85c4fc9575ba772c66e91427f69) | `` ci.eval.compare: extract main function in cmp-stats.py ``                                                      |
| [`928e921d`](https://github.com/NixOS/nixpkgs/commit/928e921d7bbf17a2c795092385f0c43d8a960ffe) | `` ci.eval.compare: sort imports in cmp-stats.py ``                                                               |
| [`cfc365f2`](https://github.com/NixOS/nixpkgs/commit/cfc365f266d7c9b9d84afa098b6db6aafe22fb0a) | `` ci.eval.compare: format cmp-stats.py with ruff ``                                                              |
| [`df6398f7`](https://github.com/NixOS/nixpkgs/commit/df6398f797f46e25b924ab4e85bfaee48f7e4165) | `` python314: 3.14.0rc2 -> 3.14.0rc3 ``                                                                           |
| [`0b98fed6`](https://github.com/NixOS/nixpkgs/commit/0b98fed67a7c4a5a881667c6a81676ec518cce90) | `` ed-odyssey-materials-helper: 2.247 -> 2.255 ``                                                                 |
| [`c03f215a`](https://github.com/NixOS/nixpkgs/commit/c03f215a708d0091fbb2a7af4c44e0a5f3867ca5) | `` fish: 4.0.6 -> 4.0.8 ``                                                                                        |
| [`406030eb`](https://github.com/NixOS/nixpkgs/commit/406030eb896f3c782cbd662c5035a68e06d86873) | `` chhoto-url: 6.3.1 -> 6.3.2 ``                                                                                  |
| [`3b2085a0`](https://github.com/NixOS/nixpkgs/commit/3b2085a03e881346f0131174d1de48f1a17836e9) | `` google-chorme: 140.0.7339.127 -> 140.0.7339.185 ``                                                             |
| [`ca6712be`](https://github.com/NixOS/nixpkgs/commit/ca6712bea9643ef5f89745b34da86951c27fb6f6) | `` wivrn: 25.8 -> 25.9 ``                                                                                         |
| [`8e9195b3`](https://github.com/NixOS/nixpkgs/commit/8e9195b3ace639d1eddab2219b8ce9db17abb682) | `` chromium,chromedriver: 140.0.7339.127 -> 140.0.7339.185 ``                                                     |
| [`c62e462a`](https://github.com/NixOS/nixpkgs/commit/c62e462a2acd80eb24e68b099c53f7b6205b8e2b) | `` mullvad-browser: 14.5.6 -> 14.5.7 ``                                                                           |
| [`e4faa507`](https://github.com/NixOS/nixpkgs/commit/e4faa50762ec5d4c6fae8e85d5b1a7ad7e4a0fbc) | `` tor-browser: 14.5.6 -> 14.5.7 ``                                                                               |
| [`a5917674`](https://github.com/NixOS/nixpkgs/commit/a59176742a67ee7769af32589415c580fb903cfe) | `` fastcdr: 2.3.0 -> 2.3.1 ``                                                                                     |
| [`693751e3`](https://github.com/NixOS/nixpkgs/commit/693751e3ee58fa2a7187202de7b9910c4f4885b6) | `` tuned: add missing runtime dependencies ``                                                                     |
| [`5f534cde`](https://github.com/NixOS/nixpkgs/commit/5f534cde9cf64cf14dae936d295bb37a6d173b92) | `` erlang_28: 28.0.4 -> 28.1 ``                                                                                   |
| [`c9fc1e99`](https://github.com/NixOS/nixpkgs/commit/c9fc1e995f7f1b665ae055775cb44e0010240c1d) | `` llvmPackages_git: 22.0.0-unstable-2025-09-07 -> 22.0.0-unstable-2025-09-16 ``                                  |
| [`07462128`](https://github.com/NixOS/nixpkgs/commit/074621280aa466f011d07ef8498840c889dfcb9e) | `` rt: 5.0.5 -> 5.0.8 ``                                                                                          |
| [`3acf2dc5`](https://github.com/NixOS/nixpkgs/commit/3acf2dc564b156b9004e8fe0205e3358fd90b6bb) | `` python3Packages.buildstream-plugins: 2.4.0 -> 2.5.0 ``                                                         |
| [`dd963371`](https://github.com/NixOS/nixpkgs/commit/dd9633711ad69a86ba7771a3af9b21f453a2c707) | `` linux-firmware: 20250808 -> 20250917 ``                                                                        |
| [`660f0a87`](https://github.com/NixOS/nixpkgs/commit/660f0a87fa8e15f5e7807f28620bcd75bda388d3) | `` garage_2: 2.0.0 -> 2.1.0 ``                                                                                    |
| [`7ecb5e0b`](https://github.com/NixOS/nixpkgs/commit/7ecb5e0b29b395c3d2ddd435c0af53ab0ff464b9) | `` garage_1: 1.2.0 -> 1.3.0 ``                                                                                    |
| [`f33b73cd`](https://github.com/NixOS/nixpkgs/commit/f33b73cd6ecd7b30eec058faf4163ae4e20b14cc) | `` godot_4_5: init at 4.5-stable ``                                                                               |
| [`75698afe`](https://github.com/NixOS/nixpkgs/commit/75698afe7d8bc824fb1bc0a3057859ce9039a8d3) | `` legcord: 1.1.4 -> 1.1.5 ``                                                                                     |
| [`a331d448`](https://github.com/NixOS/nixpkgs/commit/a331d44863d1f05e73157c2b8ac44b0e335bddbb) | `` mautrix-whatsapp: 0.12.4 -> 0.12.5 ``                                                                          |
| [`b5612679`](https://github.com/NixOS/nixpkgs/commit/b5612679adcb6ee41ce5f6728ced1b5d06da90fb) | `` linuxKernel.kernels.linux_lqx: 6.16.5 -> 6.16.7 ``                                                             |
| [`d38d3fcb`](https://github.com/NixOS/nixpkgs/commit/d38d3fcbb97a67512406bde87640822553cf0d06) | `` firefly-iii: 6.3.2 -> 6.4.0 ``                                                                                 |
| [`7124c6d3`](https://github.com/NixOS/nixpkgs/commit/7124c6d3664e456f8970e3d7da0f7b55d4de8c5b) | `` wivrn: default to xrizer for openvr compat ``                                                                  |
| [`8c11c5ca`](https://github.com/NixOS/nixpkgs/commit/8c11c5ca13032890a0337677dbad6f6568d7a1c9) | `` vrcx: 2025.08.17 -> 2025.09.10 ``                                                                              |
| [`0117a401`](https://github.com/NixOS/nixpkgs/commit/0117a401ecd96f5d25db6f66d35a044e5d199309) | `` lunatask: 2.1.6 -> 2.1.7 ``                                                                                    |
| [`47f5ace0`](https://github.com/NixOS/nixpkgs/commit/47f5ace0af6780e41bb5398cec5498ee7e7a98e6) | `` metal-cli: 0.25.0 -> 0.26.0 ``                                                                                 |
| [`cb5a00d3`](https://github.com/NixOS/nixpkgs/commit/cb5a00d30327b7cb1a6a4aaf680c6358c09a1471) | `` uutils-coreutils: 0.2.0 -> 0.2.2 ``                                                                            |
| [`f7c98c30`](https://github.com/NixOS/nixpkgs/commit/f7c98c30a9989a3de64d7581b06209386f3ec7a5) | `` uutils-coreutils: 0.1.0 -> 0.2.0 ``                                                                            |
| [`8b1dbd31`](https://github.com/NixOS/nixpkgs/commit/8b1dbd31744e335849c80fc65b851956fd7d85c5) | `` uutils-coreutils: 0.0.30 -> 0.1.0 ``                                                                           |
| [`f1e7cc4e`](https://github.com/NixOS/nixpkgs/commit/f1e7cc4ea405b3e8511111ab7bad60dfdbbca1ec) | `` uutils-coreutils: Add myself as maintainer ``                                                                  |
| [`d01a42cd`](https://github.com/NixOS/nixpkgs/commit/d01a42cdb9891631dd262580e76b8542ac3401fc) | `` wivrn: 25.6.1 -> 25.8 ``                                                                                       |
| [`46872122`](https://github.com/NixOS/nixpkgs/commit/46872122d2d8ad9670b29c146521c2ae0ab0286a) | `` nixos/wivrn: update to support wivrn 25.8 ``                                                                   |
| [`5db46e1d`](https://github.com/NixOS/nixpkgs/commit/5db46e1d3d44328c1c2d1c34fba37ccfdc4d1699) | `` virtualbox: fix 3D acceleration ``                                                                             |