### PR TITLE
chore(flake/nur): `2147792a` -> `c354d2f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758770724,
-        "narHash": "sha256-ayj0RkDQ57roFRtqOuDaUk6493Yd2x2xJrfOz44s4jk=",
+        "lastModified": 1758781050,
+        "narHash": "sha256-kbJ7l+DIWQBy3etRGGav1WqRP6pZbkfeBl3Td01mYzA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2147792a5e7b210162abdc6b318441737cd73da5",
+        "rev": "c354d2f7c8324121280d557cfc45235954551140",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c354d2f7`](https://github.com/nix-community/NUR/commit/c354d2f7c8324121280d557cfc45235954551140) | `` automatic update `` |
| [`fae9ad6c`](https://github.com/nix-community/NUR/commit/fae9ad6c3c8dcf9ca64c82adddccded57910944d) | `` automatic update `` |
| [`4f82d6e5`](https://github.com/nix-community/NUR/commit/4f82d6e59af927a495715310e902282658273656) | `` automatic update `` |
| [`7599970b`](https://github.com/nix-community/NUR/commit/7599970b18216ca277e9f313cfc0db44326107f0) | `` automatic update `` |
| [`fab32cbd`](https://github.com/nix-community/NUR/commit/fab32cbd7ac9af7ef6985ec78b29d13e5c6a351e) | `` automatic update `` |