### PR TITLE
chore(flake/nur): `2c8121b4` -> `00fe487d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758564296,
-        "narHash": "sha256-hi0PlFm1gdeeTXDz9sIYZYKJWcPbRD9ar83q26YdU9I=",
+        "lastModified": 1758574488,
+        "narHash": "sha256-lLRcFOALlUdRIIRvb3uiFSfRfYGvgNLj89Re4QeuzMQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c8121b44ea0f2b8917340d22e7f9098e1d09029",
+        "rev": "00fe487d36ff2a8630eb51647354a7b1c9d284f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`00fe487d`](https://github.com/nix-community/NUR/commit/00fe487d36ff2a8630eb51647354a7b1c9d284f8) | `` automatic update `` |
| [`ff4edc25`](https://github.com/nix-community/NUR/commit/ff4edc2514e2f4df49c2feb2c23e463d20453387) | `` automatic update `` |
| [`0b6ad842`](https://github.com/nix-community/NUR/commit/0b6ad842c2c500ce7dd1496af2c6260bdb5b7acd) | `` automatic update `` |