### PR TITLE
chore(flake/nixpkgs-unstable): `8eaee110` -> `554be649`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1758277210,
-        "narHash": "sha256-iCGWf/LTy+aY0zFu8q12lK8KuZp7yvdhStehhyX1v8w=",
+        "lastModified": 1758427187,
+        "narHash": "sha256-pHpxZ/IyCwoTQPtFIAG2QaxuSm8jWzrzBGjwQZIttJc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8eaee110344796db060382e15d3af0a9fc396e0e",
+        "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`063fe428`](https://github.com/NixOS/nixpkgs/commit/063fe428650dc1f32b8d2006b8bd015bfd5ef01d) | `` marge-bot: 0.17.0 -> 0.18.0 ``                                                    |
| [`b8424868`](https://github.com/NixOS/nixpkgs/commit/b84248686baa595c7a34b64acd82d4c7d21555fc) | `` llvmPackages.libllvm: add passthru.tests.withoutOptionalFeatures ``               |
| [`89baf532`](https://github.com/NixOS/nixpkgs/commit/89baf5322593ceb45ee3d1d19a295dcd398ad793) | `` llvmPackages.libllvm: fix enablePolly = false ``                                  |
| [`a1f7894b`](https://github.com/NixOS/nixpkgs/commit/a1f7894b5c430ac5f981327f723e2cda163cfe47) | `` python3Packages.scanpy: skip failing test ``                                      |
| [`208dbd3e`](https://github.com/NixOS/nixpkgs/commit/208dbd3e55bc754127b953c11f303747700b020b) | `` thunderbird-latest-bin-unwrapped: 142.0 -> 143.0 ``                               |
| [`886fdecd`](https://github.com/NixOS/nixpkgs/commit/886fdecdc4bd8765fa0117aab51759862f061a14) | `` nixos/incus: avoid restart on switch for incus-startup ``                         |
| [`874c7c19`](https://github.com/NixOS/nixpkgs/commit/874c7c19312c57940b3bca723bdc332ff653026b) | `` argocd: 3.1.1 -> 3.1.6 ``                                                         |
| [`4eba7aeb`](https://github.com/NixOS/nixpkgs/commit/4eba7aebe063d7f48fa573ceb40e7d2a8208324c) | `` steamcontroller: drop ``                                                          |
| [`9f7f75f8`](https://github.com/NixOS/nixpkgs/commit/9f7f75f801a99e15a1f9d559a93e25265c269834) | `` privoxy: Allow multiple listen-address options ``                                 |
| [`0894f50e`](https://github.com/NixOS/nixpkgs/commit/0894f50e10c4f89c041006e04da2e9379c710b3d) | `` vimPlugins.oil-git-nvim: init at 2025-09-03 ``                                    |
| [`4e90880e`](https://github.com/NixOS/nixpkgs/commit/4e90880ee69f0d8f975191041ce4a3fe3bf59fcb) | `` nixf-diagnose: 0.1.3 -> 0.1.4 ``                                                  |
| [`14549df8`](https://github.com/NixOS/nixpkgs/commit/14549df818995c2a465556682097fe5a77f57332) | `` maintainers: remove benwbooth ``                                                  |
| [`c3950db2`](https://github.com/NixOS/nixpkgs/commit/c3950db2bbfd73e386e05b43e77070d142b0673d) | `` inputplumber: 0.62.2 -> 0.64.0 ``                                                 |
| [`fd6bbfa5`](https://github.com/NixOS/nixpkgs/commit/fd6bbfa5e9d8863864d28fbd669092d3bd6d9513) | `` hmcl: 3.6.16 -> 3.6.17 ``                                                         |
| [`6df082c5`](https://github.com/NixOS/nixpkgs/commit/6df082c53730035bd6921e1d13586f1a40ebd495) | `` edk2: 202505 -> 202508 ``                                                         |
| [`5119cafc`](https://github.com/NixOS/nixpkgs/commit/5119cafc5927bd366a002e89addb416ea5b34d77) | `` Revert "various: fix Scudo allocator due to LLVM update" ``                       |
| [`4abba235`](https://github.com/NixOS/nixpkgs/commit/4abba235ca04f6b834b6e95ba622feb13f4897e6) | `` rcu: add co-maintainer ``                                                         |
| [`1753e8b6`](https://github.com/NixOS/nixpkgs/commit/1753e8b61ae3eb33f7a2402202d0fcce115d9da6) | `` nixos/wyoming/piper: fix cudaSupport reference ``                                 |
| [`93d37624`](https://github.com/NixOS/nixpkgs/commit/93d376245232c8294f98def979d809f8277bef52) | `` forgejo-runner: 11.1.0 -> 11.1.1 ``                                               |
| [`0c307041`](https://github.com/NixOS/nixpkgs/commit/0c307041f90ccb4b908d253cf1bc7796c8483be2) | `` rcu: Disable auto-added updateScript from python ecosystem ``                     |
| [`37617999`](https://github.com/NixOS/nixpkgs/commit/376179991ebbcb40be0f9be0ff6eddfb6dd321a6) | `` rcu: 4.0.27 -> 4.0.29 ``                                                          |
| [`41212d7d`](https://github.com/NixOS/nixpkgs/commit/41212d7dfff88c08e39f2bd2ed38ec8fca1e24ae) | `` rcu: 4.0.26 -> 4.0.27 ``                                                          |
| [`12004986`](https://github.com/NixOS/nixpkgs/commit/1200498671a7b4c4cf7d733dd2ecc7c3be5d5e0d) | `` frugally-deep,rocmPackages.miopen: add regression test for .model load failure `` |
| [`1abfa4cc`](https://github.com/NixOS/nixpkgs/commit/1abfa4cc885faa2b54b2419a43700e2f7b85967c) | `` libretro.thepowdertoy: 0-unstable-2024-09-30 -> 0-unstable-2025-09-16 ``          |
| [`c8888cdd`](https://github.com/NixOS/nixpkgs/commit/c8888cdd662a5f87d3d364164bb770e3434a4b86) | `` frugally-deep: backport CMake 4 compat ``                                         |
| [`d78ce0ec`](https://github.com/NixOS/nixpkgs/commit/d78ce0ec3e483c8282245cb568b52d8b711850c4) | `` Revert "frugally-deep: 0.15.24-p0 -> 0.18.2-unstable-2025-06-16" ``               |
| [`c4775988`](https://github.com/NixOS/nixpkgs/commit/c4775988acdb3a20bbd379fa197611b9898d4337) | `` h2o: 2.3.0-rolling-2025-09-12 → 2.3.0-rolling-2025-09-20 ``                       |
| [`b8f50117`](https://github.com/NixOS/nixpkgs/commit/b8f5011752296c2652599c0db4571cb5a57f2173) | `` esptool: 5.0.2 -> 5.1.0 ``                                                        |
| [`baa645dc`](https://github.com/NixOS/nixpkgs/commit/baa645dc53c06a206fc48f679658116e15a7d478) | `` fosrl-newt: 1.4.4 -> 1.5.0 ``                                                     |
| [`ba891586`](https://github.com/NixOS/nixpkgs/commit/ba891586c5859bfaed3088b4389426126ed2b68f) | `` theforceengine: 1.22.410 -> 1.22.420 ``                                           |
| [`cf392d4c`](https://github.com/NixOS/nixpkgs/commit/cf392d4ca163bb0cb13e7ccb423c68ead01fa53d) | `` discord: 0.0.108 -> 0.0.110 ``                                                    |
| [`ddb39285`](https://github.com/NixOS/nixpkgs/commit/ddb39285515fea08516269edf1f7d45f7f204f6f) | `` datafusion-cli: 49.0.2 -> 50.0.0 ``                                               |
| [`62310174`](https://github.com/NixOS/nixpkgs/commit/62310174dc8054399a2b6ba626e51173a5886f3d) | `` forgejo-lts: 11.0.5 -> 11.0.6 ``                                                  |
| [`52d706c4`](https://github.com/NixOS/nixpkgs/commit/52d706c4b4dd31ed9e4bae04fe3d078158c7881c) | `` forgejo: 12.0.3 -> 12.0.4 ``                                                      |
| [`7746a38a`](https://github.com/NixOS/nixpkgs/commit/7746a38af2399262271c0561942bd44f3f09167e) | `` fosrl-pangolin: 1.9.4 -> 1.10.1 ``                                                |
| [`6d71b6ba`](https://github.com/NixOS/nixpkgs/commit/6d71b6bacdf2fa5c10d954464b97ae984e0efc73) | `` plasma-panel-colorizer: 5.0.0 -> 5.0.1 ``                                         |
| [`887f04e2`](https://github.com/NixOS/nixpkgs/commit/887f04e208e1dcc4bdbd9fbc3180a9ca9515e10e) | `` python3Packages.waterfurnace: modernize ``                                        |
| [`753af06d`](https://github.com/NixOS/nixpkgs/commit/753af06dab0561b180b8d9e274a9f6c41e5107ee) | `` treewide: fix Scudo options ``                                                    |
| [`64418cb2`](https://github.com/NixOS/nixpkgs/commit/64418cb26af0e918ce3d19759afe4d00ee729d38) | `` nixos/malloc: fix Scudo library path ``                                           |
| [`48abfa54`](https://github.com/NixOS/nixpkgs/commit/48abfa54ee1f96c8ce4c287f0b4729ab8b8402a2) | `` vimPlugins.git-dashboard-nvim: init at 2025-01-02 ``                              |
| [`23cea282`](https://github.com/NixOS/nixpkgs/commit/23cea282babbe60caf9bfd08464932b5e8b2207d) | `` go-ios: fix build on darwin ``                                                    |
| [`1cac88e0`](https://github.com/NixOS/nixpkgs/commit/1cac88e0757531b9b929f553b8d63a02e594eb67) | `` home-assistant-custom-components.solis-sensor: 3.13.1 -> 3.13.2 ``                |
| [`8eef4a24`](https://github.com/NixOS/nixpkgs/commit/8eef4a2436910519fd9e9da33d70d4ee9cd0dbd2) | `` python313Packages.elasticsearch8: add missing inputs ``                           |
| [`187ca933`](https://github.com/NixOS/nixpkgs/commit/187ca9338684919a8eaf18830f7c2ca1377a7383) | `` python313Packages.rki-covid-parser: remove ``                                     |
| [`4fab3223`](https://github.com/NixOS/nixpkgs/commit/4fab32231089f5cdb09ee5f6f268bab5b432ac36) | `` python313Packages.rtsp-to-webrtc: remove ``                                       |
| [`2fad2a73`](https://github.com/NixOS/nixpkgs/commit/2fad2a73081b28fd2c3b977750832be5af06b800) | `` tunnelgraf: override paramiko ``                                                  |
| [`aeb3a003`](https://github.com/NixOS/nixpkgs/commit/aeb3a0032cefb7d399fff727f18284501fc0b41f) | `` python313Packages.sshtunnel: disable failing test ``                              |
| [`641a4592`](https://github.com/NixOS/nixpkgs/commit/641a4592788f912c6ee0aee3bf48751dc0c449b1) | `` libretro.snes9x: 0-unstable-2025-08-11 -> 0-unstable-2025-09-18 ``                |
| [`67eb0f04`](https://github.com/NixOS/nixpkgs/commit/67eb0f0494e5996fa405ff96d6819ffc95a6cec2) | `` godot: fix obj being copied to output ``                                          |
| [`28367fc2`](https://github.com/NixOS/nixpkgs/commit/28367fc246a36b56d92870bb9c3001625de292bf) | `` python3Packages.txtai: 9.0.0 -> 9.0.1 ``                                          |
| [`141956d4`](https://github.com/NixOS/nixpkgs/commit/141956d4d6fa2caf9c171746c06ad49e7076f17e) | `` gale: 1.9.6 -> 1.9.7 ``                                                           |
| [`c4bf8c39`](https://github.com/NixOS/nixpkgs/commit/c4bf8c39a2a657a53ca7ca883d285a37b1eece46) | `` tunnelgraf: update changelog entry ``                                             |
| [`6dc8602f`](https://github.com/NixOS/nixpkgs/commit/6dc8602fea03fb69a0dfd5bd32aa8fb703f5bdca) | `` python313Packages.tagoio-sdk: modernize ``                                        |
| [`fd45b607`](https://github.com/NixOS/nixpkgs/commit/fd45b6078f249370ad1f8113d5f8037d1cb69c1d) | `` pip-audit: modernize ``                                                           |
| [`e4cbbcc4`](https://github.com/NixOS/nixpkgs/commit/e4cbbcc4008b4b37a56834a59b0ef1420893712a) | `` pip-audit: relax cyclonedx-python-lib ``                                          |
| [`8c14a2e9`](https://github.com/NixOS/nixpkgs/commit/8c14a2e9ef7ad269f126441576897967594ed227) | `` weaver: 0.17.1 -> 0.18.0 ``                                                       |
| [`6b97ee62`](https://github.com/NixOS/nixpkgs/commit/6b97ee62eb6000250b9fc5ebdb2e6b9feee22345) | `` cdrkit: apply patch for cmake 4 ``                                                |
| [`62c5ee3c`](https://github.com/NixOS/nixpkgs/commit/62c5ee3c4471c792d08fee97b264220fda217c1a) | `` python3Packages.dm-control: 1.0.31 -> 1.0.34 ``                                   |
| [`8203384a`](https://github.com/NixOS/nixpkgs/commit/8203384a393532d2adb29bb9981246de724d5525) | `` cdrkit: 1.1.11-3.5 -> 1.1.11-4 ``                                                 |
| [`70e6c174`](https://github.com/NixOS/nixpkgs/commit/70e6c17404cfbd3314337fc4199dfdedd7ff0aed) | `` libpinyin: 2.10.2 -> 2.10.3 ``                                                    |
| [`a78d4603`](https://github.com/NixOS/nixpkgs/commit/a78d4603b6ba48d426df424c0dcc7c08be931b88) | `` checkov: 3.2.461 -> 3.2.471 ``                                                    |
| [`14cac1bb`](https://github.com/NixOS/nixpkgs/commit/14cac1bb77ad9407688e5edc3b1cab250747de8b) | `` python313Packages.pytest-reverse: modernize ``                                    |
| [`1c212601`](https://github.com/NixOS/nixpkgs/commit/1c212601aa3db56198e3d1d8c386ccae3dd0cefa) | `` python313Packages.gwcs: 0.25.2 -> 0.26.0 ``                                       |
| [`b1a9a35c`](https://github.com/NixOS/nixpkgs/commit/b1a9a35c3ce98f6d8ab2ebc2782d289c76d71f68) | `` python3Packages.msgraph-core: 1.3.5 -> 1.3.8 ``                                   |
| [`8c2ae63b`](https://github.com/NixOS/nixpkgs/commit/8c2ae63b13f1be79c27508150025130b9d52d9b7) | `` python313Packages.aioshelly: 13.9.0 -> 13.10.0 ``                                 |
| [`d9f4b1b2`](https://github.com/NixOS/nixpkgs/commit/d9f4b1b2a74994ec964287a0d731c584f0c8b745) | `` easytier: add shell completions ``                                                |
| [`147a14b3`](https://github.com/NixOS/nixpkgs/commit/147a14b31568890559848b255ae5d0123daf974e) | `` avalonia: 11.3.5 -> 11.3.6 ``                                                     |
| [`fa3ff6a0`](https://github.com/NixOS/nixpkgs/commit/fa3ff6a01a6b01bf83fb1e32413b3d4f3620203e) | `` postgresqlPackages.pg_roaringbitmap: 0.5.4 -> 0.5.5 ``                            |
| [`e4941ba4`](https://github.com/NixOS/nixpkgs/commit/e4941ba4925fb62fbeca4658ff3771ac3ea745df) | `` python3Packages.pytest-reverse: 1.8.0 -> 1.9.0 ``                                 |
| [`f199f6e7`](https://github.com/NixOS/nixpkgs/commit/f199f6e7fbadc7989b9df6dd2e3fec81494acbb5) | `` ni: 25.0.0 -> 26.0.1 ``                                                           |
| [`e85d49e5`](https://github.com/NixOS/nixpkgs/commit/e85d49e5bce4627418777667fd7ca05be004d93a) | `` maintainers: remove dpflug ``                                                     |
| [`4e2bf726`](https://github.com/NixOS/nixpkgs/commit/4e2bf7265d4355f90401a2240703ae5a2a2a44e9) | `` python3Packages.pyiskra: 0.1.26 -> 0.1.27 ``                                      |
| [`58a66b7e`](https://github.com/NixOS/nixpkgs/commit/58a66b7e08f921de3d55596ea3ed028d8f22978c) | `` python3Packages.wgpu-py: 0.23.0 -> 0.24.0 ``                                      |
| [`548ed262`](https://github.com/NixOS/nixpkgs/commit/548ed262ce47523c9062960fbb0da2b2d60a2af1) | `` python3Packages.llama-index-readers-docling: 0.4.0 -> 0.4.1 ``                    |
| [`c221a993`](https://github.com/NixOS/nixpkgs/commit/c221a99361871225dc85cb4978df956ac47deadb) | `` python3Packages.llama-index-vector-stores-milvus: 0.9.1 -> 0.9.2 ``               |
| [`2851c728`](https://github.com/NixOS/nixpkgs/commit/2851c728eef384241611abbc7e8136ae17603233) | `` python3Packages.llama-index-node-parser-docling: 0.4.0 -> 0.4.1 ``                |
| [`7e95c2d1`](https://github.com/NixOS/nixpkgs/commit/7e95c2d1cf92facf2ea6d40bbd7a0aec0e3927b0) | `` python3Packages.llama-stack-client: 0.2.20 -> 0.2.22 ``                           |
| [`627b79c1`](https://github.com/NixOS/nixpkgs/commit/627b79c1d3cd85488ad4ba34e1e24e0168b02ac3) | `` python3Packages.yara-x: 1.6.0 -> 1.7.1 ``                                         |
| [`fd8819a6`](https://github.com/NixOS/nixpkgs/commit/fd8819a656b3bdc7e5fefb05fa27e8d8f45a22e7) | `` telegraf: 1.35.4 -> 1.36.1 ``                                                     |
| [`0ae083b3`](https://github.com/NixOS/nixpkgs/commit/0ae083b339093c4e5b0e773b76bc6d5458fc2417) | `` maintainers: rename romner-set to azey7f ``                                       |
| [`019cef79`](https://github.com/NixOS/nixpkgs/commit/019cef79ed07ca133b8689791f42e57b4e55fabe) | `` luau: 0.691 -> 0.692 ``                                                           |
| [`53a24b0c`](https://github.com/NixOS/nixpkgs/commit/53a24b0c99506f1314b1c0c7984bcbb9734b9733) | `` mako: move homepage to github ``                                                  |
| [`db173f4a`](https://github.com/NixOS/nixpkgs/commit/db173f4a35bd8e0f76bd965879e8abb67ca26bfc) | `` mvnd: 1.0.2 -> 1.0.3 ``                                                           |
| [`8ffab668`](https://github.com/NixOS/nixpkgs/commit/8ffab6685a7aa5a60a58958c261a544e2f167343) | `` ord: 0.23.2 -> 0.23.3 ``                                                          |
| [`1edaeecd`](https://github.com/NixOS/nixpkgs/commit/1edaeecd325fa2d5e73809c4732ef2c86aafddbc) | `` misconfig-mapper: 1.14.5 -> 1.14.9 ``                                             |
| [`aa4e1bc9`](https://github.com/NixOS/nixpkgs/commit/aa4e1bc9f8a894a9b8c16165be2a4db00c2dc039) | `` zed-editor: 0.204.2 -> 0.204.3 ``                                                 |
| [`61145dce`](https://github.com/NixOS/nixpkgs/commit/61145dceb0f5590813596788a2bb64d3a1ea6a2d) | `` home-assistant-custom-lovelace-modules.universal-remote-card: 4.7.2 -> 4.8.0 ``   |
| [`9eb76e6d`](https://github.com/NixOS/nixpkgs/commit/9eb76e6d8777b9ff228ae734e60624f8e7cc3786) | `` restish: 0.20.0 -> 0.21.0 ``                                                      |
| [`d1356793`](https://github.com/NixOS/nixpkgs/commit/d1356793bb1edd43c2db262b180eb8dbcb1663d7) | `` python3Packages.pyemoncms: 0.1.2 -> 0.1.3 ``                                      |