### PR TITLE
chore(flake/nur): `28e7ada0` -> `f5016fa5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759351338,
-        "narHash": "sha256-jR9shQ9t9Xd6tKTXMAMgRt8xvXfu6s+Dm1mvwxujKDk=",
+        "lastModified": 1759367989,
+        "narHash": "sha256-va7mbyf1FE+QUHJwo39yYEXK/yj2RkidWWI0JcanPMU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "28e7ada07b589d429d25adb190e582af537c9a53",
+        "rev": "f5016fa5fdf6d313246c676c32dac97c060d2a8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                                  |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`f5016fa5`](https://github.com/nix-community/NUR/commit/f5016fa5fdf6d313246c676c32dac97c060d2a8d) | `` automatic update ``                                                   |
| [`83ba90e4`](https://github.com/nix-community/NUR/commit/83ba90e41efc8e596dd4f7bc76f6f2d8e11b54ff) | `` automatic update ``                                                   |
| [`e5996a32`](https://github.com/nix-community/NUR/commit/e5996a324a35e040241c9219e048a154175c2040) | `` Should fix https://github.com/nix-community/nur-combined/issues/41 `` |