### PR TITLE
chore(flake/nur): `7be5bbcb` -> `4ef66e4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758676009,
-        "narHash": "sha256-6/f2OgmxJeY2M0UMEyCBGVkmCciNqlOdiGXBcoMkr1M=",
+        "lastModified": 1758684141,
+        "narHash": "sha256-TxjmX7PluwNTCl+J9iXEsZgFT/zMWeL5yItn/5LMkic=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7be5bbcbd9611b67c5c9bfb6167e4e6dcda1a3bb",
+        "rev": "4ef66e4c6c00ee485b2926dd371114daa0110411",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4ef66e4c`](https://github.com/nix-community/NUR/commit/4ef66e4c6c00ee485b2926dd371114daa0110411) | `` automatic update `` |
| [`ee27bca8`](https://github.com/nix-community/NUR/commit/ee27bca8db59ebccce8c1407c88e089929105eb1) | `` automatic update `` |