### PR TITLE
chore(flake/nur): `72c1615a` -> `04440fa3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759236502,
-        "narHash": "sha256-38NfPjArII/MIkptX3hF9x3ticbeE12YkdNGag5JX1Q=",
+        "lastModified": 1759245283,
+        "narHash": "sha256-3WDlyI89IR9OpnmVetlzXF93NM826T07pFkRajWW84s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "72c1615a224fb3f6b366eef3042cd686a8db80ae",
+        "rev": "04440fa3310582bc183abe4c5f6372e8e21f285b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`04440fa3`](https://github.com/nix-community/NUR/commit/04440fa3310582bc183abe4c5f6372e8e21f285b) | `` automatic update `` |
| [`200398d7`](https://github.com/nix-community/NUR/commit/200398d73472315f503a0c51992937cbe38cd554) | `` automatic update `` |
| [`3b6b391f`](https://github.com/nix-community/NUR/commit/3b6b391f621ea3c80d94e168a8b8bc06b5edb57b) | `` automatic update `` |
| [`63dfbc66`](https://github.com/nix-community/NUR/commit/63dfbc66355f5adbb8504af182582576089d10ea) | `` automatic update `` |
| [`dedaf246`](https://github.com/nix-community/NUR/commit/dedaf24698f3f085e690e562553757655dfdfa9c) | `` automatic update `` |
| [`b60c9c6f`](https://github.com/nix-community/NUR/commit/b60c9c6f0515d6a34f0accfc0725a45e7aeffc0b) | `` automatic update `` |