### PR TITLE
chore(flake/nur): `b2b1349a` -> `d127643d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759527694,
-        "narHash": "sha256-fuQw+vP25GSQxPKTPAHZBUXuoFeN9dCTwfJxEv5sv0Y=",
+        "lastModified": 1759547999,
+        "narHash": "sha256-bsay8uQPcptK18VjM7/jtVs453A0kBH8mvKDpsAJa7Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b2b1349ad22d5ba62a3e069e9a3745f40fbb9203",
+        "rev": "d127643d50ec16f47ca67c9695b0200ea8b7cfd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d127643d`](https://github.com/nix-community/NUR/commit/d127643d50ec16f47ca67c9695b0200ea8b7cfd1) | `` automatic update `` |
| [`5dbae21c`](https://github.com/nix-community/NUR/commit/5dbae21c11207f455b8cf1af805906f0a824248c) | `` automatic update `` |
| [`5fdc3105`](https://github.com/nix-community/NUR/commit/5fdc3105c6ca941271688712de8c1e1a0169d6f9) | `` automatic update `` |