### PR TITLE
chore(flake/nur): `7d2d5b7f` -> `27b7f767`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759410446,
-        "narHash": "sha256-IuzzxubrrirbHMdlDAmtf8pZQvgFhIpZHKXl5c4GWuM=",
+        "lastModified": 1759423848,
+        "narHash": "sha256-//heULoEN59JNrFOINnHbvZnPWHpp8WeFOYg3u68YvY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7d2d5b7f6c4dbe3c5ba579a81e7fd27dc2e13c05",
+        "rev": "27b7f7675b3a09af7888e8bfa3071bd87b835a75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                            |
| -------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`27b7f767`](https://github.com/nix-community/NUR/commit/27b7f7675b3a09af7888e8bfa3071bd87b835a75) | `` automatic update ``             |
| [`0132754c`](https://github.com/nix-community/NUR/commit/0132754c9de1061ea1e395459e0be3dca5bb2e74) | `` automatic update ``             |
| [`621c0133`](https://github.com/nix-community/NUR/commit/621c01330499e0ec6580a7ef3a56dc8884c1c335) | `` Globally disable LFS locking `` |