### PR TITLE
chore(flake/nur): `1392008c` -> `5e592510`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758417531,
-        "narHash": "sha256-hmZOjRDQ/xPxmDJIYy0/rgz46h6fKN/HBbzuzER59tQ=",
+        "lastModified": 1758425824,
+        "narHash": "sha256-6Y/O7yrbXXq+hDnZN+qMAJXtdt7GlOzrCcTPmw/7bAs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1392008c0ac44fb1992523a6997790da6cd769ca",
+        "rev": "5e59251099713784f550837c72ea4ed2ccb3c838",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5e592510`](https://github.com/nix-community/NUR/commit/5e59251099713784f550837c72ea4ed2ccb3c838) | `` automatic update `` |
| [`c302d926`](https://github.com/nix-community/NUR/commit/c302d926c96b0a2a50e679d685621f7d409fe3fb) | `` automatic update `` |