### PR TITLE
chore(flake/nur): `04440fa3` -> `1ae530e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759245283,
-        "narHash": "sha256-3WDlyI89IR9OpnmVetlzXF93NM826T07pFkRajWW84s=",
+        "lastModified": 1759256045,
+        "narHash": "sha256-J4VybJVe+7ZK1KwnrIhjmnMp7LH/MuNcsT0hrS9B0hk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "04440fa3310582bc183abe4c5f6372e8e21f285b",
+        "rev": "1ae530e4e95038f670e3605e0d109fa2b0bf2a4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                         |
| -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`1ae530e4`](https://github.com/nix-community/NUR/commit/1ae530e4e95038f670e3605e0d109fa2b0bf2a4c) | `` automatic update ``                                          |
| [`7785c704`](https://github.com/nix-community/NUR/commit/7785c7048510ecc511397c5b6795fba513b0baa6) | `` automatic update ``                                          |
| [`25479a6c`](https://github.com/nix-community/NUR/commit/25479a6ce07eb93541f6f0c821a0dd26467221b9) | `` Update cachix/install-nix-action digest to a809471 (#981) `` |
| [`af55b369`](https://github.com/nix-community/NUR/commit/af55b36949f5c443b3ccd600c83994d70b26f605) | `` add lucassabreu repository (#983) ``                         |
| [`e71ae27f`](https://github.com/nix-community/NUR/commit/e71ae27f8bcebc2e65d17524b906841081eb2dc0) | `` automatic update ``                                          |