### PR TITLE
chore(flake/nur): `e3fc23fd` -> `cf20df7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758444471,
-        "narHash": "sha256-zvMgenloqjsglH0uvyyuY9t8ClDmsSfH47m/rkXuki8=",
+        "lastModified": 1758454035,
+        "narHash": "sha256-ARnOyLqbsB84A4FCTjFitFP38+YFslEsOD6XwULzX6U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e3fc23fd79e5fc7f7937fca2de69d8b2267f0193",
+        "rev": "cf20df7fec0a9dff5271f1f50b9be96559a58d4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cf20df7f`](https://github.com/nix-community/NUR/commit/cf20df7fec0a9dff5271f1f50b9be96559a58d4a) | `` automatic update `` |
| [`ffc1c639`](https://github.com/nix-community/NUR/commit/ffc1c63903ffd6dff3ef6dc0fb014aeb7707f804) | `` automatic update `` |
| [`b1fb4589`](https://github.com/nix-community/NUR/commit/b1fb458916c940a2a47e4f01f24129c719d53343) | `` automatic update `` |
| [`0d04d8f9`](https://github.com/nix-community/NUR/commit/0d04d8f9a258ef72b4bb9c9779c5c97904c92503) | `` automatic update `` |