### PR TITLE
chore(flake/nur): `83dd4507` -> `f0af31a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758331784,
-        "narHash": "sha256-mX7WrRHXKR80G5ZR6f7tN3Na35rORsCFFx7sbpPWoA0=",
+        "lastModified": 1758338435,
+        "narHash": "sha256-H2lB04mGw9t44wslneS6EEpJm/x85DbtcLRXW7XGdwQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "83dd450702b7eb5168fff28d05b20d6e17ec6280",
+        "rev": "f0af31a404363c39d0530b4bdda574a5e831cf43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f0af31a4`](https://github.com/nix-community/NUR/commit/f0af31a404363c39d0530b4bdda574a5e831cf43) | `` automatic update `` |
| [`bf2dda64`](https://github.com/nix-community/NUR/commit/bf2dda645a5ec188df466658a1fea1ac3b1b95de) | `` automatic update `` |
| [`b094377b`](https://github.com/nix-community/NUR/commit/b094377bf25162765b8ef5d75a752b055ab3701a) | `` automatic update `` |
| [`178b3bfa`](https://github.com/nix-community/NUR/commit/178b3bfaea83e31b5779beb7ef4773587af85b0b) | `` automatic update `` |