### PR TITLE
chore(flake/nur): `30213cdb` -> `e88fd776`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759083770,
-        "narHash": "sha256-zy+WI1qCN84l0fRrS7FaxhBJQyKQcaT53qM1ZAvS6c4=",
+        "lastModified": 1759091793,
+        "narHash": "sha256-BBeGZR3lbAp9x1CJxjQ2FkUZX4iOf5UIRvwUPQrSfFw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "30213cdb479b2ac4f6bded9982439a82c3d760b3",
+        "rev": "e88fd7766e9b1af996a438341cbbd51d6ca1c621",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e88fd776`](https://github.com/nix-community/NUR/commit/e88fd7766e9b1af996a438341cbbd51d6ca1c621) | `` automatic update `` |
| [`f4f4e3fe`](https://github.com/nix-community/NUR/commit/f4f4e3fecf360340d4ed2740d7e02881616e7be9) | `` automatic update `` |
| [`1eac073d`](https://github.com/nix-community/NUR/commit/1eac073db3f04be9eca753c8f0bf54b341e85e14) | `` automatic update `` |