### PR TITLE
chore(flake/nur): `052c7bb8` -> `2bad60fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759386743,
-        "narHash": "sha256-eDRiYUgfwxnT9rOfRkuGF0ZF/8x086zn8BgXLG4Nfnk=",
+        "lastModified": 1759396440,
+        "narHash": "sha256-b5pTZOz+Y3kY5fEh27agxcRNmPmSUY73dqK/KF3M1yY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "052c7bb8cf7c86cb351e2f325dbbe9c509d985c3",
+        "rev": "2bad60faf2b39a4a1f9b6a335c29f3f028d3c7eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2bad60fa`](https://github.com/nix-community/NUR/commit/2bad60faf2b39a4a1f9b6a335c29f3f028d3c7eb) | `` automatic update `` |
| [`a84d50bd`](https://github.com/nix-community/NUR/commit/a84d50bd227d008a86fc5f7c59ab4c873fe5d589) | `` automatic update `` |
| [`205a398c`](https://github.com/nix-community/NUR/commit/205a398c6facb20d15d7f568d3617158fadd3d3a) | `` automatic update `` |
| [`4f173127`](https://github.com/nix-community/NUR/commit/4f17312701a9294493444e84f1bbbf1c3538a13c) | `` automatic update `` |
| [`20970503`](https://github.com/nix-community/NUR/commit/20970503f4ef46a2a1b76d5fb97b6c808a2a6a86) | `` automatic update `` |
| [`2bb640b3`](https://github.com/nix-community/NUR/commit/2bb640b3b1d81caee162e84b51ec42c07c9450d3) | `` automatic update `` |
| [`40d8ddc5`](https://github.com/nix-community/NUR/commit/40d8ddc5efa19aa4ab9420e3ccc9a9bd86d41ff3) | `` automatic update `` |