### PR TITLE
chore(flake/nur): `3095c278` -> `81ee326e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758746563,
-        "narHash": "sha256-jNjkATDWEeVrEXg4Ibez2mfw4/eKnc281fhGLbA+Nlw=",
+        "lastModified": 1758764729,
+        "narHash": "sha256-6ZrY1O+zFSAtBExtImsLdHw8Bwsgdlh8bMY1db9Z/cg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3095c27826ffd3f5bcbac4e844306ee4e1b669a8",
+        "rev": "81ee326e272d7527cdb645f8c9b37274f1f991ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`81ee326e`](https://github.com/nix-community/NUR/commit/81ee326e272d7527cdb645f8c9b37274f1f991ff) | `` automatic update `` |
| [`0a27e260`](https://github.com/nix-community/NUR/commit/0a27e260511d37c2e318ac26048f4ffaa8182ee6) | `` automatic update `` |
| [`86cfcc70`](https://github.com/nix-community/NUR/commit/86cfcc7004c4d2bc719b4095289c90450b4b41f3) | `` automatic update `` |
| [`8ffafb7f`](https://github.com/nix-community/NUR/commit/8ffafb7f1b1ece05cb710910cf19f7e7aaf04bf2) | `` automatic update `` |
| [`e6c0f693`](https://github.com/nix-community/NUR/commit/e6c0f69365ce8fd05b5d02f8e12d0d3c6dde650a) | `` automatic update `` |