### PR TITLE
chore(flake/nur): `d7b7493d` -> `04411e57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758876714,
-        "narHash": "sha256-tYISZjmPasgM0tZGb+k/1x3BdWFQo2sdEJYbHucomdc=",
+        "lastModified": 1758905102,
+        "narHash": "sha256-AG0VmMkLMkFDC4SedMVTcPy3I+vXtSa1KoHXOmaT77A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d7b7493da27a94ee567f8adf0765e1f4e4bc5c7f",
+        "rev": "04411e57c6bb84f5c2250d9571d12d4bdd47c249",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`04411e57`](https://github.com/nix-community/NUR/commit/04411e57c6bb84f5c2250d9571d12d4bdd47c249) | `` automatic update `` |
| [`f3bc4731`](https://github.com/nix-community/NUR/commit/f3bc4731799c50b3480a87158d78f43d0dd3f8db) | `` automatic update `` |
| [`a62e72f9`](https://github.com/nix-community/NUR/commit/a62e72f97b5f7a7276ff146d59e7b84b7242fc66) | `` automatic update `` |
| [`12964b0f`](https://github.com/nix-community/NUR/commit/12964b0fe448b71b3ad278759217c0abb9927251) | `` automatic update `` |
| [`87e06653`](https://github.com/nix-community/NUR/commit/87e06653f81ed737eeb9eb713e5551e1f9e753aa) | `` automatic update `` |
| [`ec78809f`](https://github.com/nix-community/NUR/commit/ec78809f588cf703d2e971dcd3d66edccc090a72) | `` automatic update `` |
| [`28679cee`](https://github.com/nix-community/NUR/commit/28679cee2a47f637e8dab7757c3e6ee35005a102) | `` automatic update `` |