### PR TITLE
chore(flake/nur): `f395cf56` -> `3876b2ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758522602,
-        "narHash": "sha256-r48DKZLqT56eb4225N0j8GMbs0+d7zDKw/TLOH8Tab0=",
+        "lastModified": 1758532494,
+        "narHash": "sha256-hfIqhpFC+ZAlVS/60KGdXzGH+VmNGTndfeKBah3LutQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f395cf568a2c3f0c3b42c77766d8f3b5ce9b9332",
+        "rev": "3876b2aef6eaf9d9a476749626e28bfe944425d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3876b2ae`](https://github.com/nix-community/NUR/commit/3876b2aef6eaf9d9a476749626e28bfe944425d9) | `` automatic update `` |
| [`79e54690`](https://github.com/nix-community/NUR/commit/79e546908e49b0a824a7ac4827f8563452b002e7) | `` automatic update `` |
| [`395f5ac7`](https://github.com/nix-community/NUR/commit/395f5ac716e05d0a5da159a4884db0414ecf63cc) | `` automatic update `` |
| [`7a449a8d`](https://github.com/nix-community/NUR/commit/7a449a8dfde5bdd309bf179e265808240eed25ff) | `` automatic update `` |
| [`1989eab0`](https://github.com/nix-community/NUR/commit/1989eab0cce5405ea41fe3660c9259a5297a9b70) | `` automatic update `` |
| [`bb2d5dcb`](https://github.com/nix-community/NUR/commit/bb2d5dcb8347d2cef6916af74882b29b2934a1c5) | `` automatic update `` |
| [`0e479a60`](https://github.com/nix-community/NUR/commit/0e479a609aeed6a5cfff667ee03e3d2b9f349568) | `` automatic update `` |
| [`7a4fcd0a`](https://github.com/nix-community/NUR/commit/7a4fcd0ad4cb2b5df779e21c0827926339cccee2) | `` automatic update `` |