### PR TITLE
chore(flake/catppuccin): `2e0aacdd` -> `02dee881`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1758270360,
-        "narHash": "sha256-yqh6EEhlpVWRoKl85o1s+QZ72UHWTvornnc3C0Ls484=",
+        "lastModified": 1758956381,
+        "narHash": "sha256-ROUw5E8CibG3jEy6oHjrkF6/P60eiaUJmc2s2ecC/LM=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "2e0aacdd6abbecd1b1c0511a2fcd1460a6bc6645",
+        "rev": "02dee881c3e644e2b561f407742f1fd927c40b83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                   |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`02dee881`](https://github.com/catppuccin/nix/commit/02dee881c3e644e2b561f407742f1fd927c40b83) | `` chore(deps): update dependency @astrojs/starlight to ^0.36.0 (#729) `` |
| [`7d875534`](https://github.com/catppuccin/nix/commit/7d875534581678ffd101b77b884153832247a530) | `` chore(deps): update dependency sharp to v0.34.4 (#728) ``              |
| [`6dfdbe2f`](https://github.com/catppuccin/nix/commit/6dfdbe2f945f1b8ec0950e4824ec84d7bebe28cd) | `` chore(deps): update dependency astro to v5.14.1 (#719) ``              |
| [`f79f9a90`](https://github.com/catppuccin/nix/commit/f79f9a907132dbd624b3200af9934d26449842ef) | `` chore(deps): update pnpm to v10.17.1 (#708) ``                         |
| [`7e8593bc`](https://github.com/catppuccin/nix/commit/7e8593bcbd2f95a25a56643925435dc1e7a4a106) | `` feat(home-manager): add support for eza (#701) ``                      |