### PR TITLE
chore(flake/nur): `9fcd1de4` -> `3095c278`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758738022,
-        "narHash": "sha256-sQO5TXMpunOLII7uuoXYX4tX4XtbJ7NyaFvt8ze4HrA=",
+        "lastModified": 1758746563,
+        "narHash": "sha256-jNjkATDWEeVrEXg4Ibez2mfw4/eKnc281fhGLbA+Nlw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9fcd1de4a3f2417cc25ca7b9dea2126d2fb2fcf1",
+        "rev": "3095c27826ffd3f5bcbac4e844306ee4e1b669a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3095c278`](https://github.com/nix-community/NUR/commit/3095c27826ffd3f5bcbac4e844306ee4e1b669a8) | `` automatic update `` |
| [`c01ba019`](https://github.com/nix-community/NUR/commit/c01ba019a5b1eb1ec503b692e6ecacefac706046) | `` automatic update `` |
| [`c932ddf9`](https://github.com/nix-community/NUR/commit/c932ddf9d1c5e83091bcec59b634c9094df1cf25) | `` automatic update `` |
| [`07b33d40`](https://github.com/nix-community/NUR/commit/07b33d4096eb8d3c4e1bd74334f159191e998afb) | `` automatic update `` |