### PR TITLE
chore(flake/nur): `c45eead6` -> `c96d18a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758800670,
-        "narHash": "sha256-IBZPdRLJ3n7topmFhhVwP2suqbw7gG52Opdk9UvtxYs=",
+        "lastModified": 1758813450,
+        "narHash": "sha256-fxT8yeEUwWzO0bgQv4N6GCWL0BxTtBAYR2UJ67IHc+w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c45eead6fec45c3c1b46b2bdf8f03f224ffba22b",
+        "rev": "c96d18a720b20ef3dd6a9a78061aeb251a857df6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c96d18a7`](https://github.com/nix-community/NUR/commit/c96d18a720b20ef3dd6a9a78061aeb251a857df6) | `` automatic update `` |
| [`5de03c8b`](https://github.com/nix-community/NUR/commit/5de03c8b3c26de4a6fca64c78e6c657add3a3f67) | `` automatic update `` |