### PR TITLE
chore(flake/nur): `d6289909` -> `278ec4e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759178343,
-        "narHash": "sha256-mZpOa+hFXbR+2U2sa7/UVRnCLgGJBc/8oSR04Emp/Pk=",
+        "lastModified": 1759194480,
+        "narHash": "sha256-/YGF4EfRGADlGc1hI5PJPkTL/hGZ2RCtuN9niwoqLS0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d6289909d3e2f2e411a258fdb364cf9d4735200e",
+        "rev": "278ec4e9461157b0581900bc5b9878731c522ebc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                      |
| -------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`278ec4e9`](https://github.com/nix-community/NUR/commit/278ec4e9461157b0581900bc5b9878731c522ebc) | `` automatic update ``       |
| [`3fa97d51`](https://github.com/nix-community/NUR/commit/3fa97d51ffa47d088ec3bb7bd05b4dfffd7eea2a) | `` automatic update ``       |
| [`c54e6175`](https://github.com/nix-community/NUR/commit/c54e6175c0ac012848c06abbe0d0e879eb6b6f99) | `` automatic update ``       |
| [`cae3320d`](https://github.com/nix-community/NUR/commit/cae3320d11d2a533132a9642d47c42e51da388de) | `` automatic update ``       |
| [`3ee480a9`](https://github.com/nix-community/NUR/commit/3ee480a9fbb235ebeb7cf62914d6e3fa93f7238e) | `` automatic update ``       |
| [`124687b6`](https://github.com/nix-community/NUR/commit/124687b60528a501c722c238ea12f6b4f280b328) | `` add aciceri repository `` |