### PR TITLE
chore(flake/nur): `86934671` -> `8ee29d1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759602114,
-        "narHash": "sha256-2f73FPZe8xKtZanTWlfKHLqp9zsnenbw4qU/xA2M2AE=",
+        "lastModified": 1759610174,
+        "narHash": "sha256-dDLcJ7wZHJlmkUEobEVAm3GwDh2wt29W+cbRVDC9+Ig=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "869346716f2f0cdebb5c3f9c365e3c104a534244",
+        "rev": "8ee29d1a8b173400433e46c9db4cd0bcbfc18965",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8ee29d1a`](https://github.com/nix-community/NUR/commit/8ee29d1a8b173400433e46c9db4cd0bcbfc18965) | `` automatic update `` |
| [`9ddd76bb`](https://github.com/nix-community/NUR/commit/9ddd76bbee915f27a01f8eaea49d544ffc73f83f) | `` automatic update `` |
| [`7faf3839`](https://github.com/nix-community/NUR/commit/7faf3839d126d4aa40f85f8e64cfbdfb8d760089) | `` automatic update `` |