### PR TITLE
chore(flake/nur): `f4a49279` -> `30213cdb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759072441,
-        "narHash": "sha256-QBx5r4qax8OnnX/joP3DIBw5cvTKiIg4HnKpuOYLUp4=",
+        "lastModified": 1759083770,
+        "narHash": "sha256-zy+WI1qCN84l0fRrS7FaxhBJQyKQcaT53qM1ZAvS6c4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f4a492798a98f8470b60357f8fc1b94245e2d2f9",
+        "rev": "30213cdb479b2ac4f6bded9982439a82c3d760b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`30213cdb`](https://github.com/nix-community/NUR/commit/30213cdb479b2ac4f6bded9982439a82c3d760b3) | `` automatic update `` |
| [`669ab83f`](https://github.com/nix-community/NUR/commit/669ab83f6fe35cae4bee00e9a66e79b1936612cd) | `` automatic update `` |
| [`7eea3cf5`](https://github.com/nix-community/NUR/commit/7eea3cf5c0f2b96464a6a2c21877773d1a459e11) | `` automatic update `` |