### PR TITLE
chore(flake/nur): `c7f19a28` -> `a089a6a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1758690382,
-        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759136191,
-        "narHash": "sha256-1FhgEzYRwLWUWjm/csTr+OmzRVGgvlUDySqhFOyhPGM=",
+        "lastModified": 1759149170,
+        "narHash": "sha256-xiX9TSjX2Gji8nr5HNYQnTHOsPAk5U1BVBfY1B4bhB0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c7f19a28eaa25be9451bd48508eabf2b386fb72d",
+        "rev": "a089a6a1d9e609a0c4406d444dabd15648f53d90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a089a6a1`](https://github.com/nix-community/NUR/commit/a089a6a1d9e609a0c4406d444dabd15648f53d90) | `` automatic update `` |
| [`9112cb78`](https://github.com/nix-community/NUR/commit/9112cb788344b678711ea1ca70bb833995e5c873) | `` automatic update `` |
| [`660590c6`](https://github.com/nix-community/NUR/commit/660590c6a1e82e6940eadb77b37f70dd878e8633) | `` automatic update `` |
| [`f1683296`](https://github.com/nix-community/NUR/commit/f16832965e360e4db9b76e9e675a0408ae5399b4) | `` automatic update `` |
| [`781a5290`](https://github.com/nix-community/NUR/commit/781a5290f677ca8afc785f2d3a2a3ad22c956293) | `` automatic update `` |
| [`0c9f9d03`](https://github.com/nix-community/NUR/commit/0c9f9d03d8d5658b3c0142ef795c3e143ee0408d) | `` automatic update `` |