### PR TITLE
chore(flake/nur): `62688dab` -> `9ea40815`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758381358,
-        "narHash": "sha256-3edVTFHJavTAZH4D0MMraM+4JxrxXWeizQvlCWXcKnE=",
+        "lastModified": 1758390252,
+        "narHash": "sha256-Gmy/fDhdrKuVL7GooOH63KANQkJneUWvrYYp4nX5qWg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "62688dab3927fc080aad78d6814250b65cac1261",
+        "rev": "9ea4081544cdadedaf3a296961a4ecba5f13ea0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ea40815`](https://github.com/nix-community/NUR/commit/9ea4081544cdadedaf3a296961a4ecba5f13ea0b) | `` automatic update `` |
| [`096b8685`](https://github.com/nix-community/NUR/commit/096b8685f854c00ced81789c81ad77f577347cb6) | `` automatic update `` |
| [`e6cd4922`](https://github.com/nix-community/NUR/commit/e6cd4922c556fe2d47d543a0b7752bbf31cac72a) | `` automatic update `` |