### PR TITLE
chore(flake/nur): `1ae530e4` -> `710ba297`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759256045,
-        "narHash": "sha256-J4VybJVe+7ZK1KwnrIhjmnMp7LH/MuNcsT0hrS9B0hk=",
+        "lastModified": 1759264877,
+        "narHash": "sha256-gUlBK+FcgXNjeCqh3fTi8zBcWboGlIIi+lU0VQJnmi4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1ae530e4e95038f670e3605e0d109fa2b0bf2a4c",
+        "rev": "710ba29773c6cc2642f61bcee9ef25e4907a3341",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`710ba297`](https://github.com/nix-community/NUR/commit/710ba29773c6cc2642f61bcee9ef25e4907a3341) | `` automatic update `` |
| [`f380795a`](https://github.com/nix-community/NUR/commit/f380795a168accfd710fdad3fcdb478a594ca988) | `` automatic update `` |
| [`76db07ba`](https://github.com/nix-community/NUR/commit/76db07ba65227604f23daf96de4b9488af28a356) | `` automatic update `` |
| [`2b850860`](https://github.com/nix-community/NUR/commit/2b8508603232941676978619d6d4b34fc9e0b486) | `` automatic update `` |
| [`4044f303`](https://github.com/nix-community/NUR/commit/4044f3033cd180525a948802e83c9dede5092698) | `` automatic update `` |