### PR TITLE
chore(flake/nur): `a102051b` -> `2c8121b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758554259,
-        "narHash": "sha256-OWusAvgPsZIGiHo54bpZIn6HbIkTOzk4po5ifNUK5BE=",
+        "lastModified": 1758564296,
+        "narHash": "sha256-hi0PlFm1gdeeTXDz9sIYZYKJWcPbRD9ar83q26YdU9I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a102051ba5331bc85f03a49f1bc56345e6444d66",
+        "rev": "2c8121b44ea0f2b8917340d22e7f9098e1d09029",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2c8121b4`](https://github.com/nix-community/NUR/commit/2c8121b44ea0f2b8917340d22e7f9098e1d09029) | `` automatic update `` |
| [`b09c5848`](https://github.com/nix-community/NUR/commit/b09c58487af8c2e608aa4968f7e54ab5cdf447bf) | `` automatic update `` |