### PR TITLE
chore(flake/nur): `e292c9bb` -> `9568f38f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759496802,
-        "narHash": "sha256-l/scfqEIOfru2SKTY3ORPIHPjiDtwi1uk2A/RBqNYNM=",
+        "lastModified": 1759509816,
+        "narHash": "sha256-8PXMQqF3z9Na+faYOmMd55B2lXxim0AnhO8jCSIf6sc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e292c9bb58d0e09b686d5a6835d24444ea3819d6",
+        "rev": "9568f38ff4695a32aeb2b7ed9c6ae4fa691522a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9568f38f`](https://github.com/nix-community/NUR/commit/9568f38ff4695a32aeb2b7ed9c6ae4fa691522a2) | `` automatic update `` |
| [`c7efa84d`](https://github.com/nix-community/NUR/commit/c7efa84d747fb3949e4a19f30c10c7ad09bee7da) | `` automatic update `` |