### PR TITLE
chore(flake/nur): `c269c73c` -> `e9ad6dbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759327939,
-        "narHash": "sha256-Qvrg5B3a6HVFk7SSDk3peNh848GabUinj+KruvD6vCs=",
+        "lastModified": 1759340767,
+        "narHash": "sha256-M3AwMhtQGipW1cSpNnKfpxDE8mNWBp8uBbWngx8h+fc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c269c73c9d2923b2116340a8af0911110d44f6cf",
+        "rev": "e9ad6dbc1abce2c321b691b08db554b5e086dd9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e9ad6dbc`](https://github.com/nix-community/NUR/commit/e9ad6dbc1abce2c321b691b08db554b5e086dd9a) | `` automatic update `` |
| [`40d58317`](https://github.com/nix-community/NUR/commit/40d58317e97e60351bc08f3c95b94194c52e4219) | `` automatic update `` |
| [`5e751a52`](https://github.com/nix-community/NUR/commit/5e751a5236ff28f1405a9ace5324b693097e92e7) | `` automatic update `` |
| [`3229aa61`](https://github.com/nix-community/NUR/commit/3229aa61bd9a9245ec76d8191068c6aa39bf0bfe) | `` automatic update `` |
| [`b4426c42`](https://github.com/nix-community/NUR/commit/b4426c421095dc92f75c4ab5267d30092f4b8209) | `` automatic update `` |