### PR TITLE
chore(flake/nur): `9ea40815` -> `3604689d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758390252,
-        "narHash": "sha256-Gmy/fDhdrKuVL7GooOH63KANQkJneUWvrYYp4nX5qWg=",
+        "lastModified": 1758400095,
+        "narHash": "sha256-nAR7bmo7QoqJpwyj203ZwNxg2iUKvHl6p2cZbRf85W0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ea4081544cdadedaf3a296961a4ecba5f13ea0b",
+        "rev": "3604689d537d08a85641a7e8fb038c7e52f2891a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3604689d`](https://github.com/nix-community/NUR/commit/3604689d537d08a85641a7e8fb038c7e52f2891a) | `` automatic update `` |
| [`ff4a742b`](https://github.com/nix-community/NUR/commit/ff4a742b1a7d95d355c562f6ad8faadd4318c4f5) | `` automatic update `` |
| [`ed350841`](https://github.com/nix-community/NUR/commit/ed350841f6738603d1dbeddb574f8ce0cbb3d737) | `` automatic update `` |
| [`f58aa340`](https://github.com/nix-community/NUR/commit/f58aa34093b57a517ab023a7708c06e976864ae2) | `` automatic update `` |