### PR TITLE
chore(flake/chaotic): `fda4efdc` -> `ae7eac57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1759144862,
-        "narHash": "sha256-bWcc2DuzRr8rC6Sdan/0TG6tl/HfGa/BSguSJ3fLXzs=",
+        "lastModified": 1759155412,
+        "narHash": "sha256-5JMoXMQt0C1SAHzhHwKLIEZ8/Q8f0vqBGxrMnmuOvJg=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "fda4efdc4b3979f86dd46276c1edb61f4133ba12",
+        "rev": "ae7eac57b8dfc221270bb4f4752a87fe4f17ca11",
         "type": "github"
       },
       "original": {
@@ -382,11 +382,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1758815401,
-        "narHash": "sha256-Nj4iA2Msx0qfHPFDc0biubSsaChuZQlJrS3aNIaQ/T8=",
+        "lastModified": 1759147044,
+        "narHash": "sha256-3ZPFytJOcLjTChljeaGgoaNj+tOqzgEpqZAvRe3bU90=",
         "owner": "PedroHLC",
         "repo": "nixpkgs",
-        "rev": "0cc09391d851ec12e1dcbb8d105a75ab6344432b",
+        "rev": "18e83bbe13aa50992777832b52bd0e0d8585fb3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                              |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`ae7eac57`](https://github.com/chaotic-cx/nyx/commit/ae7eac57b8dfc221270bb4f4752a87fe4f17ca11) | `` vulkanPackages_latest.vulkan-tools: restore vkcube ``             |
| [`392ab4de`](https://github.com/chaotic-cx/nyx/commit/392ab4de5e68286f21fdd53c6cbbceb13985cfba) | `` failures: update aarch64-darwin ``                                |
| [`10b03514`](https://github.com/chaotic-cx/nyx/commit/10b03514c461b7079a8d937a655f1c29dbcdfe86) | `` mangohud_git: 20250923144234-be12df2 -> 20250928232517-b058618 `` |
| [`cdf9c2cd`](https://github.com/chaotic-cx/nyx/commit/cdf9c2cd80300e86dbccb9f6cf5a5e86fef9bc82) | `` failures: update x86_64-linux ``                                  |
| [`00c2aab4`](https://github.com/chaotic-cx/nyx/commit/00c2aab4d0bf6e36636204e95022a5bad8cfb00a) | `` nixpkgs: bump to 20250929 + cherry-picked llvm patches ``         |