### PR TITLE
chore(flake/nixpkgs): `b2a3852b` -> `d1d88312`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1758346548,
-        "narHash": "sha256-afXE7AJ7MY6wY1pg/Y6UPHNYPy5GtUKeBkrZZ/gC71E=",
+        "lastModified": 1758589230,
+        "narHash": "sha256-zMTCFGe8aVGTEr2RqUi/QzC1nOIQ0N1HRsbqB4f646k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b2a3852bd078e68dd2b3dfa8c00c67af1f0a7d20",
+        "rev": "d1d883129b193f0b495d75c148c2c3a7d95789a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`8f5c36cd`](https://github.com/NixOS/nixpkgs/commit/8f5c36cd0bcbac2d1e0f12987e2b5750081889e3) | `` batman-adv: 2025.2 -> 2025.3 ``                                                  |
| [`d900ea62`](https://github.com/NixOS/nixpkgs/commit/d900ea62153aafbbe010fa7fa87a1a22369e8c84) | `` jenkins: 2.516.2 -> 2.516.3 ``                                                   |
| [`87d0f767`](https://github.com/NixOS/nixpkgs/commit/87d0f767cf6401ea8d2c73482ff61d63817f0372) | `` ci/pinned: update ``                                                             |
| [`ccaaee1f`](https://github.com/NixOS/nixpkgs/commit/ccaaee1f0d91bde9a6252bef15668bd6cab5fa5d) | `` build(deps): bump cachix/install-nix-action from 31.6.1 to 31.6.2 ``             |
| [`ae4c948f`](https://github.com/NixOS/nixpkgs/commit/ae4c948f590268475feb2455ae2660170e6db8cd) | `` gancioPlugins.telegram-bridge: 1.0.5 -> 1.0.6 ``                                 |
| [`033cc13a`](https://github.com/NixOS/nixpkgs/commit/033cc13ab4c1a60b3527b242755aa625001ff1f9) | `` coqPackages.jasmin: 2025.02.0 → 2025.06.1 ``                                     |
| [`aa6cfa59`](https://github.com/NixOS/nixpkgs/commit/aa6cfa5966acf7338df3a8cadc0378d7cbbf4de0) | `` rio: update meta.homepage ``                                                     |
| [`43927170`](https://github.com/NixOS/nixpkgs/commit/43927170c5cd1853d4ef7dd26f9d3b58e84a662d) | `` tutanota-desktop: 304.250901.0 -> 309.250918.1 ``                                |
| [`2cd798e3`](https://github.com/NixOS/nixpkgs/commit/2cd798e327820d4047e46e17a60b5de94bc2d22f) | `` qt6.qtwebengine: revert commit that breaks graphics acceleration on Mesa 25.2 `` |
| [`8865c7ae`](https://github.com/NixOS/nixpkgs/commit/8865c7aec41ccf63c6202236eaf9eb1cbfe18653) | `` alt-tab-macos: 7.28.0 -> 7.29.0 ``                                               |
| [`5e212448`](https://github.com/NixOS/nixpkgs/commit/5e212448548152dfeeded09258fd192f124c6ede) | `` dbus-broker: fix test-sockopt on kernel 6.16+ ``                                 |
| [`06294310`](https://github.com/NixOS/nixpkgs/commit/0629431073bfa0c36c78e7a2f21f7d6d77156c37) | `` teleport: Re-add possibility for overrides ``                                    |
| [`5ac4de37`](https://github.com/NixOS/nixpkgs/commit/5ac4de37fba7014776c185fb2db769ac69949a96) | `` uradvd: 0-unstable-2025-08-16 -> r26-1e64364d ``                                 |
| [`5d54b1aa`](https://github.com/NixOS/nixpkgs/commit/5d54b1aa7abaf9f6410a6ae56b6e5250f6f51a80) | `` nvme-rs: 0.1.1 -> 0.2.0 ``                                                       |
| [`95fa5600`](https://github.com/NixOS/nixpkgs/commit/95fa5600c634aafdcbd7992947411c7953796d16) | `` phpPackages.composer: 2.8.11 -> 2.8.12 ``                                        |
| [`95368a2c`](https://github.com/NixOS/nixpkgs/commit/95368a2cfd335bc721b064cd765e7440dbed9b09) | `` haskellPackages.opencv: fix eval with allowBroken ``                             |
| [`278035e7`](https://github.com/NixOS/nixpkgs/commit/278035e75fcc624c289ab292858c01d4b760352e) | `` Revert "qtcreator: add missing gtk3 gsettings-schemas" ``                        |
| [`e8e99343`](https://github.com/NixOS/nixpkgs/commit/e8e9934363cd72243803a7de7da9fee37fabab9d) | `` sqlite3-to-mysql: 2.4.2 -> 2.4.5 ``                                              |
| [`da8a006e`](https://github.com/NixOS/nixpkgs/commit/da8a006ef74c5af525c1c7f596656694abe123e9) | `` sqlite3-to-mysql: 2.4.1 -> 2.4.2 ``                                              |
| [`a966098d`](https://github.com/NixOS/nixpkgs/commit/a966098de7cb151560bf9177282514621027bc9d) | `` sqlite3-to-mysql: 2.4.0 -> 2.4.1 ``                                              |
| [`004cb3d9`](https://github.com/NixOS/nixpkgs/commit/004cb3d9fae4a377d00c8b40b29a9c155b2232ed) | `` thunderbird-latest-bin-unwrapped: 142.0 -> 143.0 ``                              |
| [`e0470c53`](https://github.com/NixOS/nixpkgs/commit/e0470c53ebd387cc61bbb817707681de234e1ac7) | `` privoxy: Allow multiple listen-address options ``                                |
| [`e8a934e8`](https://github.com/NixOS/nixpkgs/commit/e8a934e8592a7c5231fa75cbf4fd6eadfa5d9f3e) | `` discord: 0.0.108 -> 0.0.110 ``                                                   |
| [`80ecb201`](https://github.com/NixOS/nixpkgs/commit/80ecb2014c0d48f040e21c23477e38fa030c6166) | `` rcu: Disable auto-added updateScript from python ecosystem ``                    |
| [`4e88d6cf`](https://github.com/NixOS/nixpkgs/commit/4e88d6cff12af8ae2f1a86774d82664820f346ca) | `` rcu: 4.0.27 -> 4.0.29 ``                                                         |
| [`fed292f6`](https://github.com/NixOS/nixpkgs/commit/fed292f67274e9ca62c494cb87d42bd8ec584fcd) | `` rcu: 4.0.26 -> 4.0.27 ``                                                         |
| [`3eb93bf6`](https://github.com/NixOS/nixpkgs/commit/3eb93bf6bc6f537a5d45acce7247481406c893e0) | `` openasar: 0-unstable-2025-07-15 -> 0-unstable-2025-09-17 ``                      |
| [`32d5efb3`](https://github.com/NixOS/nixpkgs/commit/32d5efb370227a1722d063464602f924c2fe65be) | `` xh: 0.24.1 -> 0.25.0 ``                                                          |
| [`767ee992`](https://github.com/NixOS/nixpkgs/commit/767ee992d4796dc288168ad86c77efc812fb623a) | `` xh: remove aaronjheng from maintainers ``                                        |
| [`6bf183be`](https://github.com/NixOS/nixpkgs/commit/6bf183be4bb99757d6acd8a3d871c935e6bbfb5e) | `` xh: add defelo as maintainer ``                                                  |
| [`500f6ccf`](https://github.com/NixOS/nixpkgs/commit/500f6ccffea5bd35b4b5f3260edef75f632b8707) | `` xh: add updateScript ``                                                          |
| [`3b88d450`](https://github.com/NixOS/nixpkgs/commit/3b88d4505c5c6cf43438bb8f1a95273e598f7dc0) | `` xh: add versionCheckHook ``                                                      |
| [`5673165a`](https://github.com/NixOS/nixpkgs/commit/5673165a7effe8956ca3754963da543a18ee5f7b) | `` xh: use tag in fetchFromGitHub ``                                                |
| [`6975713a`](https://github.com/NixOS/nixpkgs/commit/6975713a6cf6ffdd1874cac2c2347fbe44f84cd1) | `` xh: use finalAttrs pattern ``                                                    |
| [`9d90893b`](https://github.com/NixOS/nixpkgs/commit/9d90893b944e4754de5f36d467738387af47a163) | `` nodejs_24: 24.7.0 -> 24.8.0 ``                                                   |
| [`07b0aed8`](https://github.com/NixOS/nixpkgs/commit/07b0aed8b715a21e6121a79bbcdb52c273ceab0f) | `` forgejo-lts: 11.0.5 -> 11.0.6 ``                                                 |
| [`825c4a43`](https://github.com/NixOS/nixpkgs/commit/825c4a43e6ac84d05f3780675ac18ac2f12fe05d) | `` forgejo: 12.0.3 -> 12.0.4 ``                                                     |
| [`80d809a9`](https://github.com/NixOS/nixpkgs/commit/80d809a98227091848a22276c3c150c669d7644b) | `` python3Packages.torch-geometric: skip failing tests ``                           |
| [`46cb9057`](https://github.com/NixOS/nixpkgs/commit/46cb90575efebb34689f6c15b17de854bc228cba) | `` linux_xanmod_latest: 6.16.7 -> 6.16.8 ``                                         |
| [`47e63570`](https://github.com/NixOS/nixpkgs/commit/47e6357083b2dad61e1cf978b7d43b530846c07d) | `` linux_xanmod: 6.12.47 -> 6.12.48 ``                                              |
| [`ce5d3bf8`](https://github.com/NixOS/nixpkgs/commit/ce5d3bf8483f2b4b98e443c82cbccb7915db5e8f) | `` linuxPackages_latest.rr-zen_workaround: fix build ``                             |
| [`3f5ed135`](https://github.com/NixOS/nixpkgs/commit/3f5ed135d58b958f9550df6f39a2b15dc0d2f930) | `` nextcloudPackages: update ``                                                     |
| [`71b32d98`](https://github.com/NixOS/nixpkgs/commit/71b32d98bd5b7cf3eb44066ce8ef34ae6ce14ceb) | `` nextcloud31: 31.0.8 -> 31.0.9 ``                                                 |
| [`3b1bdccc`](https://github.com/NixOS/nixpkgs/commit/3b1bdccccc3b1c4c0c0623e0e206d97a9fe8fcba) | `` nextcloud30: 30.0.14 -> 30.0.15 ``                                               |
| [`3c8fb38b`](https://github.com/NixOS/nixpkgs/commit/3c8fb38bdad36b01854683aa642a2b18e27e3a0c) | `` paretosecurity: 0.3.4 -> 0.3.6 ``                                                |
| [`93b00f74`](https://github.com/NixOS/nixpkgs/commit/93b00f74ca867114dc0507dd1ded6cda4258cdca) | `` microsoft-edge: 140.0.3485.66 -> 140.0.3485.81 ``                                |
| [`29c2f8de`](https://github.com/NixOS/nixpkgs/commit/29c2f8decfad12284dc5bd90bd58b8c38233f0b3) | `` gancio: 1.26.1 -> 1.28.0 ``                                                      |
| [`63156aa9`](https://github.com/NixOS/nixpkgs/commit/63156aa92eb80d013bc1d0698e42b77d096248ea) | `` lmstudio: 0.3.25.2 -> 0.3.26.6 ``                                                |
| [`9a4677d3`](https://github.com/NixOS/nixpkgs/commit/9a4677d3d879aa2bb2ce0cdb4798fe66d340621c) | `` joplin-desktop: use electron_36 ``                                               |
| [`f2263fb5`](https://github.com/NixOS/nixpkgs/commit/f2263fb5bc57cc6495253c9207d0c67e8921e1a5) | `` joplin-desktop: build from source ``                                             |
| [`7bf63a08`](https://github.com/NixOS/nixpkgs/commit/7bf63a08a019a222e25d41f4b837a79070f8187b) | `` ddev: 1.24.7 -> 1.24.8 ``                                                        |
| [`77264645`](https://github.com/NixOS/nixpkgs/commit/772646454c8ee8c39c0997d268bc3addd24252af) | `` mattermost-desktop: 5.12.1 -> 5.13.1 ``                                          |
| [`b06ae040`](https://github.com/NixOS/nixpkgs/commit/b06ae04065cb0f8f8e6cadd7d515e7e68cbf3abc) | `` slack: 4.45.69 -> 4.46.96 ``                                                     |
| [`a2eef0dc`](https://github.com/NixOS/nixpkgs/commit/a2eef0dc33e7b4b5966e0b665c250a4b06a3c7dd) | `` mautrix-signal: 0.8.6 -> 0.8.7 ``                                                |
| [`9ed445c0`](https://github.com/NixOS/nixpkgs/commit/9ed445c049aa53d6dc7bb27fe61e38ec2fe85427) | `` libsignal-ffi: 0.78.2 -> 0.80.3 ``                                               |
| [`5cd1b99d`](https://github.com/NixOS/nixpkgs/commit/5cd1b99d1f488a4097be5c785a8977a55a6c5717) | `` python3Packages.ubelt: 1.3.6 -> 1.3.7 ``                                         |
| [`f56aa940`](https://github.com/NixOS/nixpkgs/commit/f56aa94065addc1961bb795c8114d766c1a88c2f) | `` authelia: 4.39.4 -> 4.39.8 ``                                                    |
| [`8e367abf`](https://github.com/NixOS/nixpkgs/commit/8e367abf6708b1c8f8b7e616a98dc4853d36026d) | `` postgresql_jdbc: add junixsocket-common and junixsocket-native-common ``         |
| [`c86b92cc`](https://github.com/NixOS/nixpkgs/commit/c86b92ccfbe1931426f7e4cb12b7427af9e19590) | `` hydra: 0-unstable-2025-08-12 -> 0-unstable-2025-09-13 ``                         |
| [`a96558d1`](https://github.com/NixOS/nixpkgs/commit/a96558d1ec17755154f0f8a8bb3f015ce4690ed3) | `` assetripper: init at 1.3.0 ``                                                    |
| [`7a6f3f3e`](https://github.com/NixOS/nixpkgs/commit/7a6f3f3ea7b19893f761a84c495b9a2f9c7dd6e7) | `` cherrytree: 1.4.0 -> 1.5.0 ``                                                    |
| [`5c67cf23`](https://github.com/NixOS/nixpkgs/commit/5c67cf230096915f4c5463f904a80d62bcb8d7be) | `` github-runner: add support for node24 ``                                         |
| [`6772785d`](https://github.com/NixOS/nixpkgs/commit/6772785d7e946e88ec7f1dd1474f4d445f7b4019) | `` signal-desktop: hardcode electron version in dictionaries URL ``                 |
| [`43386fce`](https://github.com/NixOS/nixpkgs/commit/43386fced797fd8696802e90d6a6b4492e229733) | `` mattermostLatest: 10.11.2 -> 10.12.0 ``                                          |
| [`3f02de00`](https://github.com/NixOS/nixpkgs/commit/3f02de00bbd666f12bd0916fd0dd8ffd54a467bc) | `` tomcat: 11.0.10 -> 11.0.11 ``                                                    |
| [`678ff5cf`](https://github.com/NixOS/nixpkgs/commit/678ff5cf1ce281b1c34c8670ced9a8b9888dfa58) | `` lib.attrsets.genAttrs': init (#436434) ``                                        |
| [`27984c06`](https://github.com/NixOS/nixpkgs/commit/27984c06d4471ff4b3586acd1d17cb11d6f3ca40) | `` garnet: 1.0.82 -> 1.0.83 ``                                                      |
| [`e5fb06d3`](https://github.com/NixOS/nixpkgs/commit/e5fb06d3fa870d3d5f2a1c07b8ebfe3c6c56b9e6) | `` lock: 1.7.3 -> 1.7.5 ``                                                          |
| [`038fe208`](https://github.com/NixOS/nixpkgs/commit/038fe208fc0bdb4ab10b144111da1cb88e1ce6f8) | `` limine: `nyu-efi` -> `PicoEFI` ``                                                |
| [`19317651`](https://github.com/NixOS/nixpkgs/commit/19317651b615d0e16c19ce74ca4f08bd8dbf9138) | `` limine: 9.6.1 -> 9.6.5 ``                                                        |
| [`e1be8d8d`](https://github.com/NixOS/nixpkgs/commit/e1be8d8dd1a64798eeba061c0fadf19c19c15630) | `` nixos/grafana: add `prune` option to provision.datasources ``                    |
| [`c35264d4`](https://github.com/NixOS/nixpkgs/commit/c35264d4d18a5ef0b6424406bbb069e9723cf45c) | `` junixsocket-native-common: init at 2.10.1 ``                                     |
| [`dcda8b86`](https://github.com/NixOS/nixpkgs/commit/dcda8b86002020e55692d5708398d2caf294ac96) | `` junixsocket-common: init at 2.10.1 ``                                            |
| [`59b5863c`](https://github.com/NixOS/nixpkgs/commit/59b5863c88eda046baa3e134b8840f30e4c19671) | `` rustdesk-flutter: fix cuda problem ``                                            |
| [`ce0ae555`](https://github.com/NixOS/nixpkgs/commit/ce0ae5556980325e6f8c164fb1519aa0cadc734b) | `` xcaddy: 0.4.4 -> 0.4.5 ``                                                        |
| [`7255ed8f`](https://github.com/NixOS/nixpkgs/commit/7255ed8f2c17bf8feb03a7f4d9bb87e3f89dabb0) | `` nixos/sssd: add upstream hardening options in sssd-kcm.service ``                |
| [`dcd993f7`](https://github.com/NixOS/nixpkgs/commit/dcd993f7af60f4be3282a287aa6c3b0d26e1c931) | `` nixos/sssd: add upstream directives in sssd.service ``                           |