### PR TITLE
chore(flake/nur): `360074c0` -> `209f6d87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "lastModified": 1759381078,
+        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759437092,
-        "narHash": "sha256-r8oYSq3RkCJLd8WYjnfk7sAmnjfMq/TAtta2uB/SnMI=",
+        "lastModified": 1759455582,
+        "narHash": "sha256-uwN5gKJ257/2+xULANcFGT47tjh1hkvuCtqtXhiTEj4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "360074c0ace6fe90a4f48abab8e5c9d70e4eb72e",
+        "rev": "209f6d87a39a790847343f55471f6238b88dcf26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`209f6d87`](https://github.com/nix-community/NUR/commit/209f6d87a39a790847343f55471f6238b88dcf26) | `` automatic update `` |
| [`b5b05675`](https://github.com/nix-community/NUR/commit/b5b056750117ab68fe911174cee9e1e656650064) | `` automatic update `` |
| [`62b197c6`](https://github.com/nix-community/NUR/commit/62b197c6bfd4e2f6ff6a94a8221c5d1f5308ef9a) | `` automatic update `` |
| [`6dca1435`](https://github.com/nix-community/NUR/commit/6dca1435284b181fe1f02a6fd2a3e1a0e48912a2) | `` automatic update `` |
| [`0d5fd8f0`](https://github.com/nix-community/NUR/commit/0d5fd8f00e9142e9e2c4761221a1f1944d703a5d) | `` automatic update `` |