### PR TITLE
chore(flake/nur): `f0af31a4` -> `9ea2a0fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758338435,
-        "narHash": "sha256-H2lB04mGw9t44wslneS6EEpJm/x85DbtcLRXW7XGdwQ=",
+        "lastModified": 1758344267,
+        "narHash": "sha256-IDI/9/H9WW++sihlB7jyBetLUvqU0GBnZv0Od5D/nzA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f0af31a404363c39d0530b4bdda574a5e831cf43",
+        "rev": "9ea2a0faddc79c2bf04a4cdc480ff7237f266f82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ea2a0fa`](https://github.com/nix-community/NUR/commit/9ea2a0faddc79c2bf04a4cdc480ff7237f266f82) | `` automatic update `` |
| [`acf48f1d`](https://github.com/nix-community/NUR/commit/acf48f1dd6c01ea37a3307be2fcce965ea884b6d) | `` automatic update `` |
| [`730d5fc6`](https://github.com/nix-community/NUR/commit/730d5fc6cddbf8f9fe06415b62dba54d4dbb898d) | `` automatic update `` |
| [`d9772f80`](https://github.com/nix-community/NUR/commit/d9772f802e49449b3729220426cc6ba51aa86c5d) | `` automatic update `` |
| [`67a4c3e6`](https://github.com/nix-community/NUR/commit/67a4c3e602f041d78da023d0a86ce40834004113) | `` automatic update `` |
| [`957eddcb`](https://github.com/nix-community/NUR/commit/957eddcb40c8c7dd4120f808786ea4d8b77a7feb) | `` automatic update `` |