### PR TITLE
chore(flake/nur): `b039bd7f` -> `659e2028`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759289607,
-        "narHash": "sha256-zoOtDva8VgrGZrus1DRqused0V+ly8BBANa1Ksb8tzI=",
+        "lastModified": 1759297088,
+        "narHash": "sha256-BRm8732/E5JhmWh3AiQe0e9haj28SvIE7h8o+3kFCdE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b039bd7fc269528de34a97949bb6ccdebc936385",
+        "rev": "659e202831efa7ceaecd29b906a6630aaf032178",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`659e2028`](https://github.com/nix-community/NUR/commit/659e202831efa7ceaecd29b906a6630aaf032178) | `` automatic update `` |
| [`74cf65a9`](https://github.com/nix-community/NUR/commit/74cf65a9e0edba4967dccb0c5e9afce1e4259e90) | `` automatic update `` |
| [`8a706e3f`](https://github.com/nix-community/NUR/commit/8a706e3fbe7330661083d40427699c2fb1004158) | `` automatic update `` |
| [`c676f566`](https://github.com/nix-community/NUR/commit/c676f566d7dbbf72f57b929369680f6c87b992d1) | `` automatic update `` |