### PR TITLE
chore(flake/nur): `c354d2f7` -> `a7051d59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758781050,
-        "narHash": "sha256-kbJ7l+DIWQBy3etRGGav1WqRP6pZbkfeBl3Td01mYzA=",
+        "lastModified": 1758792031,
+        "narHash": "sha256-DqPdNbJdm1lCy/hMxSXMCcXlOv2BoRZaqjtl8me1uOk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c354d2f7c8324121280d557cfc45235954551140",
+        "rev": "a7051d5988ccfc58ed0c88b2aa1ffd22cb1e9a2b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a7051d59`](https://github.com/nix-community/NUR/commit/a7051d5988ccfc58ed0c88b2aa1ffd22cb1e9a2b) | `` automatic update `` |
| [`037ace13`](https://github.com/nix-community/NUR/commit/037ace1389861cc9e3406e6bc9f2b67851aaee46) | `` automatic update `` |
| [`0a555a3a`](https://github.com/nix-community/NUR/commit/0a555a3a5592846a9ce82612e482ac3b90fa5463) | `` automatic update `` |
| [`509bd13e`](https://github.com/nix-community/NUR/commit/509bd13e01ca66bf58c0af2c59e34393e4957d00) | `` automatic update `` |
| [`3740df1d`](https://github.com/nix-community/NUR/commit/3740df1d0cd28fed47c5664f106d677431d21450) | `` automatic update `` |
| [`337e0ead`](https://github.com/nix-community/NUR/commit/337e0ead8fcd0cc94e59632165451e93b0a0ca63) | `` automatic update `` |