### PR TITLE
chore(flake/nur): `180ae0f6` -> `83dd4507`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758314668,
-        "narHash": "sha256-UeSA8UbYgBeeI/r6YRlkwKrBMhnE2ZliSFb7QB7p4zQ=",
+        "lastModified": 1758331784,
+        "narHash": "sha256-mX7WrRHXKR80G5ZR6f7tN3Na35rORsCFFx7sbpPWoA0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "180ae0f66d4d50d36c01e750bd7c05f49ff8f24b",
+        "rev": "83dd450702b7eb5168fff28d05b20d6e17ec6280",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`83dd4507`](https://github.com/nix-community/NUR/commit/83dd450702b7eb5168fff28d05b20d6e17ec6280) | `` automatic update `` |
| [`9b1c8f7b`](https://github.com/nix-community/NUR/commit/9b1c8f7b61c5cb3eb77476cd4562be52c8bb3bc7) | `` automatic update `` |