### PR TITLE
chore(flake/nur): `a7051d59` -> `c45eead6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758792031,
-        "narHash": "sha256-DqPdNbJdm1lCy/hMxSXMCcXlOv2BoRZaqjtl8me1uOk=",
+        "lastModified": 1758800670,
+        "narHash": "sha256-IBZPdRLJ3n7topmFhhVwP2suqbw7gG52Opdk9UvtxYs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a7051d5988ccfc58ed0c88b2aa1ffd22cb1e9a2b",
+        "rev": "c45eead6fec45c3c1b46b2bdf8f03f224ffba22b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c45eead6`](https://github.com/nix-community/NUR/commit/c45eead6fec45c3c1b46b2bdf8f03f224ffba22b) | `` automatic update `` |
| [`e44f6cf8`](https://github.com/nix-community/NUR/commit/e44f6cf81905ba8c4af42f036eae9acad742ea26) | `` automatic update `` |
| [`2bf3626c`](https://github.com/nix-community/NUR/commit/2bf3626c2e2239fe32e8add155d75464ad1feb06) | `` automatic update `` |