### PR TITLE
chore(flake/nix-gaming): `cd931e08` -> `5a7470df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -232,11 +232,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758420014,
-        "narHash": "sha256-a7IGWXPRppgXMRpBosBl2Afr5DICt21ogeZL45uVkX0=",
+        "lastModified": 1758639862,
+        "narHash": "sha256-J94/9KzKhdA9FQ3P4L/4sfultk3KTf11pj0Hky4kTuM=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "cd931e08409954b2e3595b1532039f8052dd8198",
+        "rev": "5a7470df1be5540aed468d88d43cc4f718660f37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message             |
| --------------------------------------------------------------------------------------------------- | ------------------- |
| [`5a7470df`](https://github.com/fufexan/nix-gaming/commit/5a7470df1be5540aed468d88d43cc4f718660f37) | `` npins: update `` |