### PR TITLE
chore(flake/nur): `5e592510` -> `86f5d2ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758425824,
-        "narHash": "sha256-6Y/O7yrbXXq+hDnZN+qMAJXtdt7GlOzrCcTPmw/7bAs=",
+        "lastModified": 1758433715,
+        "narHash": "sha256-HJoS2meEamJ8ygcLDYPcGugbmpiGk+zdhW6mVRoL5DE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e59251099713784f550837c72ea4ed2ccb3c838",
+        "rev": "86f5d2efe861e4fa2a9e3823d621c5ed7ecfb56f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`86f5d2ef`](https://github.com/nix-community/NUR/commit/86f5d2efe861e4fa2a9e3823d621c5ed7ecfb56f) | `` automatic update `` |
| [`7bc5e120`](https://github.com/nix-community/NUR/commit/7bc5e1209804dca3b36a80a544e9da298be4b6e6) | `` automatic update `` |
| [`f401a975`](https://github.com/nix-community/NUR/commit/f401a9753e3805505566ec3eacd781cd687ba18d) | `` automatic update `` |
| [`7bc97b44`](https://github.com/nix-community/NUR/commit/7bc97b44e29ccdc5cf29dee777b1fa01ed909d0f) | `` automatic update `` |
| [`5eca0579`](https://github.com/nix-community/NUR/commit/5eca057943e4dbfbddd97a973de05a5ae8b6f28e) | `` automatic update `` |
| [`f6bd0003`](https://github.com/nix-community/NUR/commit/f6bd0003a34b4317ecffdef774ef1c0a7a0ac659) | `` automatic update `` |