### PR TITLE
chore(flake/nur): `dce08ba6` -> `7e31dbef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759696599,
-        "narHash": "sha256-GkGJdNkR9gnVQt9OXwhGrD72EpK185jNVT7qoCh/3q4=",
+        "lastModified": 1759713535,
+        "narHash": "sha256-YCg5ZAjzBHyLfvpqEXKNbsfSY1vpBq5dXqXq9JK5+jo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dce08ba6904fcaad93c17ab65cf6b3e5dfc2d301",
+        "rev": "7e31dbef1b48de02b08b43722dfd73b8b9168bc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7e31dbef`](https://github.com/nix-community/NUR/commit/7e31dbef1b48de02b08b43722dfd73b8b9168bc1) | `` automatic update `` |
| [`ff2dd3b1`](https://github.com/nix-community/NUR/commit/ff2dd3b1469d3c0de12ad0b30e7572a15a85de24) | `` automatic update `` |