### PR TITLE
chore(flake/nur): `c2d0199c` -> `79f2bd42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758505304,
-        "narHash": "sha256-+GGY/8u8+DlJTh5CP2xY6pu+ehdHtRAmu3CwQopMIbg=",
+        "lastModified": 1758512373,
+        "narHash": "sha256-PJ2vvKC2CWy95mkMcfhXCQs5MJxtWYT0Xktru9AApao=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2d0199cb6a9ae76517c73307520155738dffcde",
+        "rev": "79f2bd424700a082171178025dc6c22f1ffe748b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`79f2bd42`](https://github.com/nix-community/NUR/commit/79f2bd424700a082171178025dc6c22f1ffe748b) | `` automatic update `` |
| [`18faed33`](https://github.com/nix-community/NUR/commit/18faed33b2cc57d8d0705227d802e16dcada571c) | `` automatic update `` |
| [`1e477dad`](https://github.com/nix-community/NUR/commit/1e477dad43c75b007d906babf62527ea8c1b2a89) | `` automatic update `` |