### PR TITLE
chore(flake/nur): `df3fb235` -> `2af79589`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759037763,
-        "narHash": "sha256-03rBswReBYcridphYSw4XyVauK1/+3gqFMng3NEq4CA=",
+        "lastModified": 1759049253,
+        "narHash": "sha256-1PZCzWNjN3ur5E9Em8Ydd/ZcIwfzIInb5kbyd78WIGs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "df3fb235a1e0cd5e6d0907290802a22dde333337",
+        "rev": "2af795892ad4e2039fda7dcdb4dae71c4a444ad1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2af79589`](https://github.com/nix-community/NUR/commit/2af795892ad4e2039fda7dcdb4dae71c4a444ad1) | `` automatic update `` |
| [`ebea906e`](https://github.com/nix-community/NUR/commit/ebea906e608cdfe7493ca461f5fcd1b36a42d365) | `` automatic update `` |
| [`5f4cd163`](https://github.com/nix-community/NUR/commit/5f4cd1638e5cf5c912a76727bb2dac8a29ceb7ee) | `` automatic update `` |
| [`f8f80c33`](https://github.com/nix-community/NUR/commit/f8f80c33cebc18ea0748c23f39a2cfc11b1a197f) | `` automatic update `` |