### PR TITLE
chore(flake/nur): `33404b16` -> `c9252e8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759643458,
-        "narHash": "sha256-oQLW/vQ8/BLhZqp8K8YyP1k8r9ju6iqkbBgBRZ+ah74=",
+        "lastModified": 1759667608,
+        "narHash": "sha256-AzmP2Rwu+rsVRfWwacu6mJJlFuiE18uwCzb8+OrgFVo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "33404b168828bde62e36a61f9a16b54b6d6bcdfb",
+        "rev": "c9252e8dfb8b6f52753fcc741ee2e5929757886f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c9252e8d`](https://github.com/nix-community/NUR/commit/c9252e8dfb8b6f52753fcc741ee2e5929757886f) | `` automatic update `` |
| [`df871377`](https://github.com/nix-community/NUR/commit/df8713776e7e236129f7c260017e770393b4f278) | `` automatic update `` |
| [`72097359`](https://github.com/nix-community/NUR/commit/72097359ee7faebbd6bb79f36af62aa0baa0c3b3) | `` automatic update `` |
| [`42daeed0`](https://github.com/nix-community/NUR/commit/42daeed079d96303d867c614435599319c6643ae) | `` automatic update `` |