### PR TITLE
chore(flake/nur): `0239e35d` -> `fccc09df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759108855,
-        "narHash": "sha256-0rdifQvKp5jiQkXJbq4NNBLzPKl0l2dTYNa2kwU+1C0=",
+        "lastModified": 1759117007,
+        "narHash": "sha256-DSnkPMhK2Eg0XLiyjEPVtIpdcmWmYsBMhVGCN1144SA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0239e35d66f89be5b983f882de9f197b376d4812",
+        "rev": "fccc09dffa659dc1410eceb33285831ba12bc7f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fccc09df`](https://github.com/nix-community/NUR/commit/fccc09dffa659dc1410eceb33285831ba12bc7f6) | `` automatic update `` |
| [`1110ff3c`](https://github.com/nix-community/NUR/commit/1110ff3cee4ac510d5ab89e573e813a3803b8e00) | `` automatic update `` |