### PR TITLE
chore(flake/nur): `278ec4e9` -> `871dcddf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759194480,
-        "narHash": "sha256-/YGF4EfRGADlGc1hI5PJPkTL/hGZ2RCtuN9niwoqLS0=",
+        "lastModified": 1759202507,
+        "narHash": "sha256-7tlJ3eNStwMlmTzEIte2/0LylsXEEf//35Z0x4TIYbI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "278ec4e9461157b0581900bc5b9878731c522ebc",
+        "rev": "871dcddf58327bceffde6033d06c0e656f185c3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`871dcddf`](https://github.com/nix-community/NUR/commit/871dcddf58327bceffde6033d06c0e656f185c3d) | `` automatic update `` |
| [`c45abdeb`](https://github.com/nix-community/NUR/commit/c45abdebe1c0c719f156a602641bbbe18ed360b3) | `` automatic update `` |
| [`2af870fa`](https://github.com/nix-community/NUR/commit/2af870fa31298d6cb38b7cf1e082a521370849ad) | `` automatic update `` |
| [`6fa62c67`](https://github.com/nix-community/NUR/commit/6fa62c67c8526d27980c3a8c8f87bad30b101042) | `` automatic update `` |