### PR TITLE
chore(flake/nur): `37ca70b7` -> `74b574ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759460952,
-        "narHash": "sha256-52IEeVjH/TNXAc3xKEJO9W17/VK9Z0tVD0BRQV5vzGQ=",
+        "lastModified": 1759470643,
+        "narHash": "sha256-WqDn4FT0bNQ3p8AjtM/ddO4//Ln5Nde51FmuuFs1GHI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "37ca70b7f051080f35c068b4d7b8db84eb03eaa7",
+        "rev": "74b574ed94de7e324ec15bcfa432f28e398b5ad2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`74b574ed`](https://github.com/nix-community/NUR/commit/74b574ed94de7e324ec15bcfa432f28e398b5ad2) | `` automatic update `` |
| [`924e2856`](https://github.com/nix-community/NUR/commit/924e285632da281132a7b8528c21e4e17cc54b31) | `` automatic update `` |
| [`187c3cd0`](https://github.com/nix-community/NUR/commit/187c3cd095d223e4f0236ae4b46778ffb662e234) | `` automatic update `` |