### PR TITLE
chore(flake/nixpkgs): `879bd460` -> `3bcc93c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1759439645,
-        "narHash": "sha256-oiAyQaRilPk525Z5aTtTNWNzSrcdJ7IXM0/PL3CGlbI=",
+        "lastModified": 1759580034,
+        "narHash": "sha256-YWo57PL7mGZU7D4WeKFMiW4ex/O6ZolUS6UNBHTZfkI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "879bd460b3d3e8571354ce172128fbcbac1ed633",
+        "rev": "3bcc93c5f7a4b30335d31f21e2f1281cba68c318",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`3a8446a6`](https://github.com/NixOS/nixpkgs/commit/3a8446a6455415d070b1a985595f4ebcfa4aff89) | `` linux_xanmod_latest: 6.16.9 -> 6.16.10 ``                                                 |
| [`7c040a85`](https://github.com/NixOS/nixpkgs/commit/7c040a858db223d850b4528fff5fc202f6068f67) | `` linux_xanmod: 6.12.49 -> 6.12.50 ``                                                       |
| [`cfff627c`](https://github.com/NixOS/nixpkgs/commit/cfff627c8bf44fc2a9b836cea637ec3aba775aab) | `` python3Packages.cfn-lint: skip failing tests ``                                           |
| [`e689460e`](https://github.com/NixOS/nixpkgs/commit/e689460ed60803d55588ac0a9202a17c7ea6fd4d) | `` grafana: 12.0.4 -> 12.0.5 ``                                                              |
| [`294a9fcb`](https://github.com/NixOS/nixpkgs/commit/294a9fcbfb83f9eeb50d6b6988b3839a3a4c5f48) | `` php84: 8.4.12 -> 8.4.13 ``                                                                |
| [`0aefc8b2`](https://github.com/NixOS/nixpkgs/commit/0aefc8b224e7e264e641a53162932a148b4ef8e9) | `` python313Packages.nvchecker: modernize ``                                                 |
| [`7c4f7085`](https://github.com/NixOS/nixpkgs/commit/7c4f7085fad59f2495961879ffb1ebb91d4c6b18) | `` python3Packages.nvchecker: 2.18 -> 2.19 ``                                                |
| [`1c60bfc7`](https://github.com/NixOS/nixpkgs/commit/1c60bfc73d38dac689436ea4c59dc87863af5994) | `` unftp: init at 0.15.1 ``                                                                  |
| [`e8897dd5`](https://github.com/NixOS/nixpkgs/commit/e8897dd5772a6e51c8effffe4f555e37fa70f9ec) | `` php83: 8.3.25 -> 8.3.26 ``                                                                |
| [`0199bf34`](https://github.com/NixOS/nixpkgs/commit/0199bf343218d2315d354105b5925cbf757d94c4) | `` google-chrome: 140.0.7339.207 -> 141.0.7390.54 ``                                         |
| [`4a126a1c`](https://github.com/NixOS/nixpkgs/commit/4a126a1c6ff0005b9bb4644eaffe3226dce2abf4) | `` matrix-synapse: 1.138.2 -> 1.139.0 ``                                                     |
| [`a64d8c06`](https://github.com/NixOS/nixpkgs/commit/a64d8c06b4d0d6ff3d5a5dc29ee56d7df0dde32f) | `` joplin-desktop: explicitly add darwin to platforms ``                                     |
| [`b494d517`](https://github.com/NixOS/nixpkgs/commit/b494d5170acf705bd9eb98875665e4dd14c0e178) | `` libressl_3_9: remove unsupported package ``                                               |
| [`545e9b4c`](https://github.com/NixOS/nixpkgs/commit/545e9b4cf1ebf6e11aebf16bf120311b71be5891) | `` libressl_4_1: 4.1.0 -> 4.1.1 ``                                                           |
| [`e1a61232`](https://github.com/NixOS/nixpkgs/commit/e1a612324072c0f51721dd2d82af85f7dae9203d) | `` libressl_4_0: 4.0.0 -> 4.0.1 ``                                                           |
| [`fcac6aff`](https://github.com/NixOS/nixpkgs/commit/fcac6aff23372c2b2ce80ce3da946520d0097ca7) | `` libressl_3_{6,7,8}: drop ``                                                               |
| [`39e84f49`](https://github.com/NixOS/nixpkgs/commit/39e84f49e6b6fd0bc292e563d90d490435090c54) | `` libressl: fix deprecated --replace, use TLS_DEFAULT_CA_FILE option again, misc cleanup `` |
| [`0e319455`](https://github.com/NixOS/nixpkgs/commit/0e319455e465b970553a86e3e5b1a0d655bdeafc) | `` mutt: 2.2.14 -> 2.2.15 ``                                                                 |
| [`689f3c2c`](https://github.com/NixOS/nixpkgs/commit/689f3c2c4d7c592cb535e40c126363e30fb05712) | `` libressl: 4.0.0 -> 4.1.0 ``                                                               |
| [`9f4af2bb`](https://github.com/NixOS/nixpkgs/commit/9f4af2bb46c7d95e7db6753ea083f3fe0c79fe95) | `` libressl_4_1: init at 4.1.0 ``                                                            |
| [`d0870554`](https://github.com/NixOS/nixpkgs/commit/d0870554714ebdc9e34ea00fc53fd7a6c8bb8294) | `` open-vm-tools: 12.5.2 -> 12.5.4 ``                                                        |
| [`2c1a0e89`](https://github.com/NixOS/nixpkgs/commit/2c1a0e89ebb7e0f5456d1b8e8bd42a19f43f56c5) | `` diffoscope: 303 -> 304 ``                                                                 |
| [`9d13be20`](https://github.com/NixOS/nixpkgs/commit/9d13be20b0bb82ba2c738170cf3c28df93376d25) | `` diffoscope: 302 -> 303 ``                                                                 |
| [`26c71798`](https://github.com/NixOS/nixpkgs/commit/26c71798fe489bb426cc19a92308767d898ca1f5) | `` diffoscope: fix build on Darwin ``                                                        |
| [`fd977e79`](https://github.com/NixOS/nixpkgs/commit/fd977e792d393b95761724358d2a52017f0a7360) | `` diffoscope: convert to pyproject = true ``                                                |
| [`7e410a4f`](https://github.com/NixOS/nixpkgs/commit/7e410a4f6f7c7c081a7519e6ee38991ddcbcb4df) | `` diffoscope: 301 -> 302 ``                                                                 |
| [`92c1dd40`](https://github.com/NixOS/nixpkgs/commit/92c1dd40e079cfebda08d8e3fff2fa9293c6aad4) | `` diffoscope: 300 -> 301 ``                                                                 |
| [`518c045e`](https://github.com/NixOS/nixpkgs/commit/518c045ed59ef00a986c7e6025ea8b68101fd3a3) | `` diffoscope: 298 -> 300 ``                                                                 |
| [`424b2b26`](https://github.com/NixOS/nixpkgs/commit/424b2b26ea278db2fa692ebb2305ec90ede35da9) | `` diffoscope: 297 -> 298 ``                                                                 |
| [`75e94586`](https://github.com/NixOS/nixpkgs/commit/75e945869facb0f5c07cb9ff60faff585d17aedb) | `` diffoscope: 295 -> 297 ``                                                                 |
| [`9cf90caf`](https://github.com/NixOS/nixpkgs/commit/9cf90caf7bec4917dc4ef645c2c4769b1c215bf1) | `` sops: 3.10.2 -> 3.11.0 ``                                                                 |
| [`b088d2f3`](https://github.com/NixOS/nixpkgs/commit/b088d2f3e55ef8e7443ce78a87d9fb7c5725dbb9) | `` onedrive: small improvements to postInstall ``                                            |
| [`e95300b4`](https://github.com/NixOS/nixpkgs/commit/e95300b4c3c7823da43634190136f2dabde21d33) | `` onedrive: reorder inputs according to category and ABC ``                                 |
| [`28733b52`](https://github.com/NixOS/nixpkgs/commit/28733b52b61b1abe9c62cee5a0963f82c1a50b6f) | `` onedrive: 2.5.5 -> 2.5.6 ``                                                               |