### PR TITLE
chore(flake/nixos-hardware): `170ff93c` -> `e087756c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -289,11 +289,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1758663926,
-        "narHash": "sha256-6CFdj7Xs616t1W4jLDH7IohAAvl5Dyib3qEv/Uqw1rk=",
+        "lastModified": 1759261527,
+        "narHash": "sha256-wPd5oGvBBpUEzMF0kWnXge0WITNsITx/aGI9qLHgJ4g=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "170ff93c860b2a9868ed1e1102d4e52cb3d934e1",
+        "rev": "e087756cf4abbe1a34f3544c480fc1034d68742f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`ba70d207`](https://github.com/NixOS/nixos-hardware/commit/ba70d20716fa5a658840074cc5285c85c337127b) | `` Add Lenovo ThinkPad P14s Intel Gen 2 profile ``                         |
| [`28c41d0a`](https://github.com/NixOS/nixos-hardware/commit/28c41d0a5d93caa95af4c18302ade6078ecec933) | `` msi/b550-tomahawk: init ``                                              |
| [`5e57f28e`](https://github.com/NixOS/nixos-hardware/commit/5e57f28e6ad899725a9550b018693c01a049b411) | `` mnt/reform: init ``                                                     |
| [`095a4456`](https://github.com/NixOS/nixos-hardware/commit/095a445675f0db39c1b42d62a7888df8670fe6b0) | `` apple/macbook-air/5: init ``                                            |
| [`0e9dc7cf`](https://github.com/NixOS/nixos-hardware/commit/0e9dc7cf611c900c2298054b1d93121478fbf9fa) | `` linglong/nova-studio: remove opencl config and move it to readme ``     |
| [`27581273`](https://github.com/NixOS/nixos-hardware/commit/27581273c242efc4aa26cc0f92215aa8b3aaa78c) | `` panasonic: add Let's Note CF-LX3 configuration ``                       |
| [`76a31476`](https://github.com/NixOS/nixos-hardware/commit/76a314765d46a41ff366d05d95d4654cc2b71672) | `` lenovo/t14-intel-gen1(-nvidia): init ``                                 |
| [`4ba28b48`](https://github.com/NixOS/nixos-hardware/commit/4ba28b48c8f1fb3c2dee6c7b4ee2e2e6b26ac2a0) | `` linglong/nova-studio: init ``                                           |
| [`40dffd02`](https://github.com/NixOS/nixos-hardware/commit/40dffd02e3fe00ad1a27fd1b8b0d059c253776da) | `` tuxedo/pulse/15/gen2: defer amdgpu secure display warning to Stage 2 `` |
| [`0c55f0f7`](https://github.com/NixOS/nixos-hardware/commit/0c55f0f776577c45cc9d05d2e0a38013b965d70b) | `` tuxedo/pulse/15/gen2: load more internal modules ``                     |
| [`c92f8fc5`](https://github.com/NixOS/nixos-hardware/commit/c92f8fc536cbd9898ad2cad099579c3a07c683ef) | `` style: apply formatter ``                                               |
| [`66e88bdc`](https://github.com/NixOS/nixos-hardware/commit/66e88bdcaa444d06a644f1350927b3e20a495436) | `` asus/rog-gl552vw: init ``                                               |