### PR TITLE
chore(flake/chaotic): `4d410bf0` -> `0fe60fa1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1758636125,
-        "narHash": "sha256-z7zVmiyXE39Vfk8uJtoy/CO2FYNK68GEQAj3Hhpd9mo=",
+        "lastModified": 1758642505,
+        "narHash": "sha256-056XfEHlYdBKU2RtN4R+9m2nzL588TCZ8AsIviWONRg=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "4d410bf03eaae8b67afca3a7a9604f0ca76c1fe0",
+        "rev": "0fe60fa161631289a051fef36dfaab28465ddc7b",
         "type": "github"
       },
       "original": {
@@ -382,11 +382,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1758479131,
-        "narHash": "sha256-KTCOYqnEUYSdk+DychTkXkOqgxYO2mLp9AzAw5mwAxA=",
+        "lastModified": 1758633633,
+        "narHash": "sha256-20FVSEcXWV0P1A/1EDMUH7UVFvktg/ltBNqHJmoQTO8=",
         "owner": "PedroHLC",
         "repo": "nixpkgs",
-        "rev": "94700b18eb20d3ec71e3f6cd32e30d03648664ba",
+        "rev": "36740bcdb7ea5625132575da3c627032b812c236",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                      |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`0fe60fa1`](https://github.com/chaotic-cx/nyx/commit/0fe60fa161631289a051fef36dfaab28465ddc7b) | `` failures: update x86_64-linux ``                          |
| [`a0031939`](https://github.com/chaotic-cx/nyx/commit/a00319397c09ddd176c099ebe49f54f331e2ffd4) | `` nixpkgs: bump to 20250923 + cherry-picked llvm patches `` |