### PR TITLE
chore(flake/nur): `a8f8c41a` -> `af3cd643`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759721590,
-        "narHash": "sha256-DJ/S2qWlSrEz3S9JwlPd6s+z6cJQl0+B1uV3IvGRA3A=",
+        "lastModified": 1759724112,
+        "narHash": "sha256-42DBBV0eLlIHwu+xNX0xNcoFCX7hqkKjAs5kgxZZi/w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a8f8c41a99f0ae26a0f10749d31188bd90466f2f",
+        "rev": "af3cd64344dd497054e393e288bdb32cc9621e7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`af3cd643`](https://github.com/nix-community/NUR/commit/af3cd64344dd497054e393e288bdb32cc9621e7f) | `` automatic update `` |
| [`77e071a3`](https://github.com/nix-community/NUR/commit/77e071a31cadf669cb74fd6663e063032505a79c) | `` automatic update `` |
| [`b5941e63`](https://github.com/nix-community/NUR/commit/b5941e63a9a4862236545c6da968239565f2ab7a) | `` automatic update `` |