### PR TITLE
chore(flake/nur): `3d4074cc` -> `180ae0f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758303037,
-        "narHash": "sha256-3B4RSo7b+g+8LPxkRp4t5XXkEs+oAojM41JGXgCUkys=",
+        "lastModified": 1758314668,
+        "narHash": "sha256-UeSA8UbYgBeeI/r6YRlkwKrBMhnE2ZliSFb7QB7p4zQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3d4074cc9b59e119cfb8866da67b4a81e9210b56",
+        "rev": "180ae0f66d4d50d36c01e750bd7c05f49ff8f24b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`180ae0f6`](https://github.com/nix-community/NUR/commit/180ae0f66d4d50d36c01e750bd7c05f49ff8f24b) | `` automatic update `` |
| [`a039cbeb`](https://github.com/nix-community/NUR/commit/a039cbeb1c163a3481744cf2b306396bef373ace) | `` automatic update `` |
| [`05c2afe4`](https://github.com/nix-community/NUR/commit/05c2afe4c9d758e4baa865605ecd69a4e2a1eb92) | `` automatic update `` |