### PR TITLE
chore(flake/nur): `2bad60fa` -> `cf3f8ffd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759396440,
-        "narHash": "sha256-b5pTZOz+Y3kY5fEh27agxcRNmPmSUY73dqK/KF3M1yY=",
+        "lastModified": 1759405377,
+        "narHash": "sha256-PRPqYvBWshMz30TEEdXEYponzlnWRHknmzaaPV/yKRE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2bad60faf2b39a4a1f9b6a335c29f3f028d3c7eb",
+        "rev": "cf3f8ffdb75bb2021b8b9ddba3e54e9095cf4b48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cf3f8ffd`](https://github.com/nix-community/NUR/commit/cf3f8ffdb75bb2021b8b9ddba3e54e9095cf4b48) | `` automatic update `` |
| [`02ee9839`](https://github.com/nix-community/NUR/commit/02ee9839d98a5016c204180460cfa3b476a5cbf8) | `` automatic update `` |
| [`507f3337`](https://github.com/nix-community/NUR/commit/507f3337de24fe408aab514359e7247a1818c4a4) | `` automatic update `` |
| [`cffda530`](https://github.com/nix-community/NUR/commit/cffda530132745e1e55882ccc6ec5ad60dfad7e0) | `` automatic update `` |