### PR TITLE
chore(flake/nur): `69fda6d9` -> `72c1615a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759222485,
-        "narHash": "sha256-ioE6FSaHsEbVlm0/0yM/JAWH2pYS7t3w+/enBuFxyyM=",
+        "lastModified": 1759236502,
+        "narHash": "sha256-38NfPjArII/MIkptX3hF9x3ticbeE12YkdNGag5JX1Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69fda6d9dcae315c1c3da68cf00ba3f540320f98",
+        "rev": "72c1615a224fb3f6b366eef3042cd686a8db80ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`72c1615a`](https://github.com/nix-community/NUR/commit/72c1615a224fb3f6b366eef3042cd686a8db80ae) | `` automatic update `` |
| [`44d2dc32`](https://github.com/nix-community/NUR/commit/44d2dc32ac578ff46abb3bf66916ea54d5aeafa7) | `` automatic update `` |
| [`20c18f1c`](https://github.com/nix-community/NUR/commit/20c18f1c6f384b062e6183057539e4541b12e03b) | `` automatic update `` |
| [`44937306`](https://github.com/nix-community/NUR/commit/449373069db61749a064981e039d15f82b8355d3) | `` automatic update `` |