### PR TITLE
chore(flake/nixpkgs): `5ed4e25a` -> `5b5be503`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1759143472,
-        "narHash": "sha256-TvODmeR2W7yX/JmOCmP+lAFNkTT7hAxYcF3Kz8SZV3w=",
+        "lastModified": 1759281824,
+        "narHash": "sha256-FIBE1qXv9TKvSNwst6FumyHwCRH3BlWDpfsnqRDCll0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ed4e25ab58fd4c028b59d5611e14ea64de51d23",
+        "rev": "5b5be50345d4113d04ba58c444348849f5585b4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`8a86ee57`](https://github.com/NixOS/nixpkgs/commit/8a86ee57d1a775f431648b022963204928994233) | `` stats: 2.11.54 -> 2.11.55 ``                                                   |
| [`fb344eb1`](https://github.com/NixOS/nixpkgs/commit/fb344eb10c17b00871719d3bb1fbd77f8237f78d) | `` firefox-bin-unwrapped: 143.0.1 -> 143.0.3 ``                                   |
| [`aee68f72`](https://github.com/NixOS/nixpkgs/commit/aee68f729591ad0980e82a44c8190f62e73241b2) | `` firefox-unwrapped: 143.0.1 -> 143.0.3 ``                                       |
| [`d912ecbe`](https://github.com/NixOS/nixpkgs/commit/d912ecbe2286704f91173e98dccd2cca66b33a79) | `` emacsPackages.cask: let cask use its own native compiled results ``            |
| [`ac7cb9a8`](https://github.com/NixOS/nixpkgs/commit/ac7cb9a8458cbd5084f8c6ed17d7a02689c155f3) | `` emacsPackages.cask: improve patch substitution ``                              |
| [`60e41baf`](https://github.com/NixOS/nixpkgs/commit/60e41baf4495dfa50821cec928ed9d0e8f2f160d) | `` emacsPackages.cask: 0.9.0 -> 0.9.1 ``                                          |
| [`f5e9a5e2`](https://github.com/NixOS/nixpkgs/commit/f5e9a5e247d63f93cd841f795e73d116e1b9540c) | `` emacsPackages.cask: fix import error and use non-vendored dependencies ``      |
| [`56003004`](https://github.com/NixOS/nixpkgs/commit/56003004c96dc87df4f4f8bad30a04794f811a3a) | `` emacsPackages.cask: replace install with installBin ``                         |
| [`62be9542`](https://github.com/NixOS/nixpkgs/commit/62be9542474461c872cf63b47f68c786aecf29b0) | `` freeipa: 4.12.4 -> 4.12.5 ``                                                   |
| [`d695254c`](https://github.com/NixOS/nixpkgs/commit/d695254ccb17b0ce7731a6568c26dd0820806dab) | `` pocket-casts: use electron_36 ``                                               |
| [`d638d7be`](https://github.com/NixOS/nixpkgs/commit/d638d7bec6fe1c17a774d5e4cbc6c9b9b1f97cd0) | `` pocket-casts: 0.10.3 -> 0.10.4 ``                                              |
| [`69929497`](https://github.com/NixOS/nixpkgs/commit/699294976b3dff26d03cca0d9cba07b7c3f2b084) | `` nexusmods-app:  0.16.4 → 0.17.2 ``                                             |
| [`8da8b6b3`](https://github.com/NixOS/nixpkgs/commit/8da8b6b3587324ce8a3146fb3fd038cdf712902f) | `` nexusmods-app: update games.json ``                                            |
| [`c69492dc`](https://github.com/NixOS/nixpkgs/commit/c69492dcb26ea04c8c106d4d3c942b716ee2fbc1) | `` nexusmods-app.gameHashes: ved4b249e2c35952c → v1a75cea1c1f2efc6 ``             |
| [`0ee2219a`](https://github.com/NixOS/nixpkgs/commit/0ee2219a0dd9fb445f4eb763f6f794d05eeffa15) | `` nexusmods-app: 0.15.2 → 0.16.4 ``                                              |
| [`2c9c4b7c`](https://github.com/NixOS/nixpkgs/commit/2c9c4b7cc1f8e3632aec55432ea783b0a3b0c691) | `` nexusmods-app: wrap the update scripts ``                                      |
| [`edc145b0`](https://github.com/NixOS/nixpkgs/commit/edc145b0d9c020547425fcbeb1da3fbe08ea6db0) | `` nexusmods-app: init update script for game_hashes_db ``                        |
| [`52c081e6`](https://github.com/NixOS/nixpkgs/commit/52c081e67747e3263af498395462f69b754567e7) | `` nexusmods-app: init update script for vendored files ``                        |
| [`5b42cda7`](https://github.com/NixOS/nixpkgs/commit/5b42cda70abad23a720989cfed57b1992287378c) | `` nexusmods-app: vendor games.json ``                                            |
| [`4e8436ca`](https://github.com/NixOS/nixpkgs/commit/4e8436ca5de1c5ccda708144434a21814397f569) | `` nexusmods-app: pin game hashes db ``                                           |
| [`a05d0746`](https://github.com/NixOS/nixpkgs/commit/a05d074627827caaef714511e228571d511e63c3) | `` nexusmods-app: use a fixed build date ``                                       |
| [`e5da9723`](https://github.com/NixOS/nixpkgs/commit/e5da972324a33b9096da84e6e514ba6191575f99) | `` nexusmods-app: 0.14.3 → 0.15.2 ``                                              |
| [`d3d0f0d7`](https://github.com/NixOS/nixpkgs/commit/d3d0f0d726ea91a267900c68961d357faaa2a766) | `` nexusmods-app: fix changelog URL ``                                            |
| [`44d61f41`](https://github.com/NixOS/nixpkgs/commit/44d61f414e7ea8ff0297cf893489533a1e972752) | `` stats: add iedame to maintainers ``                                            |
| [`97c574f4`](https://github.com/NixOS/nixpkgs/commit/97c574f47db9b80a2bc966f98fcf160806eb9ef7) | `` stats: 2.11.51 -> 2.11.54 ``                                                   |
| [`a10354e6`](https://github.com/NixOS/nixpkgs/commit/a10354e6ce422f7506de8600272b3513ba544cde) | `` radicle-node: 1.4.0 -> 1.5.0 ``                                                |
| [`1621b87d`](https://github.com/NixOS/nixpkgs/commit/1621b87d5cb29ffa8e2560fbfee08d6619fb5d84) | `` shogihome: 1.24.3 -> 1.25.0 ``                                                 |
| [`98b5a60b`](https://github.com/NixOS/nixpkgs/commit/98b5a60b56e9cd54ae18f9cda99620b527d2d5d1) | `` shogihome: 1.24.2 -> 1.24.3 ``                                                 |
| [`b6cbae32`](https://github.com/NixOS/nixpkgs/commit/b6cbae329933bca65c9abe8568d51c53874016d6) | `` shogihome: fix broken resource path on darwin ``                               |
| [`c342ba87`](https://github.com/NixOS/nixpkgs/commit/c342ba87197270ed6ff29d2de8ac7cba6c443f08) | `` shogihome: fix sandbox build on darwin ``                                      |
| [`e13056d8`](https://github.com/NixOS/nixpkgs/commit/e13056d8088c1160b315fa90c62486742151989f) | `` shogihome: 1.24.1 -> 1.24.2 ``                                                 |
| [`1eb11c24`](https://github.com/NixOS/nixpkgs/commit/1eb11c24fef84bb754e5de88e12f5793b6269f1b) | `` shogihome: 1.24.0 -> 1.24.1 ``                                                 |
| [`e26073d1`](https://github.com/NixOS/nixpkgs/commit/e26073d1e547ca32d54649517957d746bfb70e82) | `` shogihome: 1.23.2 -> 1.24.0 ``                                                 |
| [`e48098dd`](https://github.com/NixOS/nixpkgs/commit/e48098dd9c0acdd3b9439a0dcf6bbe05c2be0478) | `` shogihome: correct startupWMClass ``                                           |
| [`7dc66709`](https://github.com/NixOS/nixpkgs/commit/7dc66709c97a0737c116dfcafa886d5279b8a182) | `` shogihome: 1.23.0 -> 1.23.2 ``                                                 |
| [`3bc80be9`](https://github.com/NixOS/nixpkgs/commit/3bc80be92e389f24a8f6e84a8f66edfd4ec6637c) | `` shogihome: 1.22.1 -> 1.23.0 ``                                                 |
| [`3514ae00`](https://github.com/NixOS/nixpkgs/commit/3514ae00c5d8c47f4cfe4b153ba305ccb8c06344) | `` aliases: add trillium-next-* ``                                                |
| [`1b99b443`](https://github.com/NixOS/nixpkgs/commit/1b99b443642fa7d00471dc4d4c16e05e73926761) | `` trilium-desktop: 0.98.1 -> 0.99.0 ``                                           |
| [`7b9e5b75`](https://github.com/NixOS/nixpkgs/commit/7b9e5b75be9f52b5c9a9f27102fbda4e04722475) | `` trilium-desktop: 0.98.0 -> 0.98.1 ``                                           |
| [`9ae2626d`](https://github.com/NixOS/nixpkgs/commit/9ae2626ddc2b7383a6290b8314163d6ec302a42e) | `` trillium-{desktop,server}: 0.97.2 -> 0.98.0 ``                                 |
| [`07256832`](https://github.com/NixOS/nixpkgs/commit/0725683250261d3a5b29a32124cc3828e8dc3a2a) | `` trilium-next-desktop: 0.97.1 -> 0.97.2 ``                                      |
| [`bf326a60`](https://github.com/NixOS/nixpkgs/commit/bf326a60567c3b38f12f8d673e33cf1dc9fa135b) | `` trilium-next-{desktop, server}: 0.95.0 -> 0.97.1 ``                            |
| [`b37c24db`](https://github.com/NixOS/nixpkgs/commit/b37c24db987ac6705030d1c2c8fdacb1461b80fe) | `` trilium-next-{desktop,server}: 0.94.1 -> 0.95.0 ``                             |
| [`a7ef2752`](https://github.com/NixOS/nixpkgs/commit/a7ef2752d86b1427eddcd886e551ac8c3f393098) | `` trilium-next-{desktop,server}: 0.93.0 -> 0.94.1 ``                             |
| [`d49b5ff8`](https://github.com/NixOS/nixpkgs/commit/d49b5ff8f46788770abcb732ac38bfa431ca5d5e) | `` google-chrome: 140.0.7339.185 -> 140.0.7339.207 ``                             |
| [`1287b306`](https://github.com/NixOS/nixpkgs/commit/1287b306971e96d23f8d7886307f786ba476ffdc) | `` smtp4dev: 3.10.2 -> 3.10.3 ``                                                  |
| [`71d4acee`](https://github.com/NixOS/nixpkgs/commit/71d4acee4380214084502742eae5a70a1b254dd5) | `` python3Packages.oca-port: fix dependencies and build from source ``            |
| [`808884d8`](https://github.com/NixOS/nixpkgs/commit/808884d8ce28dcf44b22dee53c457385543f92bd) | `` python3Packages.giturlparse: init at 0.12.0 ``                                 |
| [`e50d57a2`](https://github.com/NixOS/nixpkgs/commit/e50d57a2a0d8dd5694c2d5d4830578145bf77258) | `` workflows/check: don't check github api for owners file ``                     |
| [`0c5608d5`](https://github.com/NixOS/nixpkgs/commit/0c5608d5192e94d0a943d4f19da0a396c9768ba9) | `` linuxKernel.kernels.linux_zen: 6.16.7 -> 6.16.9 ``                             |
| [`1ba162ae`](https://github.com/NixOS/nixpkgs/commit/1ba162aeee6678362506a29711092113df6696e3) | `` protonmail-desktop: 1.8.1 -> 1.9.0 ``                                          |
| [`9d1744a8`](https://github.com/NixOS/nixpkgs/commit/9d1744a80464572b55261a54e8f2829aab971b61) | `` aider-chat: fix flake8 invocation ``                                           |
| [`24be2701`](https://github.com/NixOS/nixpkgs/commit/24be27012cfc89f7dadc574d2e8f914ae2a26cba) | `` build(deps): bump cachix/install-nix-action from 31.6.2 to 31.7.0 ``           |
| [`6477a8f9`](https://github.com/NixOS/nixpkgs/commit/6477a8f90144006749aeadad350b3c659e41f594) | `` cherry-studio: 1.5.7 -> 1.5.11 ``                                              |
| [`158afffb`](https://github.com/NixOS/nixpkgs/commit/158afffbb3dfb2b95a5f0ddf7236aa3eb3fd6985) | `` cherry-studio: 1.5.6 -> 1.5.7 ``                                               |
| [`73f60c2e`](https://github.com/NixOS/nixpkgs/commit/73f60c2e5f8b9183be15981334944acf3b3a1f55) | `` cherry-studio: 1.5.5 -> 1.5.6 ``                                               |
| [`d2fd651b`](https://github.com/NixOS/nixpkgs/commit/d2fd651b3e42927e80c492fd3537cda4ae3adf45) | `` cherry-studio: 1.5.3 -> 1.5.5 ``                                               |
| [`146c949f`](https://github.com/NixOS/nixpkgs/commit/146c949fc9a5e5755b7d6c1d7974e4a7ed06950d) | `` cherry-studio: 1.4.8 -> 1.5.3 ``                                               |
| [`db9dbaad`](https://github.com/NixOS/nixpkgs/commit/db9dbaada7967ffc1523b0cccde3c429a2e5a708) | `` cherry-studio: pin electron_35 ``                                              |
| [`8c1a24c4`](https://github.com/NixOS/nixpkgs/commit/8c1a24c44cb6929122646450edf2ea36b2814451) | `` cherry-studio: 1.4.3 -> 1.4.8 ``                                               |
| [`7abe2a5e`](https://github.com/NixOS/nixpkgs/commit/7abe2a5e1df278881c581140b0ca2bee6e14d04d) | `` cherry-studio: 1.4.2 -> 1.4.3 ``                                               |
| [`db256ff3`](https://github.com/NixOS/nixpkgs/commit/db256ff35489d1f217910767ea2f182e26fc536b) | `` cherry-studio: 1.4.1 -> 1.4.2 ``                                               |
| [`578d6106`](https://github.com/NixOS/nixpkgs/commit/578d610680240aec01f4af52aab5d32471b111cf) | `` cherry-studio: 1.4.0 -> 1.4.1 ``                                               |
| [`1174c718`](https://github.com/NixOS/nixpkgs/commit/1174c718ba5e942454b1a749d63af5990acccdb4) | `` cherry-studio: 1.3.12 -> 1.4.0 ``                                              |
| [`0182b983`](https://github.com/NixOS/nixpkgs/commit/0182b983b58d77f481f5dcc05888a6c59159d17f) | `` cherry-studio: 1.3.9 -> 1.3.12 ``                                              |
| [`3bb5c764`](https://github.com/NixOS/nixpkgs/commit/3bb5c764c9b9b6e74eadf4b64a3eca7aa3fc8199) | `` cherry-studio: 1.3.8 -> 1.3.9 ``                                               |
| [`8b5f7fdc`](https://github.com/NixOS/nixpkgs/commit/8b5f7fdcb2dc8ce0f8901a7b326834b686c00c63) | `` cherry-studio: 1.3.4 -> 1.3.8 ``                                               |
| [`b8cb1166`](https://github.com/NixOS/nixpkgs/commit/b8cb1166effe6b0c0069fad501a02b32f0ebd1e6) | `` metal-cli: 0.26.0 -> 0.26.1 ``                                                 |
| [`03bd02b6`](https://github.com/NixOS/nixpkgs/commit/03bd02b6bf197a9522a60b5124fa438ccd9a6918) | `` ed-odyssey-materials-helper: 2.255 -> 3.0.1 ``                                 |
| [`f50b99d1`](https://github.com/NixOS/nixpkgs/commit/f50b99d191729599eb841ae4341876e8726fbd3d) | `` warp-terminal: 0.2025.09.03.08.11.stable_03 -> 0.2025.09.10.08.11.stable_01 `` |
| [`1b9531a9`](https://github.com/NixOS/nixpkgs/commit/1b9531a931b7509e645fee0572b21318424972e3) | `` palemoon-bin: 33.8.2 -> 33.9.0.1 ``                                            |
| [`316d1269`](https://github.com/NixOS/nixpkgs/commit/316d1269b882c9d5965ed6da8ffb7eeab99ac44b) | `` element-desktop: fix taskbar icon on KDE Plasma ``                             |
| [`fd31fbcf`](https://github.com/NixOS/nixpkgs/commit/fd31fbcfb0feae2d6f961daf9268c4adb4628322) | `` proton-ge-bin: GE-Proton10-16 -> GE-Proton10-17 ``                             |
| [`9be432fa`](https://github.com/NixOS/nixpkgs/commit/9be432fadb082ee6cb6909c5c1ba6364552fd95b) | `` shadps4: 0.10.0 -> 0.11.0 ``                                                   |
| [`f63f114d`](https://github.com/NixOS/nixpkgs/commit/f63f114dbc2ab36465ee7fb415f99e9f47296702) | `` xbyak: 7.29.2 -> 7.30 ``                                                       |
| [`593aed16`](https://github.com/NixOS/nixpkgs/commit/593aed167fbddd52ef27dac752131c4c0943c31d) | `` xbyak: 7.28 -> 7.29.2 ``                                                       |
| [`6263cd3d`](https://github.com/NixOS/nixpkgs/commit/6263cd3d3ce3d027ceaf4214454134c332d6eb03) | `` xbyak: init at 7.28 ``                                                         |
| [`d584f447`](https://github.com/NixOS/nixpkgs/commit/d584f447fb1fc427164f71072b765de7247635e7) | `` mprisence: 1.2.6 -> 1.2.7 ``                                                   |
| [`0caf6e3e`](https://github.com/NixOS/nixpkgs/commit/0caf6e3e1795d88740dd0378ffdc1e2bd679d4eb) | `` thunderbird-esr-bin-unwrapped: 140.2.1esr -> 140.3.0esr ``                     |
| [`a719dc16`](https://github.com/NixOS/nixpkgs/commit/a719dc16ed855d315376dbfab8f96331dbee73b6) | `` protonmail-desktop: 1.8.0 -> 1.8.1 ``                                          |
| [`a9d1d96c`](https://github.com/NixOS/nixpkgs/commit/a9d1d96cb1c45e88979d88343481a0284a988047) | `` python3Packages.yara-x: 1.5.0 -> 1.6.0 ``                                      |
| [`579f3883`](https://github.com/NixOS/nixpkgs/commit/579f3883d6c364858a410526cf6298f44403d4ab) | `` librewolf-unwrapped: 142.0.1-1 -> 143.0-1 ``                                   |
| [`0cdab8cd`](https://github.com/NixOS/nixpkgs/commit/0cdab8cdfe85cc3aac060e2853fb83655c1a90d8) | `` ceph: 19.2.2 -> 19.2.3 ``                                                      |