### PR TITLE
chore(flake/nur): `fc4bde0d` -> `fc81e15b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759562581,
-        "narHash": "sha256-Ws/2AeBPNO0rKZClWMZGHzpYYxvzipkQe0Uv0bRcYDM=",
+        "lastModified": 1759578289,
+        "narHash": "sha256-w6+mGGDG1x6SdUfp3g2n2wHDBQFKKd861Nr63BwE0nY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc4bde0d1bbd11352fd7836af54e56573f6649e6",
+        "rev": "fc81e15b9422a3457f8b0cb4d8c9a2fc2876fce6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc81e15b`](https://github.com/nix-community/NUR/commit/fc81e15b9422a3457f8b0cb4d8c9a2fc2876fce6) | `` automatic update `` |
| [`8a83e7c7`](https://github.com/nix-community/NUR/commit/8a83e7c7dfbf5367a38a659b983cad26a0fb6a96) | `` automatic update `` |