### PR TITLE
chore(flake/nixpkgs): `d1d88312` -> `25e53aa1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1758589230,
-        "narHash": "sha256-zMTCFGe8aVGTEr2RqUi/QzC1nOIQ0N1HRsbqB4f646k=",
+        "lastModified": 1758791193,
+        "narHash": "sha256-F8WmEwFoHsnix7rt290R0rFXNJiMbClMZyIC/e+HYf0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d1d883129b193f0b495d75c148c2c3a7d95789a0",
+        "rev": "25e53aa156d47bad5082ff7618f5feb1f5e02d01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`216ebe5d`](https://github.com/NixOS/nixpkgs/commit/216ebe5d68c18c63c7a1477962eb8ed756cb16cf) | `` discord-ptb: 0.0.160 -> 0.0.161 ``                                            |
| [`5a8ef41b`](https://github.com/NixOS/nixpkgs/commit/5a8ef41be4ff81a6bce4bcdcc4c6f56d4f36d813) | `` discord-canary: 0.0.752 -> 0.0.756 ``                                         |
| [`b33fee1b`](https://github.com/NixOS/nixpkgs/commit/b33fee1b6e3fb314e656453bb359a1bcd4d5327b) | `` alt-tab-macos: 7.29.0 -> 7.30.0 ``                                            |
| [`d6204904`](https://github.com/NixOS/nixpkgs/commit/d6204904d3950d092b2848ed11428ebb3f6c4c2a) | `` gitlab: 18.3.2 -> 18.4.0 ``                                                   |
| [`b5d84e5b`](https://github.com/NixOS/nixpkgs/commit/b5d84e5b26d74be4bd806161af0878251342c65a) | `` nixos/mosquitto: add `retain_expiry_interval` freeform key ``                 |
| [`8efaa049`](https://github.com/NixOS/nixpkgs/commit/8efaa049256a3c974db3014332dfb19b9410a7ec) | `` firefox-bin-unwrapped: 143.0 -> 143.0.1 ``                                    |
| [`5989c863`](https://github.com/NixOS/nixpkgs/commit/5989c86395decbc31ca769e8d9f17c16779d9c0d) | `` firefox-unwrapped: 143.0 -> 143.0.1 ``                                        |
| [`597dcf6a`](https://github.com/NixOS/nixpkgs/commit/597dcf6ac3a32457c5a340dc59aa4993f94aa584) | `` firefox-esr-140-unwrapped: 140.3.0esr -> 140.3.1esr ``                        |
| [`37ba286f`](https://github.com/NixOS/nixpkgs/commit/37ba286f5bc6aa8a6c7bcb2b7bf996914d0c98c2) | `` yt-dlp: 2025.09.05 -> 2025.09.23 ``                                           |
| [`3d9b5367`](https://github.com/NixOS/nixpkgs/commit/3d9b5367d318c0e354bb9453dfed05d314ba6ad6) | `` zammad: 6.5.1 -> 6.5.2 ``                                                     |
| [`b3bf1396`](https://github.com/NixOS/nixpkgs/commit/b3bf1396321344614bf23c338f466b234aa29996) | `` difftastic: 0.64.0 -> 0.65.0 ``                                               |
| [`a9986c7d`](https://github.com/NixOS/nixpkgs/commit/a9986c7d0ad7d6a8773ba6a16837b7180417f7e5) | `` limine: 9.6.6 -> 9.6.7 ``                                                     |
| [`fb642259`](https://github.com/NixOS/nixpkgs/commit/fb642259a361bab0fc44bf64db82f2fd95a731a8) | `` nixos/btrfs: use sha256 instead of sha256_generic ``                          |
| [`02afe551`](https://github.com/NixOS/nixpkgs/commit/02afe55111cc5da94919ba218678134b3b5453b9) | `` matrix-authentication-service: 1.2.0 -> 1.3.0 ``                              |
| [`f8072202`](https://github.com/NixOS/nixpkgs/commit/f8072202bdddc7acfde92d0ae3a985ed5fd80d85) | `` matrix-authentication-service: 1.1.0 -> 1.2.0 ``                              |
| [`cb23f16f`](https://github.com/NixOS/nixpkgs/commit/cb23f16fe7eec2832abe69c08cab242137eab805) | `` vivaldi: 7.6.3797.52 -> 7.6.3797.55 ``                                        |
| [`2818f236`](https://github.com/NixOS/nixpkgs/commit/2818f2360d802f6d1f2065bcb8fe35385693791d) | `` chromium,chromedriver: 140.0.7339.185 -> 140.0.7339.207 ``                    |
| [`33834f4c`](https://github.com/NixOS/nixpkgs/commit/33834f4c5a21d4d6d0fac4d60290bf7981c17f23) | `` bird2: 2.17.1 -> 2.17.2 ``                                                    |
| [`fb0d1840`](https://github.com/NixOS/nixpkgs/commit/fb0d18407e8332744e4a682763ba34f8da9ae993) | `` espanso: remove self from maintainers list ``                                 |
| [`b99d89d5`](https://github.com/NixOS/nixpkgs/commit/b99d89d572d323b39fba20dc8e879e446c0ddbc7) | `` maintainers: remove bmanuel ``                                                |
| [`4794e1fa`](https://github.com/NixOS/nixpkgs/commit/4794e1fa422e21303fec1e46d0ae5f35f95dcda0) | `` mastodon: 4.3.12 -> 4.3.13 ``                                                 |
| [`eb346391`](https://github.com/NixOS/nixpkgs/commit/eb3463915bc77c92123f70633402ee882d4403e5) | `` vencord: 1.12.13 -> 1.13.0 ``                                                 |
| [`361b25dd`](https://github.com/NixOS/nixpkgs/commit/361b25dd5f1aaf26523bc8f523bda0fa86c3eb40) | `` matrix-authentication-service: 1.0.0 -> 1.1.0 ``                              |
| [`154ce231`](https://github.com/NixOS/nixpkgs/commit/154ce231888266f3f677b76fb5b8a2a7aafc06b2) | `` [Backport release-25.05] bird3: 3.1.2 -> 3.1.4 (#445451) ``                   |
| [`772ed967`](https://github.com/NixOS/nixpkgs/commit/772ed96743a959d4ce152244a2540a0e25f078d3) | `` soundsource: 5.8.5 -> 5.8.7 ``                                                |
| [`34441962`](https://github.com/NixOS/nixpkgs/commit/3444196212282df3c8294e22239581c05b39c417) | `` nheko: apply patch to fix rendering of replies with QT 6.9.2 ``               |
| [`97f3562f`](https://github.com/NixOS/nixpkgs/commit/97f3562f72803e086d6d4ea936522ce2b902be8f) | `` wiki-js: 2.5.307 -> 2.5.308 ``                                                |
| [`9e8d4c9a`](https://github.com/NixOS/nixpkgs/commit/9e8d4c9a0e7c2aeb50542e7969f506d2cc46c4a2) | `` jdk11: 11.0.27+6 -> 11.0.28+6 ``                                              |
| [`5a82e194`](https://github.com/NixOS/nixpkgs/commit/5a82e19479bc1b29550634837eef51b4274c2f20) | `` jdk17: 17.0.15+6 -> 17.0.16+8 ``                                              |
| [`cfd51cb9`](https://github.com/NixOS/nixpkgs/commit/cfd51cb9385cf7684f1026234e82c2b3dc899e32) | `` redmine: 6.0.6 -> 6.0.7 ``                                                    |
| [`a46abce0`](https://github.com/NixOS/nixpkgs/commit/a46abce0f1325bb4db34de735add117a1b0e7b8a) | `` qq: 2025-08-20 -> 2025-09-04 ``                                               |
| [`e67cc7a3`](https://github.com/NixOS/nixpkgs/commit/e67cc7a39bb8b29569acd8dd8eda00d50496a77b) | `` psi-plus: 1.5.2081 -> 1.5.2115 ``                                             |
| [`804d651a`](https://github.com/NixOS/nixpkgs/commit/804d651addb9c134fa60f777af923ac3ca34d612) | `` istat-menus: add maintainer iedame ``                                         |
| [`33bdfb3d`](https://github.com/NixOS/nixpkgs/commit/33bdfb3d93175fce6fdff1bd89080598707b996b) | `` istat-menus: 7.10.2 -> 7.10.4 ``                                              |
| [`c9c94cb0`](https://github.com/NixOS/nixpkgs/commit/c9c94cb0b9c645891c468ad375376a5b9a2a971a) | `` itsycal: add maintainer iedame ``                                             |
| [`919ad8c2`](https://github.com/NixOS/nixpkgs/commit/919ad8c296fe044d306b3fd9761773af30739af2) | `` itsycal: 0.15.5 -> 0.15.6 ``                                                  |
| [`624585e7`](https://github.com/NixOS/nixpkgs/commit/624585e7c1eb83baf39b25d4b2b4b663f35f293a) | `` limine: 9.6.5 -> 9.6.6 ``                                                     |
| [`8e8345e3`](https://github.com/NixOS/nixpkgs/commit/8e8345e39b460e676a829a4d8aa68d6c16dbdf35) | `` llvmPackages_git: 22.0.0-unstable-2025-09-16 -> 22.0.0-unstable-2025-09-21 `` |
| [`2b53fe21`](https://github.com/NixOS/nixpkgs/commit/2b53fe213d4145532bdaf50d14b9423eb838e590) | `` proton-ge-bin: GE-Proton10-15 -> GE-Proton10-16 ``                            |
| [`584317c6`](https://github.com/NixOS/nixpkgs/commit/584317c6c52bb886985ce26b37d7f4983dc9a115) | `` lightway: fix build for release 25.05 ``                                      |
| [`74fd94aa`](https://github.com/NixOS/nixpkgs/commit/74fd94aa11e60fbbdc0141c120abe65de0d58196) | `` lightway: 0-unstable-2025-09-04 -> 0-unstable-2025-09-19 ``                   |
| [`f9dde1e4`](https://github.com/NixOS/nixpkgs/commit/f9dde1e4b3bd3ee6f86ec4d8941794bd146d6fca) | `` mosquitto: 2.0.21 -> 2.0.22 ``                                                |
| [`110a05c3`](https://github.com/NixOS/nixpkgs/commit/110a05c388ea310b88d40d31884129dee87e2c38) | `` alcom: fix meta.mainProgram ``                                                |
| [`929b2c37`](https://github.com/NixOS/nixpkgs/commit/929b2c372227be9b3ac4641509277380aad72036) | `` alcom: 1.0.1 -> 1.1.4 ``                                                      |
| [`5fb2d9a1`](https://github.com/NixOS/nixpkgs/commit/5fb2d9a1bb30bb57b0790fcf9bd55f862361b55d) | `` blackmagic-desktop-video: 14.4.1 -> 15.0 ``                                   |
| [`8dea302d`](https://github.com/NixOS/nixpkgs/commit/8dea302da2db9fe02868d83173cf08bcf5460614) | `` blackmagic-desktop-video: add updateScript ``                                 |
| [`24f5a186`](https://github.com/NixOS/nixpkgs/commit/24f5a18648c9ed728991bcf49b6800f92124e25c) | `` octoprint: 1.11.2 -> 1.11.3 ``                                                |
| [`f188e7c1`](https://github.com/NixOS/nixpkgs/commit/f188e7c160b6885c78a89a9b7372234331e19f90) | `` octoprint: fix header issue with tornado ``                                   |
| [`9e3a0154`](https://github.com/NixOS/nixpkgs/commit/9e3a0154d32b7ba9473d8fedb1ba39df0284ca1f) | `` nixos/immich: add VectorChord migration docs ``                               |
| [`000dc781`](https://github.com/NixOS/nixpkgs/commit/000dc781597605959296f6e477c8d6f0018521c7) | `` nixos/immich: add enableVectors option ``                                     |
| [`952ad309`](https://github.com/NixOS/nixpkgs/commit/952ad309b6ded283f125cbd4a1c40fb0e5ad1d3d) | `` nixos/immich: add enableVectorChord option ``                                 |
| [`62100309`](https://github.com/NixOS/nixpkgs/commit/621003091435ba5bab1d57add57cbf18673c9bbd) | `` nixos/immich: only start after reaching postgresql.service ``                 |