### PR TITLE
chore(flake/nur): `871dcddf` -> `277bf808`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759202507,
-        "narHash": "sha256-7tlJ3eNStwMlmTzEIte2/0LylsXEEf//35Z0x4TIYbI=",
+        "lastModified": 1759208743,
+        "narHash": "sha256-gsQDpRxDf6EyON14ng4uRvwCsO+V0a/aUy7J/tDiZ2g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "871dcddf58327bceffde6033d06c0e656f185c3d",
+        "rev": "277bf80893db769e7c5b665fd62ebd23424543b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`277bf808`](https://github.com/nix-community/NUR/commit/277bf80893db769e7c5b665fd62ebd23424543b5) | `` automatic update `` |
| [`f2d0f353`](https://github.com/nix-community/NUR/commit/f2d0f3530cdd31b730173bb3c92a2c39167dce4b) | `` automatic update `` |