### PR TITLE
chore(flake/nixpkgs): `25e53aa1` -> `5ed4e25a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1758791193,
-        "narHash": "sha256-F8WmEwFoHsnix7rt290R0rFXNJiMbClMZyIC/e+HYf0=",
+        "lastModified": 1759143472,
+        "narHash": "sha256-TvODmeR2W7yX/JmOCmP+lAFNkTT7hAxYcF3Kz8SZV3w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "25e53aa156d47bad5082ff7618f5feb1f5e02d01",
+        "rev": "5ed4e25ab58fd4c028b59d5611e14ea64de51d23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                               |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| [`cb524ea4`](https://github.com/NixOS/nixpkgs/commit/cb524ea4c2a2f306b8de54471521ea63e4d69130) | `` jdk24: 24.0.1+9 -> 24.0.2+12 ``                                                                    |
| [`d88bee41`](https://github.com/NixOS/nixpkgs/commit/d88bee41dbec574b3c2bf97de37371d90f96475d) | `` llvmPackages_git: 22.0.0-unstable-2025-09-21 -> 22.0.0-unstable-2025-09-28 ``                      |
| [`c75ca42e`](https://github.com/NixOS/nixpkgs/commit/c75ca42e131052bffe58fefeeb4aac78fa767fac) | `` pkgsCross.aarch64-darwin.discord-development: 0.0.97 -> 0.0.100 ``                                 |
| [`0d3467d0`](https://github.com/NixOS/nixpkgs/commit/0d3467d0ec820a7f291dd532e41010e8595511d0) | `` pkgsCross.aarch64-darwin.discord-ptb: 0.0.190 -> 0.0.192 ``                                        |
| [`46100922`](https://github.com/NixOS/nixpkgs/commit/461009228c30c41f241442a13bee699e235d01e9) | `` pkgsCross.aarch64-darwin.discord-canary: 0.0.858 -> 0.0.867 ``                                     |
| [`9a49ccf7`](https://github.com/NixOS/nixpkgs/commit/9a49ccf79e524827791f39613601c7d5f0848501) | `` pkgsCross.aarch64-darwin.discord: 0.0.359 -> 0.0.362 ``                                            |
| [`b63aced6`](https://github.com/NixOS/nixpkgs/commit/b63aced622636e5d25f362cce72c0b8ad63ea729) | `` discord-development: 0.0.85 -> 0.0.89 ``                                                           |
| [`362e3504`](https://github.com/NixOS/nixpkgs/commit/362e35040134d7db934d5ab903779374f0b9b490) | `` discord: 0.0.110 -> 0.0.111 ``                                                                     |
| [`c423e09f`](https://github.com/NixOS/nixpkgs/commit/c423e09fe593a34bb5c72c5210f8941cde6f3e7f) | `` sc-controller: 0.5.2 -> 0.5.3 ``                                                                   |
| [`29ad61f2`](https://github.com/NixOS/nixpkgs/commit/29ad61f213cb9e1256f13441eb2836f4189d8695) | `` linuxKernel.kernels.linux_lqx: 6.16.7 -> 6.16.9 ``                                                 |
| [`8a3fea6e`](https://github.com/NixOS/nixpkgs/commit/8a3fea6e876f9f336e086f158926650cf3fd7666) | `` smtp4dev: 3.10.1 -> 3.10.2 ``                                                                      |
| [`d7e92e21`](https://github.com/NixOS/nixpkgs/commit/d7e92e217a8b4126180c571f42b8b24c378b7850) | `` smtp4dev: 3.9.0 -> 3.10.1 ``                                                                       |
| [`602b7a89`](https://github.com/NixOS/nixpkgs/commit/602b7a89212659021d7703146253fdf275214d99) | `` dolibarr: 22.0.1 -> 22.0.2 ``                                                                      |
| [`cb8acf47`](https://github.com/NixOS/nixpkgs/commit/cb8acf47cb677f339c49ec49e45397ba1a64d120) | `` nncp: 8.11.0 -> 8.12.1 ``                                                                          |
| [`10abe523`](https://github.com/NixOS/nixpkgs/commit/10abe523aba99efef36cc00b17a0665697251322) | `` maintainers: rename romner-set to azey7f ``                                                        |
| [`db3124c7`](https://github.com/NixOS/nixpkgs/commit/db3124c7c90dfaae8da3d52afcacd25070f6a969) | `` nixos/outline: ajust for deprecation of MAXIMUM_IMPORT_SIZE ``                                     |
| [`27e30db5`](https://github.com/NixOS/nixpkgs/commit/27e30db5a4da2b540aaaef4e6cd1c9ed6e1391ae) | `` nixos/tests/outline: drop minio to simplify test; increase memorySize do to OOM error ``           |
| [`676a8631`](https://github.com/NixOS/nixpkgs/commit/676a86314e322ff81e01d89e0133540e2f833b5e) | `` element-desktop: fix missing app icon ``                                                           |
| [`c74c7340`](https://github.com/NixOS/nixpkgs/commit/c74c7340bd29abf998b2e6e5ba643a97804d5f34) | `` element-desktop: 1.11.112 -> 1.12.0 ``                                                             |
| [`255d2572`](https://github.com/NixOS/nixpkgs/commit/255d2572faa51180e2b5c97354beab746faaf7f8) | `` element-web-unwrapped: 1.11.112 -> 1.12.0 ``                                                       |
| [`2b017029`](https://github.com/NixOS/nixpkgs/commit/2b017029924ad9462fdf3f75ff1d6f86d6b411e4) | `` yt-dlp: 2025.09.23 -> 2025.09.26 ``                                                                |
| [`8013672b`](https://github.com/NixOS/nixpkgs/commit/8013672b3b52dab87cd977c405c8b50058d250ea) | `` lely-core: init at 2.3.5 ``                                                                        |
| [`c0b31f35`](https://github.com/NixOS/nixpkgs/commit/c0b31f35307c7b8bab694c87960ddbb1a2c7071a) | `` zellij: drop self from maintainers ``                                                              |
| [`f9e45869`](https://github.com/NixOS/nixpkgs/commit/f9e45869ae88255e5f582ec669ff79df648b3e1e) | `` discord-canary: 0.0.756 -> 0.0.761 ``                                                              |
| [`c1640089`](https://github.com/NixOS/nixpkgs/commit/c1640089f4700eac448b2b2cbdeea5c1b0e46f52) | `` nextcloudPackages: update ``                                                                       |
| [`d886bdb2`](https://github.com/NixOS/nixpkgs/commit/d886bdb2062132b661f77e35c9fc3b0fb51e1d78) | `` nextcloud30: 30.0.15 -> 30.0.16 ``                                                                 |
| [`182f5a6c`](https://github.com/NixOS/nixpkgs/commit/182f5a6c052fa5d8f3e84c6de0fa95c049ec3049) | `` linux_xanmod_latest: 6.16.8 -> 6.16.9 ``                                                           |
| [`b7f5e14e`](https://github.com/NixOS/nixpkgs/commit/b7f5e14ea1da8fefccf1cf28abaa5d2c557ec7c1) | `` linux_xanmod: 6.12.48 -> 6.12.49 ``                                                                |
| [`abac62a8`](https://github.com/NixOS/nixpkgs/commit/abac62a85248cb1f50678be81044db5cd45d0968) | `` raycast: 1.103.0 -> 1.103.2 ``                                                                     |
| [`b9fc3b69`](https://github.com/NixOS/nixpkgs/commit/b9fc3b69a1f1d041d53be5ff5097ef45cee48b2e) | `` ci/pinned: update ``                                                                               |
| [`4d96e9ca`](https://github.com/NixOS/nixpkgs/commit/4d96e9ca639aa19dcfc37fb5a2970c67ad3ff83c) | `` microsoft-edge: 140.0.3485.81 -> 140.0.3485.94 ``                                                  |
| [`459758ac`](https://github.com/NixOS/nixpkgs/commit/459758aca9e28ad3d3ed926670443a492bf45f88) | `` iina: 1.4.0 -> 1.4.1 ``                                                                            |
| [`46b25ead`](https://github.com/NixOS/nixpkgs/commit/46b25eade4e41d7a1f90cc18da4e1b6bd67c3d23) | `` snipe-it: 8.3.0 -> 8.3.2 ``                                                                        |
| [`a4419a98`](https://github.com/NixOS/nixpkgs/commit/a4419a9857395619739d7b68f7188f74b10a4a8d) | `` dprint: 0.50.1 -> 0.50.2 ``                                                                        |
| [`c73e0916`](https://github.com/NixOS/nixpkgs/commit/c73e09165eb573383724a775fbe28fd6e4336da8) | `` dprint: Fix build failure with Rust ≥ 1.89.0 ``                                                    |
| [`1fcc6f56`](https://github.com/NixOS/nixpkgs/commit/1fcc6f56efacc6128b0ed230009cf02d9e35d436) | `` dprint-plugins.dprint-plugin-typescript: 0.95.10 -> 0.95.11 ``                                     |
| [`27ea3874`](https://github.com/NixOS/nixpkgs/commit/27ea3874d2be071f87c772d8b5d188b87e468fb0) | `` dprint-plugins.dprint-plugin-typescript: 0.95.9 -> 0.95.10 ``                                      |
| [`2d7cb390`](https://github.com/NixOS/nixpkgs/commit/2d7cb3901468de40b440c7ec38c9eb952339c951) | `` dprint-plugins.dprint-plugin-biome: 0.10.1 -> 0.10.3 ``                                            |
| [`adbca225`](https://github.com/NixOS/nixpkgs/commit/adbca22599a548a3ce3dac56b47e6448c3d1bf93) | `` dprint-plugins.dprint-plugin-biome: 0.9.3 -> 0.10.1 ``                                             |
| [`6d2113c0`](https://github.com/NixOS/nixpkgs/commit/6d2113c035d7f7e491f935a751b04db471d485c8) | `` dprint-plugins.dprint-plugin-biome: 0.9.2 -> 0.9.3 ``                                              |
| [`a79de649`](https://github.com/NixOS/nixpkgs/commit/a79de6498d83c045fddb912b4750815342001de1) | `` dprint-plugins.dprint-plugin-biome: 0.9.1 -> 0.9.2 ``                                              |
| [`4c48bc8f`](https://github.com/NixOS/nixpkgs/commit/4c48bc8ff4f6e11cc1932ad0cb9b760989a76319) | `` brave: 1.82.170 -> 1.82.172 ``                                                                     |
| [`d77c949e`](https://github.com/NixOS/nixpkgs/commit/d77c949e8a6be084159e8200a669510359775c9e) | `` dprint-plugins.dprint-plugin-biome: 0.9.0 -> 0.9.1 ``                                              |
| [`aabb1806`](https://github.com/NixOS/nixpkgs/commit/aabb180693568063655f93b7b8049fbfbd498a17) | `` dprint-plugins.dprint-plugin-biome: 0.7.1 -> 0.9.0 ``                                              |
| [`5ff6ae31`](https://github.com/NixOS/nixpkgs/commit/5ff6ae317839fbc19dd7ec6e94310c8bfa8bf458) | `` dprint-plugins.dprint-plugin-markdown: 0.18.0 -> 0.19.0 ``                                         |
| [`8386705e`](https://github.com/NixOS/nixpkgs/commit/8386705e6724326caa5500ae784e2bf1d41890a6) | `` gitlab: 18.4.0 -> 18.4.1 ``                                                                        |
| [`f0360d0c`](https://github.com/NixOS/nixpkgs/commit/f0360d0cf97ce93ebe4439f0aeb61d89640c25a8) | `` lk-jwt-service: 0.2.3 -> 0.3.0 ``                                                                  |
| [`a6ad2357`](https://github.com/NixOS/nixpkgs/commit/a6ad2357408e04c53773f45c32f278cf8c58e412) | `` maintainers: update HeitorAugustoLN ``                                                             |
| [`13ca0f19`](https://github.com/NixOS/nixpkgs/commit/13ca0f195659f25f252246af93fc1a2213520900) | `` matrix-synapse: 1.138.0 -> 1.138.2 ``                                                              |
| [`fb73215b`](https://github.com/NixOS/nixpkgs/commit/fb73215b0b917a27ee8af2750ccd3839d8833839) | `` paretosecurity: 0.3.6 -> 0.3.8 ``                                                                  |
| [`35980645`](https://github.com/NixOS/nixpkgs/commit/359806457e9b7ca7dc059378cba68b28683a0c2e) | `` linux_6_1: 6.1.153 -> 6.1.154 ``                                                                   |
| [`eae8c990`](https://github.com/NixOS/nixpkgs/commit/eae8c99005b410a047f5f06c04f66cfac5ade1f7) | `` linux_6_6: 6.6.107 -> 6.6.108 ``                                                                   |
| [`55cb0d42`](https://github.com/NixOS/nixpkgs/commit/55cb0d4245c75ef1c0420f4b834234fd2831f3e5) | `` linux_6_12: 6.12.48 -> 6.12.49 ``                                                                  |
| [`9f9e397a`](https://github.com/NixOS/nixpkgs/commit/9f9e397a547bf333a67da2bf7fff59aeb9af4531) | `` linux_6_16: 6.16.8 -> 6.16.9 ``                                                                    |
| [`a06997c8`](https://github.com/NixOS/nixpkgs/commit/a06997c8c979483019f81bdb036d0a6f1a3c7986) | `` linux_testing: 6.17-rc6 -> 6.17-rc7 ``                                                             |
| [`136b2bd8`](https://github.com/NixOS/nixpkgs/commit/136b2bd830d2b49e4a757874dcd2f33efb55e660) | `` lunatask: 2.1.7 -> 2.1.10 ``                                                                       |
| [`224e2e2d`](https://github.com/NixOS/nixpkgs/commit/224e2e2d5eebcfec349157494e136a6321631447) | `` outline: 0.87.3 -> 0.87.4 ``                                                                       |
| [`51b1f42a`](https://github.com/NixOS/nixpkgs/commit/51b1f42a59db414a0fd52e8f8c3041ceb220b010) | `` ungoogled-chromium: 140.0.7339.185-1 -> 140.0.7339.207-1 ``                                        |
| [`de2c1da6`](https://github.com/NixOS/nixpkgs/commit/de2c1da679fb1d33a4d19f60793a8e82e4aaa55c) | `` immich: 1.140.1 -> 1.142.0 ``                                                                      |
| [`95f42bda`](https://github.com/NixOS/nixpkgs/commit/95f42bda5f5a651e386f9fb240efc830c2fb29bf) | `` vips_8_17: init at 8.17.1 ``                                                                       |
| [`2e91ca96`](https://github.com/NixOS/nixpkgs/commit/2e91ca96aaadcefbc56187d02d89c56a568f6eb9) | `` chromium: move `export` in `preConfigure` to `env.` ``                                             |
| [`f23fd9ae`](https://github.com/NixOS/nixpkgs/commit/f23fd9ae51dd9fb1cc04e27f688ae67cd7034b49) | `` chromium: fix xlst rendering on `release-25.05` ``                                                 |
| [`94bacf93`](https://github.com/NixOS/nixpkgs/commit/94bacf939b6ea616f03209d8bb2fd48165eb2869) | `` mozillavpn: 2.30.0 -> 2.31.0 ``                                                                    |
| [`bf484430`](https://github.com/NixOS/nixpkgs/commit/bf4844306f4e3b2a127bef2d6c4442506a4942cb) | `` webkitgtk_6_0: 2.48.6 → 2.50.0 ``                                                                  |
| [`cfbf2909`](https://github.com/NixOS/nixpkgs/commit/cfbf2909f3fb32c0e3ff6a014f2148603c1fe4c7) | `` electron-source.electron_38: 38.0.0 -> 38.1.2 ``                                                   |
| [`577f8b21`](https://github.com/NixOS/nixpkgs/commit/577f8b21ef9a832abe07ba4ced50378a78d0ff10) | `` electron-source.electron_37: 37.4.0 -> 37.5.1 ``                                                   |
| [`d540b7b1`](https://github.com/NixOS/nixpkgs/commit/d540b7b1954b6d8b3d0342fda979c93cfa7d2073) | `` electron-source.electron_36: 36.8.1 -> 36.9.1 ``                                                   |
| [`fe7d2d80`](https://github.com/NixOS/nixpkgs/commit/fe7d2d80f60036613306990f07d72fc03153a405) | `` electron-chromedriver_38: 38.0.0 -> 38.1.2 ``                                                      |
| [`156e0761`](https://github.com/NixOS/nixpkgs/commit/156e076167bb5fd6f6f47c81ccc8b15ed16b3821) | `` electron_38-bin: 38.0.0 -> 38.1.2 ``                                                               |
| [`bbe18b8e`](https://github.com/NixOS/nixpkgs/commit/bbe18b8e8202fefdd44e82ab7c7a920db1fe7337) | `` electron-chromedriver_37: 37.4.0 -> 37.5.1 ``                                                      |
| [`73abaa4d`](https://github.com/NixOS/nixpkgs/commit/73abaa4df7e6fbe7085dfca0e2b26baaed4c4617) | `` electron_37-bin: 37.4.0 -> 37.5.1 ``                                                               |
| [`6f5f112e`](https://github.com/NixOS/nixpkgs/commit/6f5f112e00c29f4eb8e454b38f37a6b5bb12ec6e) | `` electron-chromedriver_36: 36.8.1 -> 36.9.1 ``                                                      |
| [`eb88bab1`](https://github.com/NixOS/nixpkgs/commit/eb88bab175a60dadc47cbfbe645785f9aace12c3) | `` electron_36-bin: 36.8.1 -> 36.9.1 ``                                                               |
| [`33f4815e`](https://github.com/NixOS/nixpkgs/commit/33f4815eca24425b6520ac40d885149ddce6d0e1) | `` crow: 1.2 -> 1.2.1.2 ``                                                                            |
| [`053cb6f6`](https://github.com/NixOS/nixpkgs/commit/053cb6f65664106d5142488560d265f198cd71da) | `` notesnook: 3.0.19 -> 3.2.4 ``                                                                      |
| [`69c9a5f6`](https://github.com/NixOS/nixpkgs/commit/69c9a5f61906e1fba6134d34ad28e93f755d7c96) | `` lockbook-desktop: 0.9.27 -> 25.9.17 ``                                                             |
| [`6b475a53`](https://github.com/NixOS/nixpkgs/commit/6b475a53bd92ba6be89dcf2603d15a82d02abca1) | `` lockbook: 0.9.27 -> 25.9.17 ``                                                                     |
| [`9dcf174c`](https://github.com/NixOS/nixpkgs/commit/9dcf174c465352a8b926acad56e1ef9dc4640704) | `` cyberduck: add maintainer iedame ``                                                                |
| [`81c60949`](https://github.com/NixOS/nixpkgs/commit/81c60949db2900f85ebed08d7cde7270bdffb026) | `` cyberduck: 9.1.2.42722 -> 9.2.4.43667 ``                                                           |
| [`8735e70d`](https://github.com/NixOS/nixpkgs/commit/8735e70de9c2345e251872c555364754d3bf19c4) | `` authelia: 4.39.8 -> 4.39.10 ``                                                                     |
| [`9ed34c65`](https://github.com/NixOS/nixpkgs/commit/9ed34c659ecac54e026d33937878b3a01b617ec0) | `` tomcat9: 9.0.108 -> 9.0.109 ``                                                                     |
| [`fa908acf`](https://github.com/NixOS/nixpkgs/commit/fa908acf235a98d899b9434d357c0011258b79da) | `` tomcat10: 10.1.44 -> 10.1.46 ``                                                                    |
| [`62ee1581`](https://github.com/NixOS/nixpkgs/commit/62ee1581737944db7db1165150b8791c76d9f63e) | `` jetty: 12.1.0 -> 12.1.1 ``                                                                         |
| [`bd35e1cb`](https://github.com/NixOS/nixpkgs/commit/bd35e1cb5fe476af9cb4d74b93673e50eb80ec08) | `` nixos/ec2-data: sshd.service -> sshd-keygen.service ``                                             |
| [`f0e4be39`](https://github.com/NixOS/nixpkgs/commit/f0e4be399a8526069d38440e4b59c3f6f3d89989) | `` signal-desktop-bin(darwin): 7.69.0 -> 7.71.0 ``                                                    |
| [`e4b1750c`](https://github.com/NixOS/nixpkgs/commit/e4b1750c225e14372a1eb8b29922b4a2aab64283) | `` signal-desktop-bin(aarch64-linux): 7.69.0 -> 7.71.0 ``                                             |
| [`4a639955`](https://github.com/NixOS/nixpkgs/commit/4a63995551b6d8196a5f443a47cb7ce9806baed2) | `` signal-desktop-bin: 7.69.0 -> 7.71.0 ``                                                            |
| [`80cd684b`](https://github.com/NixOS/nixpkgs/commit/80cd684bbf82fd78be39450eb4891abfbcd08ec7) | `` signal-desktop-bin(darwin): 7.64.0 -> 7.69.0 ``                                                    |
| [`3de13758`](https://github.com/NixOS/nixpkgs/commit/3de137582ec2b63a007c57631631e6df6a53056d) | `` signal-desktop-bin(aarch64): 7.64.0 -> 7.69.0 ``                                                   |
| [`96de6369`](https://github.com/NixOS/nixpkgs/commit/96de6369dac4cc4aafa875204bacbf20d82eaabc) | `` signal-desktop-bin: 7.64.0 -> 7.69.0 ``                                                            |
| [`46746eb2`](https://github.com/NixOS/nixpkgs/commit/46746eb242bc2067663cfb4fd8ef024d81fd0ddf) | `` [Backport release-25.05] zapzap: update meta.homepage ``                                           |
| [`11d960a7`](https://github.com/NixOS/nixpkgs/commit/11d960a74cb67afa63927bec2be698cc1ec4ee52) | `` ayatana-indicator-sound: Lengthen timeouts in tests ``                                             |
| [`9214d9f2`](https://github.com/NixOS/nixpkgs/commit/9214d9f26a094ec3655b02b309832596ca8c25c1) | `` nixosTests.lomiri.desktop-appinteractions: Switch Content-Hub test to using Gallery app instead `` |
| [`062b9d9c`](https://github.com/NixOS/nixpkgs/commit/062b9d9c180e893b0a946953faad5b7e1d0a9fff) | `` nixos/lomiri: Exclude Morph Browser by default ``                                                  |
| [`cb487a28`](https://github.com/NixOS/nixpkgs/commit/cb487a28776ffeb91d1ff439e693ba9442dcaee6) | `` fastnetmon-advanced: 2.0.371 -> 2.0.372 (#436727) ``                                               |