### PR TITLE
chore(flake/nur): `4d606b49` -> `6b219faa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758920398,
-        "narHash": "sha256-JCk6Y5HNA5H9C4OAKB3+A+ycrsUoFOvuW6naxBHTEvk=",
+        "lastModified": 1758924686,
+        "narHash": "sha256-s2XRpgctPSZHe00TfUwyEEmwRF64kn5Ao7OU3Q+zGEg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4d606b49d29710ccf0e323490d070ced5aac983f",
+        "rev": "6b219faa81c094a5cc2e46e865a2fd8b2bff9f99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6b219faa`](https://github.com/nix-community/NUR/commit/6b219faa81c094a5cc2e46e865a2fd8b2bff9f99) | `` automatic update `` |
| [`1711a198`](https://github.com/nix-community/NUR/commit/1711a198acfd0a32b2499834680e981f70dddbc9) | `` automatic update `` |
| [`12803d52`](https://github.com/nix-community/NUR/commit/12803d52c7354c69577b9128df32582f732bde01) | `` automatic update `` |