### PR TITLE
chore(flake/nur): `86f5d2ef` -> `e3fc23fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758433715,
-        "narHash": "sha256-HJoS2meEamJ8ygcLDYPcGugbmpiGk+zdhW6mVRoL5DE=",
+        "lastModified": 1758444471,
+        "narHash": "sha256-zvMgenloqjsglH0uvyyuY9t8ClDmsSfH47m/rkXuki8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "86f5d2efe861e4fa2a9e3823d621c5ed7ecfb56f",
+        "rev": "e3fc23fd79e5fc7f7937fca2de69d8b2267f0193",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e3fc23fd`](https://github.com/nix-community/NUR/commit/e3fc23fd79e5fc7f7937fca2de69d8b2267f0193) | `` automatic update `` |
| [`c58bc8e6`](https://github.com/nix-community/NUR/commit/c58bc8e66492ff28a8bcdbe04b5b6b00f6f386b0) | `` automatic update `` |
| [`0b39a4bc`](https://github.com/nix-community/NUR/commit/0b39a4bc26b048efcfa476ad9f88c690250deb60) | `` automatic update `` |
| [`42749e10`](https://github.com/nix-community/NUR/commit/42749e1003a6349e0d87fab6733e85c2c6b19acc) | `` automatic update `` |