### PR TITLE
chore(flake/nur): `e28098ef` -> `dce08ba6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759685532,
-        "narHash": "sha256-s66mrae7pyWr6nt0iaqkxdaXG2GnGOq9RnJMz9kO7oE=",
+        "lastModified": 1759696599,
+        "narHash": "sha256-GkGJdNkR9gnVQt9OXwhGrD72EpK185jNVT7qoCh/3q4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e28098ef238619c60c34ee09393d8bc87749e13f",
+        "rev": "dce08ba6904fcaad93c17ab65cf6b3e5dfc2d301",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dce08ba6`](https://github.com/nix-community/NUR/commit/dce08ba6904fcaad93c17ab65cf6b3e5dfc2d301) | `` automatic update `` |
| [`8a0d1df7`](https://github.com/nix-community/NUR/commit/8a0d1df762827b4f0d3d6f69597783b9d937905a) | `` automatic update `` |
| [`46aa2238`](https://github.com/nix-community/NUR/commit/46aa2238f1ac51f3f2bceb26ed9a18702519df09) | `` automatic update `` |