### PR TITLE
chore(flake/nur): `209f6d87` -> `37ca70b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759455582,
-        "narHash": "sha256-uwN5gKJ257/2+xULANcFGT47tjh1hkvuCtqtXhiTEj4=",
+        "lastModified": 1759460952,
+        "narHash": "sha256-52IEeVjH/TNXAc3xKEJO9W17/VK9Z0tVD0BRQV5vzGQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "209f6d87a39a790847343f55471f6238b88dcf26",
+        "rev": "37ca70b7f051080f35c068b4d7b8db84eb03eaa7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`37ca70b7`](https://github.com/nix-community/NUR/commit/37ca70b7f051080f35c068b4d7b8db84eb03eaa7) | `` automatic update `` |
| [`2b96b86a`](https://github.com/nix-community/NUR/commit/2b96b86a17bf6c00b3af2faec10be383be2db7dd) | `` automatic update `` |
| [`4eb59ad2`](https://github.com/nix-community/NUR/commit/4eb59ad283cfa94ef0d3cbbe460c2f74b568991a) | `` automatic update `` |
| [`cbdd606b`](https://github.com/nix-community/NUR/commit/cbdd606b255b0654ae00befebd56ac8b0a59f9b4) | `` automatic update `` |