### PR TITLE
chore(flake/nur): `d9836c7a` -> `b2b1349a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759523908,
-        "narHash": "sha256-V821wcMS1IrLFp2golmWZ2Oe3ae7XMxLRy8ZSxRGHYc=",
+        "lastModified": 1759527694,
+        "narHash": "sha256-fuQw+vP25GSQxPKTPAHZBUXuoFeN9dCTwfJxEv5sv0Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d9836c7ad552dd7e2c81477482f30103588157bd",
+        "rev": "b2b1349ad22d5ba62a3e069e9a3745f40fbb9203",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                      |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`b2b1349a`](https://github.com/nix-community/NUR/commit/b2b1349ad22d5ba62a3e069e9a3745f40fbb9203) | `` automatic update ``                       |
| [`a5dd0f24`](https://github.com/nix-community/NUR/commit/a5dd0f24eb9be5eaeb478ab90ec14caf5619d276) | `` Revert "add aciceri repository" (#991) `` |