### PR TITLE
chore(flake/nixpkgs): `5b5be503` -> `879bd460`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1759281824,
-        "narHash": "sha256-FIBE1qXv9TKvSNwst6FumyHwCRH3BlWDpfsnqRDCll0=",
+        "lastModified": 1759439645,
+        "narHash": "sha256-oiAyQaRilPk525Z5aTtTNWNzSrcdJ7IXM0/PL3CGlbI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b5be50345d4113d04ba58c444348849f5585b4a",
+        "rev": "879bd460b3d3e8571354ce172128fbcbac1ed633",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`77afcc96`](https://github.com/NixOS/nixpkgs/commit/77afcc96d3503d4b3589d8c97add4add05d0ebb4) | `` ungoogled-chromium: 140.0.7339.207-1 -> 141.0.7390.54-1 ``                        |
| [`6d17b758`](https://github.com/NixOS/nixpkgs/commit/6d17b758be6b8484302f6e1d87a1cedd56f8abc5) | `` synapse-admin-etkecc: 0.11.1-etke47 -> 0.11.1-etke48 ``                           |
| [`47f7ddcb`](https://github.com/NixOS/nixpkgs/commit/47f7ddcbb9bdd18d33358019e553bc2af3da7054) | `` linux/common-config: enable nice things for 6.17 ``                               |
| [`b6391aca`](https://github.com/NixOS/nixpkgs/commit/b6391aca3ae9be36c771e52a7b4640b6d24c5f47) | `` linux_5_4: 5.4.299 -> 5.4.300 ``                                                  |
| [`208425ad`](https://github.com/NixOS/nixpkgs/commit/208425add2157d5de2cc76b23de712ffe6b7ccab) | `` linux_5_10: 5.10.244 -> 5.10.245 ``                                               |
| [`46891360`](https://github.com/NixOS/nixpkgs/commit/468913609689386f332286432ebdefc30ce7b70d) | `` linux_5_15: 5.15.193 -> 5.15.194 ``                                               |
| [`e6e44c53`](https://github.com/NixOS/nixpkgs/commit/e6e44c53694d7f502f53a17a513f7244f0c79128) | `` linux_6_1: 6.1.154 -> 6.1.155 ``                                                  |
| [`7a11ab2d`](https://github.com/NixOS/nixpkgs/commit/7a11ab2d6a63ec0fb78c403d9877ea0cf1490627) | `` linux_6_6: 6.6.108 -> 6.6.109 ``                                                  |
| [`200ce171`](https://github.com/NixOS/nixpkgs/commit/200ce171dd8afbdd8c0e4902b140ae0227cbd530) | `` linux_6_12: 6.12.49 -> 6.12.50 ``                                                 |
| [`63786a63`](https://github.com/NixOS/nixpkgs/commit/63786a6337e126fbf45998ba85a04c023c8944f5) | `` linux_6_16: 6.16.9 -> 6.16.10 ``                                                  |
| [`bf1a65b3`](https://github.com/NixOS/nixpkgs/commit/bf1a65b333007922184f6fbabc2af5eb2e5edf72) | `` linux_6_17: init at 6.17 ``                                                       |
| [`db0d1175`](https://github.com/NixOS/nixpkgs/commit/db0d1175e41b563b1f31ae1d2e44fb9f0a246a81) | `` protonmail-desktop: 1.9.0 -> 1.9.1 ``                                             |
| [`e0b5f828`](https://github.com/NixOS/nixpkgs/commit/e0b5f8286b5da6cad09e493d69df7a52a2cf0654) | `` python3Packages.django_5: 5.1.12 -> 5.1.13 ``                                     |
| [`b54f9a82`](https://github.com/NixOS/nixpkgs/commit/b54f9a82c3e1172f594f79a505ccb1f189a69daf) | `` mediamate: init at 3.8.2-316 ``                                                   |
| [`5cec7a46`](https://github.com/NixOS/nixpkgs/commit/5cec7a4619daf45af5dcf87dfb700b05ac9557ce) | `` chromium,chromedriver: 140.0.7339.207 -> 141.0.7390.54 ``                         |
| [`f88bb1c2`](https://github.com/NixOS/nixpkgs/commit/f88bb1c2680d06ef2137a7835af313e594cc0a5f) | `` chromium: remove redundant `run_mksnapshot_default` build target ``               |
| [`e121e143`](https://github.com/NixOS/nixpkgs/commit/e121e14311ec0839b51acfb52bfcc024f3cab3f1) | `` mozillavpn: 2.31.0 -> 2.31.1 ``                                                   |
| [`f52a151e`](https://github.com/NixOS/nixpkgs/commit/f52a151e628d6d9b9d5202e94682344631cbe161) | `` librewolf-unwrapped: 143.0-1 -> 143.0.3-1 ``                                      |
| [`c184119b`](https://github.com/NixOS/nixpkgs/commit/c184119b075ff189ca8381354f1cd0c3bc335443) | `` nextcloud-notify_push: 1.1.0 -> 1.2.0 ``                                          |
| [`4f363a4f`](https://github.com/NixOS/nixpkgs/commit/4f363a4fa706d1ac8467573956bd7318fd110b70) | `` nodePackages_latest.nodejs: 24.8.0 -> 24.9.0 ``                                   |
| [`f61198b0`](https://github.com/NixOS/nixpkgs/commit/f61198b04b8a0a50024cbfe8824e2e4ef902c291) | `` electron-source.electron_38: 38.1.2 -> 38.2.0 ``                                  |
| [`bd158cfd`](https://github.com/NixOS/nixpkgs/commit/bd158cfd638769531c7e77f7849490d7d17cd9eb) | `` electron-source.electron_37: 37.5.1 -> 37.6.0 ``                                  |
| [`61ae28c5`](https://github.com/NixOS/nixpkgs/commit/61ae28c55cf35f406a94466e86802501e9072915) | `` electron-source.electron_36: 36.9.1 -> 36.9.2 ``                                  |
| [`4962fdaf`](https://github.com/NixOS/nixpkgs/commit/4962fdaf46ec7eddc414b72c7dcef8827b7d399b) | `` electron-chromedriver_38: 38.1.2 -> 38.2.0 ``                                     |
| [`4e3aa4b4`](https://github.com/NixOS/nixpkgs/commit/4e3aa4b4f33bcdd72a787aa0a88f4b4be9178d3c) | `` electron_38-bin: 38.1.2 -> 38.2.0 ``                                              |
| [`964f0bf6`](https://github.com/NixOS/nixpkgs/commit/964f0bf6299cd493390c27c24fd723c47ed09d93) | `` electron-chromedriver_37: 37.5.1 -> 37.6.0 ``                                     |
| [`62883b67`](https://github.com/NixOS/nixpkgs/commit/62883b673fa9a605dc985fc018ae9e03eb39645d) | `` electron_37-bin: 37.5.1 -> 37.6.0 ``                                              |
| [`964fe819`](https://github.com/NixOS/nixpkgs/commit/964fe8192257e37325d4c0793a583219dbe865b2) | `` electron-chromedriver_36: 36.9.1 -> 36.9.2 ``                                     |
| [`508f93c7`](https://github.com/NixOS/nixpkgs/commit/508f93c7419cfa603a7d91aec25706b5e2e75d04) | `` electron_36-bin: 36.9.1 -> 36.9.2 ``                                              |
| [`40fb07d4`](https://github.com/NixOS/nixpkgs/commit/40fb07d4c7ffece51a5aa9711c5b847545995108) | `` linux/common-config: only enable BCACHEFS things between versions 6.7 and 6.17 `` |
| [`bad25377`](https://github.com/NixOS/nixpkgs/commit/bad2537732dd95b65b1748a0dd61cb8ba0597b9c) | `` fastcdr: 2.3.1 -> 2.3.2 ``                                                        |
| [`ae4bf390`](https://github.com/NixOS/nixpkgs/commit/ae4bf390364e7a11bdc6b4d11a071472244e4140) | `` mmctl: 10.5.10 -> 10.5.11 ``                                                      |
| [`08f7a4a6`](https://github.com/NixOS/nixpkgs/commit/08f7a4a6141792130b3335afb8093b801476b052) | `` ruby_3_4: 3.4.5 -> 3.4.6 ``                                                       |
| [`1d3002d9`](https://github.com/NixOS/nixpkgs/commit/1d3002d9336da6fd4b4b370deb15ca660000cf3f) | `` ente-desktop: bump to electron_37 ``                                              |
| [`3c11ef33`](https://github.com/NixOS/nixpkgs/commit/3c11ef33ed2c5ddafde2bd301909a8b7cfd64f5c) | `` ente-desktop: 1.7.11 -> 1.7.14 (#427695) ``                                       |
| [`f2af9702`](https://github.com/NixOS/nixpkgs/commit/f2af9702a37c89954a3be1b32d1d946cc6930316) | `` firefox-devedition-unwrapped: 144.0b1 -> 144.0b4 ``                               |
| [`2f20d9e9`](https://github.com/NixOS/nixpkgs/commit/2f20d9e959b5899a4246ff8cda457bbf84a44011) | `` firefox-beta-unwrapped: 144.0b1 -> 144.0b4 ``                                     |
| [`1250259d`](https://github.com/NixOS/nixpkgs/commit/1250259ded26a899ecfd23f373bbc4d5f1a492e9) | `` thunderbird-latest-unwrapped: 143.0 -> 143.0.1 ``                                 |
| [`17c503b1`](https://github.com/NixOS/nixpkgs/commit/17c503b1a6b379bb0ab5e6893e599aa9793cffe1) | `` devenv: 1.8.2 -> 1.9 ``                                                           |