### PR TITLE
chore(flake/nur): `4ac4b05a` -> `74565f4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758467657,
-        "narHash": "sha256-OgKd/g0jHaXwmlJ4SSqMauW+NbLDsbQ26Z6QFsAXlyg=",
+        "lastModified": 1758478314,
+        "narHash": "sha256-nlZD/pKHxv69oNGxRk31ONcM2Iv2TwQmTWgLFk4gVrY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ac4b05a074a0b1aab9a4799e1b49a985847a52b",
+        "rev": "74565f4c9b78ec9b00e704ee42d7a1577a8175ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`74565f4c`](https://github.com/nix-community/NUR/commit/74565f4c9b78ec9b00e704ee42d7a1577a8175ea) | `` automatic update `` |
| [`3513699d`](https://github.com/nix-community/NUR/commit/3513699d4adccb29efa4629e68b09d6ad5db7fa3) | `` automatic update `` |
| [`b5331734`](https://github.com/nix-community/NUR/commit/b53317340d231acb7c742eb308e301af1b94af70) | `` automatic update `` |