### PR TITLE
chore(flake/nur): `2521014d` -> `7be5bbcb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758660880,
-        "narHash": "sha256-y8s6KMDyrK1cNYm4LHmt/gUsLpUThm7mW0AxnCC+vco=",
+        "lastModified": 1758676009,
+        "narHash": "sha256-6/f2OgmxJeY2M0UMEyCBGVkmCciNqlOdiGXBcoMkr1M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2521014dd72310cce13854d9db828ae5c3cee005",
+        "rev": "7be5bbcbd9611b67c5c9bfb6167e4e6dcda1a3bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7be5bbcb`](https://github.com/nix-community/NUR/commit/7be5bbcbd9611b67c5c9bfb6167e4e6dcda1a3bb) | `` automatic update `` |
| [`335d0a7e`](https://github.com/nix-community/NUR/commit/335d0a7e0af02b7d1a9f8a8cf78e6f677c7367ea) | `` automatic update `` |
| [`8a943d6b`](https://github.com/nix-community/NUR/commit/8a943d6bdc50caf26b5522ee746dadb00be929e4) | `` automatic update `` |
| [`c29d18f2`](https://github.com/nix-community/NUR/commit/c29d18f2060236fe71cdc1dbe27d69757c2e542e) | `` automatic update `` |