### PR TITLE
chore(flake/nur): `79f74235` -> `e292c9bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759481427,
-        "narHash": "sha256-XmFcvW1Rz+Qy/+gWFWji+QcQTGkCbIxi0p11SI+PTc4=",
+        "lastModified": 1759496802,
+        "narHash": "sha256-l/scfqEIOfru2SKTY3ORPIHPjiDtwi1uk2A/RBqNYNM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "79f74235d46273e3e85c8db65215eae4c1a60a38",
+        "rev": "e292c9bb58d0e09b686d5a6835d24444ea3819d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e292c9bb`](https://github.com/nix-community/NUR/commit/e292c9bb58d0e09b686d5a6835d24444ea3819d6) | `` automatic update `` |
| [`06df014f`](https://github.com/nix-community/NUR/commit/06df014f1ca12e064f3f4b4bb4b54fe30d6c3f51) | `` automatic update `` |
| [`6d5935af`](https://github.com/nix-community/NUR/commit/6d5935af0f29a31efe6be997c48d02aef4bd87dc) | `` automatic update `` |
| [`e14a90ff`](https://github.com/nix-community/NUR/commit/e14a90ffeaca1bb5ef04a5ab25f3b3b5ffe29384) | `` automatic update `` |
| [`1a26ccba`](https://github.com/nix-community/NUR/commit/1a26ccba259dbf1e8cc333179fab911c31ffab6f) | `` automatic update `` |
| [`58ed6fc0`](https://github.com/nix-community/NUR/commit/58ed6fc09dc11580c2f875cff9cc4d03015ae1ae) | `` automatic update `` |