### PR TITLE
chore(flake/nur): `dd8d08aa` -> `c269c73c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759322636,
-        "narHash": "sha256-+U4ZNGd76ZO1vqTaJ4OwGFapTIZm2UvMhzXvL4OoVJ0=",
+        "lastModified": 1759327939,
+        "narHash": "sha256-Qvrg5B3a6HVFk7SSDk3peNh848GabUinj+KruvD6vCs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd8d08aa429e5134c4d9859382e16ea02fe27fa3",
+        "rev": "c269c73c9d2923b2116340a8af0911110d44f6cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c269c73c`](https://github.com/nix-community/NUR/commit/c269c73c9d2923b2116340a8af0911110d44f6cf) | `` automatic update `` |
| [`d9673c28`](https://github.com/nix-community/NUR/commit/d9673c2896cc0be75103bea1797b51d8e2abdc07) | `` automatic update `` |
| [`57e7a827`](https://github.com/nix-community/NUR/commit/57e7a8278aaf9ed55872e27702f127c5cc074325) | `` automatic update `` |