### PR TITLE
chore(flake/nur): `50d2c97c` -> `2f247753`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758597760,
-        "narHash": "sha256-HdkQaKzMMxdgrBOpFxskfe9745ULI20ONad+vNIlASo=",
+        "lastModified": 1758609005,
+        "narHash": "sha256-jNdWm7EbraNUUEP5JeYUlkOpdT6KZQJAonJcVp+IEl4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50d2c97c73f71a6544d69ff20feeb1dcfe1c8159",
+        "rev": "2f2477539e4f28a6f58e971091ea2398785aab84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2f247753`](https://github.com/nix-community/NUR/commit/2f2477539e4f28a6f58e971091ea2398785aab84) | `` automatic update `` |
| [`de4f5ff4`](https://github.com/nix-community/NUR/commit/de4f5ff4f5dabad8356f67119fbe582a44c9e969) | `` automatic update `` |
| [`72ed02e7`](https://github.com/nix-community/NUR/commit/72ed02e7f65db82f7274a1dccf0196763a1317c3) | `` automatic update `` |