### PR TITLE
chore(flake/nur): `fc81e15b` -> `86934671`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759578289,
-        "narHash": "sha256-w6+mGGDG1x6SdUfp3g2n2wHDBQFKKd861Nr63BwE0nY=",
+        "lastModified": 1759602114,
+        "narHash": "sha256-2f73FPZe8xKtZanTWlfKHLqp9zsnenbw4qU/xA2M2AE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc81e15b9422a3457f8b0cb4d8c9a2fc2876fce6",
+        "rev": "869346716f2f0cdebb5c3f9c365e3c104a534244",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`86934671`](https://github.com/nix-community/NUR/commit/869346716f2f0cdebb5c3f9c365e3c104a534244) | `` automatic update `` |
| [`c95772f7`](https://github.com/nix-community/NUR/commit/c95772f7420e4710a497ec8d3f140d40d09d40e8) | `` automatic update `` |
| [`38a31b21`](https://github.com/nix-community/NUR/commit/38a31b2183210fe4aebf48c232ed89cc624456d5) | `` automatic update `` |