### PR TITLE
chore(flake/nur): `6b219faa` -> `c898a1ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758924686,
-        "narHash": "sha256-s2XRpgctPSZHe00TfUwyEEmwRF64kn5Ao7OU3Q+zGEg=",
+        "lastModified": 1758942380,
+        "narHash": "sha256-mlwsHUYMJb7sHjdcyrSLH8KQ8desj8AQ86/m6ZP53fY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b219faa81c094a5cc2e46e865a2fd8b2bff9f99",
+        "rev": "c898a1ed2da0164bc6f395f44aad52edb84c84d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c898a1ed`](https://github.com/nix-community/NUR/commit/c898a1ed2da0164bc6f395f44aad52edb84c84d4) | `` automatic update `` |
| [`c9973236`](https://github.com/nix-community/NUR/commit/c9973236cf98b0cb1e0eadade782e967224e8cea) | `` automatic update `` |
| [`61abf365`](https://github.com/nix-community/NUR/commit/61abf365408b00b3306b7d9691df4fb957b250eb) | `` automatic update `` |