### PR TITLE
chore(flake/nur): `482ba74c` -> `b12d9127`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1758976054,
-        "narHash": "sha256-5TNhxapxrBKUsMqiRnz4ZiEF2+znwwaqLkCs9z1aEbo=",
+        "lastModified": 1758986280,
+        "narHash": "sha256-xuvw0q3JAcUZteJ5x46ukkArWInTvSroWb23Wsd+sHs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "482ba74c70a5afab4c6e920716a4b0ad86e452f4",
+        "rev": "b12d9127abe1fde785f751ddcf046b6707f53990",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b12d9127`](https://github.com/nix-community/NUR/commit/b12d9127abe1fde785f751ddcf046b6707f53990) | `` automatic update `` |
| [`f64b7b5c`](https://github.com/nix-community/NUR/commit/f64b7b5cce4c13ffba0582caae5e05c92a9c7899) | `` automatic update `` |
| [`dc6aa258`](https://github.com/nix-community/NUR/commit/dc6aa258292b2c4411e0f6b6ebb03d880ac5b00d) | `` automatic update `` |