### PR TITLE
chore(flake/nur): `710ba297` -> `c8b17784`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759264877,
-        "narHash": "sha256-gUlBK+FcgXNjeCqh3fTi8zBcWboGlIIi+lU0VQJnmi4=",
+        "lastModified": 1759282287,
+        "narHash": "sha256-yL34ymEKncsmC8T5jPrUQXiqXTdKpRH+LPZvpsMIh+o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "710ba29773c6cc2642f61bcee9ef25e4907a3341",
+        "rev": "c8b17784d700d1d9a35de58bad1e5ea7e8d9e3d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c8b17784`](https://github.com/nix-community/NUR/commit/c8b17784d700d1d9a35de58bad1e5ea7e8d9e3d2) | `` automatic update `` |
| [`e24ff10d`](https://github.com/nix-community/NUR/commit/e24ff10daaf9e9c4381fd2c645364591a6a7bdf3) | `` automatic update `` |
| [`c9429f2a`](https://github.com/nix-community/NUR/commit/c9429f2adac6096639c5890eaa972de5ee150e8c) | `` automatic update `` |
| [`75e92a93`](https://github.com/nix-community/NUR/commit/75e92a93b86449bf230e0d7bfda0d4d6b743563a) | `` automatic update `` |