### PR TITLE
chore(flake/nur): `8ee29d1a` -> `762122c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759610174,
-        "narHash": "sha256-dDLcJ7wZHJlmkUEobEVAm3GwDh2wt29W+cbRVDC9+Ig=",
+        "lastModified": 1759627271,
+        "narHash": "sha256-q3MvNDVGsZXM66zRUQiiiL8mp8U7eY31ZhkOylrFJXw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8ee29d1a8b173400433e46c9db4cd0bcbfc18965",
+        "rev": "762122c9c8adb62c96a53536322a061fdfa8b5d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`762122c9`](https://github.com/nix-community/NUR/commit/762122c9c8adb62c96a53536322a061fdfa8b5d6) | `` automatic update `` |
| [`2edcb08c`](https://github.com/nix-community/NUR/commit/2edcb08c08b541088834d35cf560601038b3c3a2) | `` automatic update `` |