### PR TITLE
chore(flake/nur): `7e31dbef` -> `a8f8c41a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759713535,
-        "narHash": "sha256-YCg5ZAjzBHyLfvpqEXKNbsfSY1vpBq5dXqXq9JK5+jo=",
+        "lastModified": 1759721590,
+        "narHash": "sha256-DJ/S2qWlSrEz3S9JwlPd6s+z6cJQl0+B1uV3IvGRA3A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7e31dbef1b48de02b08b43722dfd73b8b9168bc1",
+        "rev": "a8f8c41a99f0ae26a0f10749d31188bd90466f2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a8f8c41a`](https://github.com/nix-community/NUR/commit/a8f8c41a99f0ae26a0f10749d31188bd90466f2f) | `` automatic update `` |
| [`f5306839`](https://github.com/nix-community/NUR/commit/f53068397adcfa6497859e351ec12cd0b9e66bf8) | `` automatic update `` |
| [`0160b2a0`](https://github.com/nix-community/NUR/commit/0160b2a08d6c9af75a451a36f871f30253f68d84) | `` automatic update `` |
| [`a85ac1f5`](https://github.com/nix-community/NUR/commit/a85ac1f596a235e87b8161c29dca2a3884b26c73) | `` automatic update `` |