### PR TITLE
chore(flake/nur): `3876b2ae` -> `7cb52c07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758532494,
-        "narHash": "sha256-hfIqhpFC+ZAlVS/60KGdXzGH+VmNGTndfeKBah3LutQ=",
+        "lastModified": 1758542646,
+        "narHash": "sha256-6yvLYW+xyfS47tYfBC9YsmfvcGUtZ39zVK7sv6HY35U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3876b2aef6eaf9d9a476749626e28bfe944425d9",
+        "rev": "7cb52c07ba402009169d219cdf0c7c6d0c8afabd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7cb52c07`](https://github.com/nix-community/NUR/commit/7cb52c07ba402009169d219cdf0c7c6d0c8afabd) | `` automatic update `` |
| [`b5931428`](https://github.com/nix-community/NUR/commit/b5931428abf7141858255faeef479d0d16f46ea2) | `` automatic update `` |