### PR TITLE
chore(flake/nixpkgs-unstable): `0147c2f1` -> `8eaee110`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1758198701,
-        "narHash": "sha256-7To75JlpekfUmdkUZewnT6MoBANS0XVypW6kjUOXQwc=",
+        "lastModified": 1758277210,
+        "narHash": "sha256-iCGWf/LTy+aY0zFu8q12lK8KuZp7yvdhStehhyX1v8w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0147c2f1d54b30b5dd6d4a8c8542e8d7edf93b5d",
+        "rev": "8eaee110344796db060382e15d3af0a9fc396e0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`3c675d20`](https://github.com/NixOS/nixpkgs/commit/3c675d2003e363d53d0414791d96726d2ba4079b) | `` nuclei-templates: 10.2.8 -> 10.2.9 ``                                            |
| [`7b475708`](https://github.com/NixOS/nixpkgs/commit/7b475708b14d32e73c6d2000da3224683998f4ff) | `` vivaldi: 7.5.3735.74 -> 7.6.3797.52 ``                                           |
| [`5ea0e760`](https://github.com/NixOS/nixpkgs/commit/5ea0e760c25f4a924b41c6b809f46761b9102c5b) | `` eigenwallet: 3.0.0-beta.8 -> 3.0.1 ``                                            |
| [`a604057a`](https://github.com/NixOS/nixpkgs/commit/a604057a579912ec2b5b4f718b818c1845cfce98) | `` codex: 0.38.0 -> 0.39.0 ``                                                       |
| [`c04bcb89`](https://github.com/NixOS/nixpkgs/commit/c04bcb89a62a70fb64e67823f9fc257bb18aa055) | `` databricks-cli: 0.267.0 -> 0.269.0 ``                                            |
| [`f9c5a2df`](https://github.com/NixOS/nixpkgs/commit/f9c5a2dfb3d11cc2a48de18db5ff3bc22911b36c) | `` screen: backport pending patch to fix UB in unit tests ``                        |
| [`e6c3eb81`](https://github.com/NixOS/nixpkgs/commit/e6c3eb818618db879cc49a374dda70b1578087d8) | `` wit-bindgen: 0.45.1 -> 0.46.0 ``                                                 |
| [`a246280b`](https://github.com/NixOS/nixpkgs/commit/a246280b51a96cad3a8449969d25dade07cf5de4) | `` coqPackages.autosubst-ocaml: 1.1+8.20 -> 1.1+9.0 ``                              |
| [`bca8a7b2`](https://github.com/NixOS/nixpkgs/commit/bca8a7b28a384d9b7aad1d5320a478c85f2760a5) | `` bark-server: 2.2.5 -> 2.2.6 ``                                                   |
| [`e823a502`](https://github.com/NixOS/nixpkgs/commit/e823a50247057c6240280d06efe62daf1a9a327d) | `` terraform-providers.opentelekomcloud: 1.36.47 -> 1.36.48 ``                      |
| [`221e9c7c`](https://github.com/NixOS/nixpkgs/commit/221e9c7c43e580a9b1f2862f794cd70d24764851) | `` terraform-providers.migadu: 2025.8.28 -> 2025.9.18 ``                            |
| [`943fa98b`](https://github.com/NixOS/nixpkgs/commit/943fa98bf79a681ec1604d4f98cc6ba427f2d261) | `` python3Packages.euporie: init at 2.8.13 ``                                       |
| [`a035fc15`](https://github.com/NixOS/nixpkgs/commit/a035fc15d971d924d5fb7f50c25087b16e5ca9e6) | `` terraform-providers.huaweicloud: 1.78.1 -> 1.78.4 ``                             |
| [`11f4fb1b`](https://github.com/NixOS/nixpkgs/commit/11f4fb1b3d4a81ce90a6c6b7f7c10a1ca8fe4772) | `` zed-editor: 0.204.1 -> 0.204.2 ``                                                |
| [`197788b1`](https://github.com/NixOS/nixpkgs/commit/197788b1daffa0e626a90810ff732cefd823f77a) | `` pixi: 0.54.2 -> 0.55.0 ``                                                        |
| [`8432ab23`](https://github.com/NixOS/nixpkgs/commit/8432ab232e64d1cb33f88b773a8aa2e3191f08dd) | `` python3Packages.flatlatex: init at 0.15 ``                                       |
| [`0a72eb70`](https://github.com/NixOS/nixpkgs/commit/0a72eb7000ca3107a27ad6f71235d783fbfa96d3) | `` cursor-cli: 0-unstable-2025-09-04 -> 0-unstable-2025-09-18 ``                    |
| [`7869f0c9`](https://github.com/NixOS/nixpkgs/commit/7869f0c9674e33c1a8b0c1d8e0961062ddd9d0d7) | `` last: 1642 -> 1645 ``                                                            |
| [`e9c54611`](https://github.com/NixOS/nixpkgs/commit/e9c54611c3e97275dcee9b248e844acaf02aa6e6) | `` supabase-cli: 2.40.6 -> 2.45.2 ``                                                |
| [`74591064`](https://github.com/NixOS/nixpkgs/commit/74591064ed9172cbf9c5acd8895c5ae6aa27a60f) | `` nixos-rebuild-ng: do not try to copy closure when running dry-build ``           |
| [`3b2c18ef`](https://github.com/NixOS/nixpkgs/commit/3b2c18ef500a1315c0802052cec61485d53f2e86) | `` python3Packages.weaviate-client: 4.16.9 -> 4.16.10 ``                            |
| [`51caf3bd`](https://github.com/NixOS/nixpkgs/commit/51caf3bd633284dab05c97405d76cc6c86e0265b) | `` mariadb_{106,1011}: fix build with CMake 4 ``                                    |
| [`313fa9dc`](https://github.com/NixOS/nixpkgs/commit/313fa9dc99b2839cfee4dd2bcc6ce3e621466901) | `` nixos/top-level: fix cutoffPackages without initialRamdisk ``                    |
| [`e27b8698`](https://github.com/NixOS/nixpkgs/commit/e27b869895dd9fdc44bdb5b64949a3e96a728253) | `` ungoogled-chromium: 140.0.7339.127-1 -> 140.0.7339.185-1 ``                      |
| [`ac516b99`](https://github.com/NixOS/nixpkgs/commit/ac516b99e504276d72b6ba61bd24a847048de364) | `` zapzap: update meta.homepage ``                                                  |
| [`7f8cf3a9`](https://github.com/NixOS/nixpkgs/commit/7f8cf3a9557f08b266f13495259dea3439a4a757) | `` metis: add qbisi to maintainers ``                                               |
| [`14ee50fd`](https://github.com/NixOS/nixpkgs/commit/14ee50fdf0a493252241872221ccfc34dbfe4400) | `` sofa: patch to allow metis > 5.1 ``                                              |
| [`725f147d`](https://github.com/NixOS/nixpkgs/commit/725f147d8991afa7ceaeeeedfcbdc828d18ad1af) | `` parmetis: 4.0.3 -> 4.0.3-unstable-2023-03-26 ``                                  |
| [`f65f70b8`](https://github.com/NixOS/nixpkgs/commit/f65f70b8732fcc7241b77556e498be9062c3ad5e) | `` metis: apply upstream cmake_minimum_required bump ``                             |
| [`c2401037`](https://github.com/NixOS/nixpkgs/commit/c24010370f2fa3068fcb3e507acacf1a4967071b) | `` metis: 5.1.0 -> 5.2.1 ``                                                         |
| [`47fec804`](https://github.com/NixOS/nixpkgs/commit/47fec8041dacddf204da3788782c1dd2138498a8) | `` gklib: 5.1.1-unstable-2023-03-27 -> 5.1.1-unstable-2025-07-15 ``                 |
| [`e0c829f6`](https://github.com/NixOS/nixpkgs/commit/e0c829f65a80e78ecebc48f8ae1d89e25b835c87) | `` gklib: init at 5.1.1-unstable-2023-03-27 ``                                      |
| [`68f62a7e`](https://github.com/NixOS/nixpkgs/commit/68f62a7ed616395c9f980e3bbfb8b3a1919f93af) | `` python3Packages.tree-sitter-markdown: 0.5.0 -> 0.5.1 ``                          |
| [`757cc801`](https://github.com/NixOS/nixpkgs/commit/757cc801dcc51af39f2fdb8fdb6a4f161deb6b12) | `` python313Packages.boto3-stubs: 1.40.33 -> 1.40.34 ``                             |
| [`451de7a7`](https://github.com/NixOS/nixpkgs/commit/451de7a7b4bf245139a821a91b1401e19171a71c) | `` python313Packages.botocore-stubs: 1.40.32 -> 1.40.33 ``                          |
| [`fe70c202`](https://github.com/NixOS/nixpkgs/commit/fe70c202a74428ddcd4c62aa7609069fd1eb7759) | `` python312Packages.mypy-boto3-ec2: 1.40.33 -> 1.40.34 ``                          |
| [`7983bbd9`](https://github.com/NixOS/nixpkgs/commit/7983bbd976724e33f7ba683123b950af550e7f9f) | `` python312Packages.mypy-boto3-chime-sdk-messaging: 1.40.17 -> 1.40.34 ``          |
| [`2d68e801`](https://github.com/NixOS/nixpkgs/commit/2d68e80179613aa16f4f68d5957f49101f69fb90) | `` python312Packages.mypy-boto3-budgets: 1.40.32 -> 1.40.34 ``                      |
| [`336e4361`](https://github.com/NixOS/nixpkgs/commit/336e4361595c70a28b4550183dc79df61f91399d) | `` python313Packages.boto3-stubs: 1.40.30 -> 1.40.33 ``                             |
| [`f760842a`](https://github.com/NixOS/nixpkgs/commit/f760842ae9daf59ba58a616f06b700bc902b7cd6) | `` python313Packages.botocore-stubs: 1.40.31 -> 1.40.32 ``                          |
| [`be96ee10`](https://github.com/NixOS/nixpkgs/commit/be96ee10c758ad9b6dd8fdbd8b8a35a4e03289d6) | `` python312Packages.mypy-boto3-osis: 1.40.20 -> 1.40.32 ``                         |
| [`452a9048`](https://github.com/NixOS/nixpkgs/commit/452a9048904678b31492c726874f857b75a74459) | `` python312Packages.mypy-boto3-network-firewall: 1.40.0 -> 1.40.33 ``              |
| [`22a02d26`](https://github.com/NixOS/nixpkgs/commit/22a02d26e928536fbc46cb95479a56e8cb3e708d) | `` python312Packages.mypy-boto3-logs: 1.40.0 -> 1.40.32 ``                          |
| [`32cfe529`](https://github.com/NixOS/nixpkgs/commit/32cfe529aafed5248f36e2a3b8efc0d113a3751c) | `` python312Packages.mypy-boto3-ivs-realtime: 1.40.0 -> 1.40.32 ``                  |
| [`12a8abeb`](https://github.com/NixOS/nixpkgs/commit/12a8abeb56568dabb9b4a32722a4d91b548272e5) | `` python312Packages.mypy-boto3-ec2: 1.40.24 -> 1.40.33 ``                          |
| [`f6e7f1b1`](https://github.com/NixOS/nixpkgs/commit/f6e7f1b172c2017e719c1eba5b5cd7ed0195931a) | `` python312Packages.mypy-boto3-budgets: 1.40.4 -> 1.40.32 ``                       |
| [`17d05fce`](https://github.com/NixOS/nixpkgs/commit/17d05fce8557f2e61a4914e6e33d4f85575bb3d2) | `` libloot: fix custom yaml-cpp build ``                                            |
| [`56668b9b`](https://github.com/NixOS/nixpkgs/commit/56668b9b1ae4cd0b1f7c4cabc775193c3ba3c6c7) | `` python3Packages.llama-index-readers-json: 0.4.0 -> 0.4.1 ``                      |
| [`bbc94cb1`](https://github.com/NixOS/nixpkgs/commit/bbc94cb1251f7ff3d12db2e718121076ad9f0f73) | `` jsonwatch: add changelog entry to meta ``                                        |
| [`ce656bff`](https://github.com/NixOS/nixpkgs/commit/ce656bff12e03795229de265e4c373f47b8f390a) | `` use latest patch for bisect_ppx ``                                               |
| [`0efee58d`](https://github.com/NixOS/nixpkgs/commit/0efee58dceda7ee0533f6411864a012f9ea849d8) | `` sentry-native: 0.10.1 -> 0.11.0 ``                                               |
| [`0f1a23a3`](https://github.com/NixOS/nixpkgs/commit/0f1a23a39780741b81d4ae8e19ac38cca92c1e64) | `` topicctl: 1.20.2 -> 1.21.0 ``                                                    |
| [`26bdd107`](https://github.com/NixOS/nixpkgs/commit/26bdd1074bf60637fa0f585a9caa5c5c35f3fed7) | `` vscodium: 1.104.06114 -> 1.104.16282 ``                                          |
| [`c0fed236`](https://github.com/NixOS/nixpkgs/commit/c0fed23683efa20bbccacaed1e86ce42890c17ee) | `` vscode: 1.104.0 -> 1.104.1 ``                                                    |
| [`ecf67f3c`](https://github.com/NixOS/nixpkgs/commit/ecf67f3cf1ad2d63f15c8633cd45116f331bc7a1) | `` python3Packages.osc: 1.19.1 -> 1.20.0 ``                                         |
| [`96fc08be`](https://github.com/NixOS/nixpkgs/commit/96fc08be0ca88cd88cfbfee0e9140ffbc92609da) | `` graalvm-ce: 24.0.2 → 25.0.0 ``                                                   |
| [`94b261c3`](https://github.com/NixOS/nixpkgs/commit/94b261c3fbdc9d25de1d27ecaa786983d1f3de19) | `` graalvm-ce-musl: only test --static on x86_64-linux ``                           |
| [`fde3a6e2`](https://github.com/NixOS/nixpkgs/commit/fde3a6e26dbed44056d463364bf27ab424ddae3c) | `` beets: 2.3.1 -> 2.4.0 ``                                                         |
| [`b8ef40a3`](https://github.com/NixOS/nixpkgs/commit/b8ef40a33a6a840d643213e676039030f1366944) | `` viceroy: 0.14.2 -> 0.14.3 ``                                                     |
| [`660fd74d`](https://github.com/NixOS/nixpkgs/commit/660fd74d85300209a0f72daa3e59593800b5bc2c) | `` s7: 11.5-unstable-2025-09-06 -> 11.5-unstable-2025-09-18 ``                      |
| [`afad5fbf`](https://github.com/NixOS/nixpkgs/commit/afad5fbf2675939160d44c4a75f276fd53e87ffc) | `` copybara: 20250901 -> 20250915 ``                                                |
| [`d8065285`](https://github.com/NixOS/nixpkgs/commit/d80652857e5376b4edc82186d426f0cd547934e7) | `` gophertube: init at 2.8.0 ``                                                     |
| [`a16d8215`](https://github.com/NixOS/nixpkgs/commit/a16d82151499bc3ecf6dc66f16275620052c7216) | `` pkgs/top-level/metrics.nix: fix the jq to count derivations ``                   |
| [`72bea47f`](https://github.com/NixOS/nixpkgs/commit/72bea47fa43dee34d87a22144c51e80c6eb8a0b4) | `` python3Packages.pythonqwt: 0.14.5 -> 0.14.6 ``                                   |
| [`349a646f`](https://github.com/NixOS/nixpkgs/commit/349a646fa986f3e34cec105bb50c4e80152e8e53) | `` nixVersions.nix_2_31: 2.31.1 -> 2.31.2 ``                                        |
| [`b7429be8`](https://github.com/NixOS/nixpkgs/commit/b7429be85dcf7b8e73d9899f6966216a6d3cd37c) | `` versitygw: 1.0.17 -> 1.0.18 ``                                                   |
| [`b51208fc`](https://github.com/NixOS/nixpkgs/commit/b51208fc2701e2ba859db632bed54094fe567bf4) | `` syft: 1.32.0 -> 1.33.0 ``                                                        |
| [`356c16f9`](https://github.com/NixOS/nixpkgs/commit/356c16f9848761a01f564c37d70f58761cd5aa5c) | `` vboot_reference: add jmbaur as maintainer ``                                     |
| [`3d243905`](https://github.com/NixOS/nixpkgs/commit/3d24390579cf99a05ba84c012ad2feefb1f770db) | `` vboot_reference: use --replace-fail with substituteInPlace ``                    |
| [`c61d94fd`](https://github.com/NixOS/nixpkgs/commit/c61d94fdee7a299a3f5e81acc679f8bcdd5b6224) | `` vboot_reference: remove irrelevant cflags ``                                     |
| [`fc139f60`](https://github.com/NixOS/nixpkgs/commit/fc139f603e4a4df52b41737dd994b92faacee44f) | `` vboot_reference: 111.15329 -> 135.16209 ``                                       |
| [`007dc528`](https://github.com/NixOS/nixpkgs/commit/007dc528ae151ec7e724a6a3ec60f84c2fa39457) | `` jankyborders: 1.8.0 -> 1.8.3 ``                                                  |
| [`cab9db80`](https://github.com/NixOS/nixpkgs/commit/cab9db80469f2fe89f237181d89297b12e4b82ea) | `` ldeep: 1.0.87 -> 1.0.88 ``                                                       |
| [`fdd31787`](https://github.com/NixOS/nixpkgs/commit/fdd31787021602a3b0990e30e2cc8249e3576d44) | `` atlantis: 0.35.1 -> 0.36.0 ``                                                    |
| [`1f18f1bb`](https://github.com/NixOS/nixpkgs/commit/1f18f1bb5c01b75502b9291bb68348981adebbd1) | `` clipcat: 0.21.0 -> 0.21.1 ``                                                     |
| [`cb3b6bc0`](https://github.com/NixOS/nixpkgs/commit/cb3b6bc029c6e07fe72ab8d009997a5875429a62) | `` wrangler: 4.30.0 -> 4.38.0 ``                                                    |
| [`3d0e2841`](https://github.com/NixOS/nixpkgs/commit/3d0e2841b8bd8cf58b59cb19752d8441fff17f4e) | `` ci.eval.compare: keep warnings as warnings rather than raising them as errors `` |
| [`2d31447b`](https://github.com/NixOS/nixpkgs/commit/2d31447b252570f13ef7453f7d34882f46ab3538) | `` vaporizer2: init at 3.5.0-unstable-2024-09-14 ``                                 |
| [`d8021c41`](https://github.com/NixOS/nixpkgs/commit/d8021c41f3c3b0ed0232e1c7d0c27bb30ed86039) | `` trufflehog: 3.90.6 -> 3.90.8 ``                                                  |
| [`361a3e99`](https://github.com/NixOS/nixpkgs/commit/361a3e99acd5c20d0e46219a70a7eaa756220996) | `` spacectl: 1.15.1 -> 1.15.2 ``                                                    |
| [`2b182956`](https://github.com/NixOS/nixpkgs/commit/2b182956f5089326859790f51ff12b143c49afca) | `` containerlab: remove aaronjheng from maintainers ``                              |
| [`af89f21d`](https://github.com/NixOS/nixpkgs/commit/af89f21de9e4c49853d8737e946ca65f3916db13) | `` nixos/snapserver: fix default http port ``                                       |
| [`9c5ad731`](https://github.com/NixOS/nixpkgs/commit/9c5ad731e7e1044bebb7444bc8ebf73c182d6d45) | `` forgejo-runner: 11.0.0 -> 11.1.0 ``                                              |