### PR TITLE
chore(flake/nur): `00fe487d` -> `386857f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758574488,
-        "narHash": "sha256-lLRcFOALlUdRIIRvb3uiFSfRfYGvgNLj89Re4QeuzMQ=",
+        "lastModified": 1758589856,
+        "narHash": "sha256-mvnsqtQk+DcTklcd1xKEAV6mic7hnfBQBC0ujAY/JO8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "00fe487d36ff2a8630eb51647354a7b1c9d284f8",
+        "rev": "386857f1aec8c3a809e929cc9493edfbd9b7fbad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`386857f1`](https://github.com/nix-community/NUR/commit/386857f1aec8c3a809e929cc9493edfbd9b7fbad) | `` automatic update `` |
| [`7f659ff3`](https://github.com/nix-community/NUR/commit/7f659ff3f1e52eaba0476053a9740882da666572) | `` automatic update `` |
| [`4208a555`](https://github.com/nix-community/NUR/commit/4208a555f0c519d4a9a52e9014fa2b161e344d10) | `` automatic update `` |