### PR TITLE
chore(flake/nur): `c9252e8d` -> `02a5670b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759667608,
-        "narHash": "sha256-AzmP2Rwu+rsVRfWwacu6mJJlFuiE18uwCzb8+OrgFVo=",
+        "lastModified": 1759675064,
+        "narHash": "sha256-/O8VuykUTr66TBDVvFmyXtLx2E8kdjyZoTPnHSjBQ5I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c9252e8dfb8b6f52753fcc741ee2e5929757886f",
+        "rev": "02a5670b5c53886a2f5a4a5615371906af465f32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`02a5670b`](https://github.com/nix-community/NUR/commit/02a5670b5c53886a2f5a4a5615371906af465f32) | `` automatic update `` |
| [`fe3cbd3d`](https://github.com/nix-community/NUR/commit/fe3cbd3d6bac8a1fe6971a92a1106e10aaeb6016) | `` automatic update `` |