### PR TITLE
chore(flake/nur): `c8b17784` -> `b039bd7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759282287,
-        "narHash": "sha256-yL34ymEKncsmC8T5jPrUQXiqXTdKpRH+LPZvpsMIh+o=",
+        "lastModified": 1759289607,
+        "narHash": "sha256-zoOtDva8VgrGZrus1DRqused0V+ly8BBANa1Ksb8tzI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c8b17784d700d1d9a35de58bad1e5ea7e8d9e3d2",
+        "rev": "b039bd7fc269528de34a97949bb6ccdebc936385",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b039bd7f`](https://github.com/nix-community/NUR/commit/b039bd7fc269528de34a97949bb6ccdebc936385) | `` automatic update `` |
| [`61d249b8`](https://github.com/nix-community/NUR/commit/61d249b8c2613537305438bfe0b2509de1c64170) | `` automatic update `` |
| [`443dfbde`](https://github.com/nix-community/NUR/commit/443dfbdeacbf46c257e902eda4f5ef169fdce811) | `` automatic update `` |
| [`ce2a9c0b`](https://github.com/nix-community/NUR/commit/ce2a9c0b2cb4fd5c9131b0e95c1c36afe6bb7949) | `` automatic update `` |
| [`39413086`](https://github.com/nix-community/NUR/commit/39413086e272c00fdc7e950612e4ded7e54eb489) | `` automatic update `` |