### PR TITLE
chore(flake/nur): `d127643d` -> `61d31b6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759547999,
-        "narHash": "sha256-bsay8uQPcptK18VjM7/jtVs453A0kBH8mvKDpsAJa7Q=",
+        "lastModified": 1759552423,
+        "narHash": "sha256-cQEfMFDfZKcWivNWeEd2yslf0uPB8cjjXwe0U5fSsiM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d127643d50ec16f47ca67c9695b0200ea8b7cfd1",
+        "rev": "61d31b6dae9b9c16d484bd20648e85e406d68c89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`61d31b6d`](https://github.com/nix-community/NUR/commit/61d31b6dae9b9c16d484bd20648e85e406d68c89) | `` automatic update `` |
| [`ab0765f0`](https://github.com/nix-community/NUR/commit/ab0765f03321b476be226124cf6b76a89b9dadb3) | `` automatic update `` |
| [`582dab08`](https://github.com/nix-community/NUR/commit/582dab088bef587d7caba6c675a47b361304b9cc) | `` automatic update `` |