### PR TITLE
chore(flake/nur): `5485cb56` -> `2521014d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758648600,
-        "narHash": "sha256-2+9rHquPi4uU4XsBW5AaLiQydhXASoXmdGSaMwzUWs0=",
+        "lastModified": 1758660880,
+        "narHash": "sha256-y8s6KMDyrK1cNYm4LHmt/gUsLpUThm7mW0AxnCC+vco=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5485cb562f16cc5c92ec0046620c7eaf5fe31f8d",
+        "rev": "2521014dd72310cce13854d9db828ae5c3cee005",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2521014d`](https://github.com/nix-community/NUR/commit/2521014dd72310cce13854d9db828ae5c3cee005) | `` automatic update `` |
| [`699442e5`](https://github.com/nix-community/NUR/commit/699442e5319ab19512881e0397ea9ee555f8d822) | `` automatic update `` |
| [`5083a7b3`](https://github.com/nix-community/NUR/commit/5083a7b30f45e8a0a36df21162ea4511af1fa064) | `` automatic update `` |
| [`a2b7c1f3`](https://github.com/nix-community/NUR/commit/a2b7c1f3f0796c5a63a57f21eb22e98bddded6f4) | `` automatic update `` |
| [`aa14f4f0`](https://github.com/nix-community/NUR/commit/aa14f4f00f9df07df0bedb02c2ba55e3b46c2b05) | `` automatic update `` |
| [`57d051cc`](https://github.com/nix-community/NUR/commit/57d051cc0417b267ce191f0f3c52004531624a25) | `` automatic update `` |