### PR TITLE
chore(flake/nur): `401e35bc` -> `dd8d08aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759310087,
-        "narHash": "sha256-vDwWHcGTEuIH2aq4nl0/GXji+3hvqghLcKrlpKJYka0=",
+        "lastModified": 1759322636,
+        "narHash": "sha256-+U4ZNGd76ZO1vqTaJ4OwGFapTIZm2UvMhzXvL4OoVJ0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "401e35bcd025327acb83df93dd04c9f43265ff6b",
+        "rev": "dd8d08aa429e5134c4d9859382e16ea02fe27fa3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dd8d08aa`](https://github.com/nix-community/NUR/commit/dd8d08aa429e5134c4d9859382e16ea02fe27fa3) | `` automatic update `` |
| [`cffab088`](https://github.com/nix-community/NUR/commit/cffab0886a910d1d2707fc1bbb558a9cb4cd2899) | `` automatic update `` |
| [`93d454a9`](https://github.com/nix-community/NUR/commit/93d454a976a606063c18d49da8aff4801b6be632) | `` automatic update `` |
| [`7d8e0b1f`](https://github.com/nix-community/NUR/commit/7d8e0b1fdfcd86bd9c6b68b4014d4adfc806ac50) | `` automatic update `` |