### PR TITLE
chore(flake/nur): `2f55e54f` -> `5485cb56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758627334,
-        "narHash": "sha256-PV8pa2UWNdQfJjtAUyLEjfNUZknDFayMvzo6lFbq6sk=",
+        "lastModified": 1758648600,
+        "narHash": "sha256-2+9rHquPi4uU4XsBW5AaLiQydhXASoXmdGSaMwzUWs0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f55e54fe689ab1edfb24b21a1d40b0bba4ef222",
+        "rev": "5485cb562f16cc5c92ec0046620c7eaf5fe31f8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5485cb56`](https://github.com/nix-community/NUR/commit/5485cb562f16cc5c92ec0046620c7eaf5fe31f8d) | `` automatic update `` |
| [`77687c76`](https://github.com/nix-community/NUR/commit/77687c76ab8cf1a899cb4770813b14904fcfade1) | `` automatic update `` |
| [`af2e804a`](https://github.com/nix-community/NUR/commit/af2e804a55892665adfd0b30c75088b1ad1b462c) | `` automatic update `` |
| [`0ac3e575`](https://github.com/nix-community/NUR/commit/0ac3e575bed9f0869ceafd5bb3c57a5856b279a0) | `` automatic update `` |