### PR TITLE
chore(flake/nur): `af3cd643` -> `9ea4f672`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759724112,
-        "narHash": "sha256-42DBBV0eLlIHwu+xNX0xNcoFCX7hqkKjAs5kgxZZi/w=",
+        "lastModified": 1759742968,
+        "narHash": "sha256-yk56xZpanCPlhowzIEdS2GfPDG0yQ4kE/j85lJbAX1Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af3cd64344dd497054e393e288bdb32cc9621e7f",
+        "rev": "9ea4f672c7138273a4131dd25038da49306685b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ea4f672`](https://github.com/nix-community/NUR/commit/9ea4f672c7138273a4131dd25038da49306685b8) | `` automatic update `` |
| [`76c75e50`](https://github.com/nix-community/NUR/commit/76c75e5077c704dcf29da0cef840a9c5818abc32) | `` automatic update `` |
| [`86b734d9`](https://github.com/nix-community/NUR/commit/86b734d9e1439a8f343d4cb7f5e3bbbc8cc54d93) | `` automatic update `` |