### PR TITLE
chore(flake/nur): `c96d18a7` -> `e92f6d43`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1758427187,
-        "narHash": "sha256-pHpxZ/IyCwoTQPtFIAG2QaxuSm8jWzrzBGjwQZIttJc=",
+        "lastModified": 1758690382,
+        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
+        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758813450,
-        "narHash": "sha256-fxT8yeEUwWzO0bgQv4N6GCWL0BxTtBAYR2UJ67IHc+w=",
+        "lastModified": 1758855536,
+        "narHash": "sha256-Oz8Rn2fPCootChXYuhBqVx2nAQcU7AoTFpDGIfFwhgY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c96d18a720b20ef3dd6a9a78061aeb251a857df6",
+        "rev": "e92f6d43b4a0fb79f4f99b228067ce216fb6e1f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e92f6d43`](https://github.com/nix-community/NUR/commit/e92f6d43b4a0fb79f4f99b228067ce216fb6e1f4) | `` automatic update `` |
| [`22c0f479`](https://github.com/nix-community/NUR/commit/22c0f47962ec31c5b81c12659d187867dffcac20) | `` automatic update `` |
| [`d39e95e9`](https://github.com/nix-community/NUR/commit/d39e95e918ee44504f897b52cddf6b2bc70acc36) | `` automatic update `` |
| [`b4e5c5a7`](https://github.com/nix-community/NUR/commit/b4e5c5a72db023737e0ff3f989707968c29c0f07) | `` automatic update `` |
| [`d3f92062`](https://github.com/nix-community/NUR/commit/d3f920624a37f24d323782909b959fe3ef2d9760) | `` automatic update `` |
| [`4640fcc3`](https://github.com/nix-community/NUR/commit/4640fcc3816e020cc941cb15aa68ceeb71305df6) | `` automatic update `` |
| [`6b6972b2`](https://github.com/nix-community/NUR/commit/6b6972b2cb544033d3366b9094dade9514820c84) | `` automatic update `` |
| [`544f12f6`](https://github.com/nix-community/NUR/commit/544f12f6987ceb94fe2052696da65623c238da4c) | `` automatic update `` |
| [`8e3c5973`](https://github.com/nix-community/NUR/commit/8e3c5973cb8e217bb20271ac820feaad646e3dd1) | `` automatic update `` |
| [`60032b2e`](https://github.com/nix-community/NUR/commit/60032b2e37e2b7accd8408273c2ba879d0982c3b) | `` automatic update `` |
| [`652ff2fe`](https://github.com/nix-community/NUR/commit/652ff2fec39136b1c9e4c9b9766b19652f120771) | `` automatic update `` |