### PR TITLE
chore(flake/nixos-hardware): `67a709cf` -> `170ff93c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -289,11 +289,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1757943327,
-        "narHash": "sha256-w6cDExPBqbq7fTLo4dZ1ozDGeq3yV6dSN4n/sAaS6OM=",
+        "lastModified": 1758663926,
+        "narHash": "sha256-6CFdj7Xs616t1W4jLDH7IohAAvl5Dyib3qEv/Uqw1rk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "67a709cfe5d0643dafd798b0b613ed579de8be05",
+        "rev": "170ff93c860b2a9868ed1e1102d4e52cb3d934e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`3caaf86f`](https://github.com/NixOS/nixos-hardware/commit/3caaf86f9d7558cce864cfc929a2de619ecc0de2) | `` feat: kernel params for x1 carbon `` |