### PR TITLE
chore(flake/nur): `97197815` -> `482ba74c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758954406,
-        "narHash": "sha256-MCP/VGjybBfDJvWW8SgJwmEe0DuqyQ42GN6EGRiQigk=",
+        "lastModified": 1758976054,
+        "narHash": "sha256-5TNhxapxrBKUsMqiRnz4ZiEF2+znwwaqLkCs9z1aEbo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9719781501c879bfffe618adc5ba736e06011b0d",
+        "rev": "482ba74c70a5afab4c6e920716a4b0ad86e452f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`482ba74c`](https://github.com/nix-community/NUR/commit/482ba74c70a5afab4c6e920716a4b0ad86e452f4) | `` automatic update `` |
| [`e39e2b15`](https://github.com/nix-community/NUR/commit/e39e2b15a41cb527c8b68baf946e98a37a806847) | `` automatic update `` |