### PR TITLE
chore(flake/nur): `cd07e34a` -> `df3fb235`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759030674,
-        "narHash": "sha256-HFrk2BF+8kCzGIGmvjwtiCLRRVzZUBPFXlA1vdYBd4k=",
+        "lastModified": 1759037763,
+        "narHash": "sha256-03rBswReBYcridphYSw4XyVauK1/+3gqFMng3NEq4CA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd07e34a7305d828d5e507c87e8ec40f4061ba78",
+        "rev": "df3fb235a1e0cd5e6d0907290802a22dde333337",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`df3fb235`](https://github.com/nix-community/NUR/commit/df3fb235a1e0cd5e6d0907290802a22dde333337) | `` automatic update `` |
| [`b873e23f`](https://github.com/nix-community/NUR/commit/b873e23f8ab30e3d7ed85165b037eed70855e56e) | `` automatic update `` |
| [`b12b0f57`](https://github.com/nix-community/NUR/commit/b12b0f57055006b1126972894153a4a8c7c44e8d) | `` automatic update `` |
| [`eb0a72b2`](https://github.com/nix-community/NUR/commit/eb0a72b223db0a0a9095ac53b375148e5f868775) | `` automatic update `` |
| [`13700b47`](https://github.com/nix-community/NUR/commit/13700b476b9868776eee20414d5277ea1a57fbee) | `` automatic update `` |