### PR TITLE
chore(flake/nur): `02a5670b` -> `e28098ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759675064,
-        "narHash": "sha256-/O8VuykUTr66TBDVvFmyXtLx2E8kdjyZoTPnHSjBQ5I=",
+        "lastModified": 1759685532,
+        "narHash": "sha256-s66mrae7pyWr6nt0iaqkxdaXG2GnGOq9RnJMz9kO7oE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "02a5670b5c53886a2f5a4a5615371906af465f32",
+        "rev": "e28098ef238619c60c34ee09393d8bc87749e13f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e28098ef`](https://github.com/nix-community/NUR/commit/e28098ef238619c60c34ee09393d8bc87749e13f) | `` automatic update `` |
| [`ba4952df`](https://github.com/nix-community/NUR/commit/ba4952df76bc6179d0bb3b9e7b4ff8517cfec870) | `` automatic update `` |
| [`bbfeb9e5`](https://github.com/nix-community/NUR/commit/bbfeb9e587a3621cc550b110a501244dbf4ac1c7) | `` automatic update `` |