### PR TITLE
chore(flake/nur): `9ea4f672` -> `cc56d2cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759742968,
-        "narHash": "sha256-yk56xZpanCPlhowzIEdS2GfPDG0yQ4kE/j85lJbAX1Y=",
+        "lastModified": 1759754444,
+        "narHash": "sha256-P2fhvpUotw+1vppq0MwyQCZwZuHgic8oNWFGBzX1hZU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ea4f672c7138273a4131dd25038da49306685b8",
+        "rev": "cc56d2cfed781db0247fea72e9e5390440215e07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cc56d2cf`](https://github.com/nix-community/NUR/commit/cc56d2cfed781db0247fea72e9e5390440215e07) | `` automatic update `` |