### PR TITLE
chore(flake/nur): `2d644af2` -> `3d4074cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758273929,
-        "narHash": "sha256-8ZhQaoeWOcCpe14PLgJ7ZEhWFFISA2qcVuXTGlNZGgU=",
+        "lastModified": 1758303037,
+        "narHash": "sha256-3B4RSo7b+g+8LPxkRp4t5XXkEs+oAojM41JGXgCUkys=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d644af21cc32d53594b9d17fa167c4eec6431cd",
+        "rev": "3d4074cc9b59e119cfb8866da67b4a81e9210b56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3d4074cc`](https://github.com/nix-community/NUR/commit/3d4074cc9b59e119cfb8866da67b4a81e9210b56) | `` automatic update `` |
| [`65544a1a`](https://github.com/nix-community/NUR/commit/65544a1a085c5ceb128570a855a07e346401e374) | `` automatic update `` |
| [`1a6b6450`](https://github.com/nix-community/NUR/commit/1a6b645095e3c1f148b6a1d9a3f0e302116e9bc7) | `` automatic update `` |