### PR TITLE
chore(flake/nur): `7f3ecc7e` -> `4f55c0e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758712580,
-        "narHash": "sha256-0xmCEK2sIjE5ZcmMuJjbvl/Xo5AtB/OqE2oWjQzRefg=",
+        "lastModified": 1758726968,
+        "narHash": "sha256-UaahYRurw+KA9nXTUkfaJNQAOAWuVw5vixTTzZ0IoBs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f3ecc7eeb5cdfc43c27126200220fc928883e68",
+        "rev": "4f55c0e4f8b2e852a29893b69d552c07dc8acef5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f55c0e4`](https://github.com/nix-community/NUR/commit/4f55c0e4f8b2e852a29893b69d552c07dc8acef5) | `` automatic update `` |
| [`2ddd31bb`](https://github.com/nix-community/NUR/commit/2ddd31bb11d8c875cfee45d3478515b2abebbceb) | `` automatic update `` |
| [`1f262506`](https://github.com/nix-community/NUR/commit/1f26250627602189ff31c2cbef9b46978dad03c3) | `` automatic update `` |
| [`ef71f2e2`](https://github.com/nix-community/NUR/commit/ef71f2e23a3fc5cd991ac1e64ff17b1b21458e2b) | `` automatic update `` |