### PR TITLE
chore(flake/nur): `2c730f91` -> `d7b7493d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758868070,
-        "narHash": "sha256-bPkJhoP7tSeSlA4w0tSyK/kn4xhfB5dtjTegUncvZOg=",
+        "lastModified": 1758876714,
+        "narHash": "sha256-tYISZjmPasgM0tZGb+k/1x3BdWFQo2sdEJYbHucomdc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c730f9116c87c6c119f5e1ad5b2a1833d501e6a",
+        "rev": "d7b7493da27a94ee567f8adf0765e1f4e4bc5c7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d7b7493d`](https://github.com/nix-community/NUR/commit/d7b7493da27a94ee567f8adf0765e1f4e4bc5c7f) | `` automatic update `` |
| [`5fc54bd3`](https://github.com/nix-community/NUR/commit/5fc54bd3c1e969c41ee0a854a287326e6c75d3ce) | `` automatic update `` |
| [`523a9a9c`](https://github.com/nix-community/NUR/commit/523a9a9cb355bef2127bfbddabe68f1bfb23be8b) | `` automatic update `` |