### PR TITLE
chore(flake/nur): `74b574ed` -> `79f74235`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759470643,
-        "narHash": "sha256-WqDn4FT0bNQ3p8AjtM/ddO4//Ln5Nde51FmuuFs1GHI=",
+        "lastModified": 1759481427,
+        "narHash": "sha256-XmFcvW1Rz+Qy/+gWFWji+QcQTGkCbIxi0p11SI+PTc4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "74b574ed94de7e324ec15bcfa432f28e398b5ad2",
+        "rev": "79f74235d46273e3e85c8db65215eae4c1a60a38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`79f74235`](https://github.com/nix-community/NUR/commit/79f74235d46273e3e85c8db65215eae4c1a60a38) | `` automatic update `` |
| [`1d38cb6e`](https://github.com/nix-community/NUR/commit/1d38cb6e7f916b7a31f4d8ef1995ba9fbaf93380) | `` automatic update `` |
| [`710020b2`](https://github.com/nix-community/NUR/commit/710020b24e452e9c55a03314dd8583df28e68c03) | `` automatic update `` |