### PR TITLE
chore(flake/home-manager): `f21d9167` -> `6f656618`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757808926,
-        "narHash": "sha256-K6PEI5PYY94TVMH0mX3MbZNYFme7oNRKml/85BpRRAo=",
+        "lastModified": 1758313341,
+        "narHash": "sha256-SsI6INUzWwPcRKRaxvi50RttnD9rcC4EjV+67TOEfrQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f21d9167782c086a33ad53e2311854a8f13c281e",
+        "rev": "6f656618ebc71ca82d93d306a8aecb2c5f6f2ab2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                     |
| ----------------------------------------------------------------------------------------------------------- | --------------------------- |
| [`6f656618`](https://github.com/nix-community/home-manager/commit/6f656618ebc71ca82d93d306a8aecb2c5f6f2ab2) | `` nvchecker: add module `` |