### PR TITLE
chore(flake/nixpkgs): `d2ed9964` -> `b2a3852b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1758216857,
-        "narHash": "sha256-h1BW2y7CY4LI9w61R02wPaOYfmYo82FyRqHIwukQ6SY=",
+        "lastModified": 1758346548,
+        "narHash": "sha256-afXE7AJ7MY6wY1pg/Y6UPHNYPy5GtUKeBkrZZ/gC71E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2ed99647a4b195f0bcc440f76edfa10aeb3b743",
+        "rev": "b2a3852bd078e68dd2b3dfa8c00c67af1f0a7d20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`359fad89`](https://github.com/NixOS/nixpkgs/commit/359fad89d552cf079a40e293d415e4df7b9ea4d9) | `` wofi-power-menu: 0.3.1 -> 0.3.2 ``                                     |
| [`48163aea`](https://github.com/NixOS/nixpkgs/commit/48163aea023ec3fa52212d14e71d81043e87953b) | `` brave: 1.82.166 -> 1.82.170 ``                                         |
| [`cbf81247`](https://github.com/NixOS/nixpkgs/commit/cbf8124759856e91acc21be4e2cd8ac563a4f50d) | `` grav: 1.7.49.4 -> 1.7.49.5 ``                                          |
| [`f7cc9bbd`](https://github.com/NixOS/nixpkgs/commit/f7cc9bbde374fa249ed6e3a633117e69843b0f3a) | `` why3: 1.8.1 -> 1.8.2 ``                                                |
| [`4a65163f`](https://github.com/NixOS/nixpkgs/commit/4a65163f384cc9927eda053515f0dc185e85d9a2) | `` linux_6_1: 6.1.152 -> 6.1.153 ``                                       |
| [`31327e8e`](https://github.com/NixOS/nixpkgs/commit/31327e8e5ec8d2b4acfb9bc670d8fde6fd0b33d3) | `` linux_6_6: 6.6.106 -> 6.6.107 ``                                       |
| [`11fc2c2e`](https://github.com/NixOS/nixpkgs/commit/11fc2c2ea012e3f53523776bf487b4d2a696a4cb) | `` linux_6_12: 6.12.47 -> 6.12.48 ``                                      |
| [`c0f8c4e5`](https://github.com/NixOS/nixpkgs/commit/c0f8c4e597b7be004ecbab9a114aa708a94fa3dc) | `` linux_6_16: 6.16.7 -> 6.16.8 ``                                        |
| [`391df024`](https://github.com/NixOS/nixpkgs/commit/391df024de7e80ac1884185e587fcf0a41a1242c) | `` linux_testing: 6.17-rc5 -> 6.17-rc6 ``                                 |
| [`a7170c6d`](https://github.com/NixOS/nixpkgs/commit/a7170c6d0a09d100edf567aee0042ffa41fd3924) | `` miniflux: add `meta.changelog` ``                                      |
| [`b4d13b94`](https://github.com/NixOS/nixpkgs/commit/b4d13b940f11034bc275033201fce714a61f0dad) | `` miniflux: use `finalAttrs` ``                                          |
| [`f2f60f23`](https://github.com/NixOS/nixpkgs/commit/f2f60f23127ff5709b7209be185e519472cb7377) | `` miniflux: 2.2.12 -> 2.2.13 ``                                          |
| [`ea701775`](https://github.com/NixOS/nixpkgs/commit/ea701775c3664071581daa00915ab10c0f88acdd) | `` curlFull: fixup build temporarily ``                                   |
| [`dc9d2340`](https://github.com/NixOS/nixpkgs/commit/dc9d2340fd5c6c7ab977e260cfe381a9921621e3) | `` linuxKernel.kernels.linux_zen: 6.16.5 -> 6.16.7 ``                     |
| [`812d5617`](https://github.com/NixOS/nixpkgs/commit/812d5617e71484219ee59f301b82fae4cca72a60) | `` wpa_supplicant: patch ext_password_file bug ``                         |
| [`9b19922a`](https://github.com/NixOS/nixpkgs/commit/9b19922a608bb660033367d79fb4724bb5cbc4cf) | `` qtcreator: 17.0.0 -> 17.0.1 ``                                         |
| [`e096196a`](https://github.com/NixOS/nixpkgs/commit/e096196afe5afc0f7a2d4620894cb1f461561530) | `` nixos-rebuild-ng: do not try to copy closure when running dry-build `` |
| [`1723d10f`](https://github.com/NixOS/nixpkgs/commit/1723d10fa8dd4a6c245d8dd48356d49709ea8b9a) | `` vivaldi: 7.5.3735.74 -> 7.6.3797.52 ``                                 |
| [`4cb3429d`](https://github.com/NixOS/nixpkgs/commit/4cb3429d75f1763224ad913340a6270a2c718796) | `` qtcreator: 16.0.2 -> 17.0.0 ``                                         |
| [`5bb6983c`](https://github.com/NixOS/nixpkgs/commit/5bb6983cc938bb40aa829d2ccf420ca7faacbd41) | `` vscodium: 1.104.06114 -> 1.104.16282 ``                                |
| [`dea33606`](https://github.com/NixOS/nixpkgs/commit/dea336064664dd28760fc348168a471dbe162ced) | `` vscode: 1.104.0 -> 1.104.1 ``                                          |
| [`03109cc0`](https://github.com/NixOS/nixpkgs/commit/03109cc0905778c0c5bba4d4651ab935c7833182) | `` ungoogled-chromium: 140.0.7339.127-1 -> 140.0.7339.185-1 ``            |
| [`c787a565`](https://github.com/NixOS/nixpkgs/commit/c787a565c8487b1f9b52147f07695bbf1b979b30) | `` knot-dns: fix cross compilation ``                                     |
| [`f777f326`](https://github.com/NixOS/nixpkgs/commit/f777f326cfc943f59f9e93f38a9525558753e910) | `` xdp-tools: fix cross compilation ``                                    |
| [`6c20082d`](https://github.com/NixOS/nixpkgs/commit/6c20082dcbca930817bae138bd4851982f669caa) | `` varnish60: 6.0.15 -> 6.0.16 ``                                         |
| [`8f4070e4`](https://github.com/NixOS/nixpkgs/commit/8f4070e4aa1aff0b50dd02864d83521087f89efa) | `` thunderbird-esr-unwrapped: 140.2.1esr -> 140.3.0esr ``                 |
| [`83cb74c2`](https://github.com/NixOS/nixpkgs/commit/83cb74c21a056a597f406ffb56d52eccdfc051a5) | `` thunderbird-latest-unwrapped: 142.0 -> 143.0 ``                        |
| [`32bb02ee`](https://github.com/NixOS/nixpkgs/commit/32bb02eebaf6b541830b0b86f1bb005bd5e3f68d) | `` qpdf: disable timestamp test for now ``                                |
| [`fc4ca4c8`](https://github.com/NixOS/nixpkgs/commit/fc4ca4c8a430e7da5f0444f995c8a37f8fa77e59) | `` python3Packages.msgspec: fix src hash ``                               |
| [`1af2de9a`](https://github.com/NixOS/nixpkgs/commit/1af2de9acaca8cce830ce2cebe457bf6a213124a) | `` curlMinimal: apply patches for CVE-2025-9086 and CVE-2025-10148 ``     |
| [`2844be53`](https://github.com/NixOS/nixpkgs/commit/2844be539b45d7697ad48063c2d68b03f75173a0) | `` systemd: 257.8 -> 257.9 ``                                             |
| [`cc9a7508`](https://github.com/NixOS/nixpkgs/commit/cc9a75082350c272dc2a3e37de3d4ddc267eafc9) | `` python3Packages.django_4: 4.2.23 -> 4.2.24 ``                          |
| [`15af35b2`](https://github.com/NixOS/nixpkgs/commit/15af35b286594542b6bcca685fc7c9547f07ef75) | `` nodejs_22: 22.18.0 -> 22.19.0 ``                                       |
| [`ae6121c9`](https://github.com/NixOS/nixpkgs/commit/ae6121c986db5b8a705805e0a7069b7155498c29) | `` valkey: set upper limit for parallelism in test-suite ``               |
| [`92f8b07e`](https://github.com/NixOS/nixpkgs/commit/92f8b07e1a446a0c0ea889ead0871b02b1709cf7) | `` python313Packages.pyside6: 6.9.1 -> 6.9.2 ``                           |
| [`d5db150f`](https://github.com/NixOS/nixpkgs/commit/d5db150f3a67bb3d4e86a845395ce9cf6525ea50) | `` qt6: 6.9.1 -> 6.9.2 ``                                                 |
| [`6851eb64`](https://github.com/NixOS/nixpkgs/commit/6851eb6418e5172bc79a2e30f1b513bf3dfaf916) | `` gupnp_1_6: 1.6.8 -> 1.6.9 ``                                           |
| [`94d54510`](https://github.com/NixOS/nixpkgs/commit/94d54510482ecba83fb47dfdf0cf4f33787ac074) | `` libtiff: apply patch CVE-2024-13978 and CVE-2025-9165 ``               |
| [`a090b8b5`](https://github.com/NixOS/nixpkgs/commit/a090b8b54791fceed86116f11c73f28925427972) | `` php: fix systemdLibs dependency ``                                     |