### PR TITLE
chore(flake/nur): `cf20df7f` -> `4ac4b05a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758454035,
-        "narHash": "sha256-ARnOyLqbsB84A4FCTjFitFP38+YFslEsOD6XwULzX6U=",
+        "lastModified": 1758467657,
+        "narHash": "sha256-OgKd/g0jHaXwmlJ4SSqMauW+NbLDsbQ26Z6QFsAXlyg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cf20df7fec0a9dff5271f1f50b9be96559a58d4a",
+        "rev": "4ac4b05a074a0b1aab9a4799e1b49a985847a52b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4ac4b05a`](https://github.com/nix-community/NUR/commit/4ac4b05a074a0b1aab9a4799e1b49a985847a52b) | `` automatic update `` |
| [`09bf63d6`](https://github.com/nix-community/NUR/commit/09bf63d621279655c7d4c6d4f0dc5fdad9a72a71) | `` automatic update `` |
| [`2729a7e2`](https://github.com/nix-community/NUR/commit/2729a7e25be295dd2e812946987c4807088ab76d) | `` automatic update `` |