### PR TITLE
chore(flake/nur): `659e2028` -> `401e35bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759297088,
-        "narHash": "sha256-BRm8732/E5JhmWh3AiQe0e9haj28SvIE7h8o+3kFCdE=",
+        "lastModified": 1759310087,
+        "narHash": "sha256-vDwWHcGTEuIH2aq4nl0/GXji+3hvqghLcKrlpKJYka0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "659e202831efa7ceaecd29b906a6630aaf032178",
+        "rev": "401e35bcd025327acb83df93dd04c9f43265ff6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`401e35bc`](https://github.com/nix-community/NUR/commit/401e35bcd025327acb83df93dd04c9f43265ff6b) | `` automatic update `` |
| [`3dcf858a`](https://github.com/nix-community/NUR/commit/3dcf858a2eaeb9725c7ab0f2e833959395b871f5) | `` automatic update `` |
| [`d45b542c`](https://github.com/nix-community/NUR/commit/d45b542c49e55d1246a25374692b079e448cb701) | `` automatic update `` |
| [`9f2f1757`](https://github.com/nix-community/NUR/commit/9f2f17575ab23c7be49454f0058c33d232dec8c3) | `` automatic update `` |
| [`c8d7d1f2`](https://github.com/nix-community/NUR/commit/c8d7d1f26a9bef14043f8d346fb275638d872bd7) | `` automatic update `` |
| [`35c3a9a3`](https://github.com/nix-community/NUR/commit/35c3a9a3c9f27a5824ab4afd60413173b906163d) | `` automatic update `` |
| [`6207dc31`](https://github.com/nix-community/NUR/commit/6207dc31b1d1a417198937c573482971b13d1fc6) | `` automatic update `` |