### PR TITLE
chore(flake/nur): `79f2bd42` -> `f395cf56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758512373,
-        "narHash": "sha256-PJ2vvKC2CWy95mkMcfhXCQs5MJxtWYT0Xktru9AApao=",
+        "lastModified": 1758522602,
+        "narHash": "sha256-r48DKZLqT56eb4225N0j8GMbs0+d7zDKw/TLOH8Tab0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "79f2bd424700a082171178025dc6c22f1ffe748b",
+        "rev": "f395cf568a2c3f0c3b42c77766d8f3b5ce9b9332",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f395cf56`](https://github.com/nix-community/NUR/commit/f395cf568a2c3f0c3b42c77766d8f3b5ce9b9332) | `` automatic update `` |
| [`0068046f`](https://github.com/nix-community/NUR/commit/0068046feb84fb40bb8dc70f159ef0e1e4ef965b) | `` automatic update `` |
| [`c2e74d4d`](https://github.com/nix-community/NUR/commit/c2e74d4d12d1a6c3bdc99d40bd40cdca9c000bee) | `` automatic update `` |
| [`8ac3f92a`](https://github.com/nix-community/NUR/commit/8ac3f92ab4b23d49a27551a3fb8d60b700cf4b51) | `` automatic update `` |
| [`46238033`](https://github.com/nix-community/NUR/commit/46238033a9926601261bb6aa2ce0d39436a356f0) | `` automatic update `` |