### PR TITLE
chore(flake/chaotic): `c2bc079a` -> `4d410bf0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1758540151,
-        "narHash": "sha256-5emcCJqkkpInzhyCGUXXcktPjNQInRHzCvHzP/2XspY=",
+        "lastModified": 1758636125,
+        "narHash": "sha256-z7zVmiyXE39Vfk8uJtoy/CO2FYNK68GEQAj3Hhpd9mo=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "c2bc079a4179295eee766d00b9ae264e68e13db9",
+        "rev": "4d410bf03eaae8b67afca3a7a9604f0ca76c1fe0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                               |
| ----------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`4d410bf0`](https://github.com/chaotic-cx/nyx/commit/4d410bf03eaae8b67afca3a7a9604f0ca76c1fe0) | `` openmohaa: upgrade llvmPackages `` |
| [`795ce3db`](https://github.com/chaotic-cx/nyx/commit/795ce3db53085b5e468b415a1a0cba19fad32c6f) | `` failures: update aarch64-darwin `` |
| [`3734d2f6`](https://github.com/chaotic-cx/nyx/commit/3734d2f61ebc63bfb7e2d749ae790ac1c5b6a376) | `` failures: update aarch64-linux ``  |