### PR TITLE
chore(flake/nur): `fccc09df` -> `4edcc30d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759117007,
-        "narHash": "sha256-DSnkPMhK2Eg0XLiyjEPVtIpdcmWmYsBMhVGCN1144SA=",
+        "lastModified": 1759119499,
+        "narHash": "sha256-//Y/6+fvsqcszAIR75u8JwOOx2Ic81tp1IUcg4N8RZw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fccc09dffa659dc1410eceb33285831ba12bc7f6",
+        "rev": "4edcc30d423cad749c216428403842ba34cefb8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4edcc30d`](https://github.com/nix-community/NUR/commit/4edcc30d423cad749c216428403842ba34cefb8a) | `` automatic update `` |
| [`daed4e48`](https://github.com/nix-community/NUR/commit/daed4e48d334bcd08be45bbf50d89308d957b592) | `` automatic update `` |