### PR TITLE
chore(flake/nixpkgs): `3bcc93c5` -> `20c4598c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1759580034,
-        "narHash": "sha256-YWo57PL7mGZU7D4WeKFMiW4ex/O6ZolUS6UNBHTZfkI=",
+        "lastModified": 1759735786,
+        "narHash": "sha256-a0+h02lyP2KwSNrZz4wLJTu9ikujNsTWIC874Bv7IJ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3bcc93c5f7a4b30335d31f21e2f1281cba68c318",
+        "rev": "20c4598c84a671783f741e02bf05cbfaf4907cff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`3537e1d0`](https://github.com/NixOS/nixpkgs/commit/3537e1d097e21a5ceecb3dd07b3e1927df5d1524) | `` wordpress: 6.8.2 -> 6.8.3 ``                                                                |
| [`6416f610`](https://github.com/NixOS/nixpkgs/commit/6416f6105b2dfa8109ff264d6667ae56411db4d7) | `` limesurvey: 6.10.2+250127 -> 6.15.14+250924 ``                                              |
| [`bcbbfaf9`](https://github.com/NixOS/nixpkgs/commit/bcbbfaf949d5ac419a2cbdc7a14a68e94f319e61) | `` lixPackageSets.git: 2.94.0-pre-20250912_d90e4a65812c -> 2.94.0-pre-20251001_f1ef994f120a `` |
| [`3fb2ed82`](https://github.com/NixOS/nixpkgs/commit/3fb2ed825da1b6b425083586a6b75fd857aae217) | `` moonlight: 1.3.28 -> 1.3.30 ``                                                              |
| [`62182364`](https://github.com/NixOS/nixpkgs/commit/62182364bde2a9aebc542aa4895aac37f908a509) | `` openipmi: fix cross compilation ``                                                          |
| [`caf99aac`](https://github.com/NixOS/nixpkgs/commit/caf99aac23a733feca0d3bc296bd9a0d3b601eaf) | `` haproxy: apply patch for CVE-2025-11230 ``                                                  |
| [`a5a98e50`](https://github.com/NixOS/nixpkgs/commit/a5a98e5019bd24678918f7f459d8642c427068ef) | `` .git-blame-ignore-revs: add nixf-diagnose commits ``                                        |
| [`5cbdb94f`](https://github.com/NixOS/nixpkgs/commit/5cbdb94f3aa2e7de13f3c0a67899ec17427b58ce) | `` treewide: remove redundant parentheses ``                                                   |
| [`1c6af9ba`](https://github.com/NixOS/nixpkgs/commit/1c6af9ba0a9667e10ad97f53d2cff663abc290c9) | `` treewide: remove unused with ``                                                             |
| [`6c1e6f90`](https://github.com/NixOS/nixpkgs/commit/6c1e6f90d35932355fdee300b13136a8b7ec851c) | `` treewide: remove unused rec ``                                                              |
| [`2f6da601`](https://github.com/NixOS/nixpkgs/commit/2f6da601055d2cac0091cf36664957c606fca5cc) | `` ci/treefmt: add nixf-diagnose ``                                                            |
| [`5f49970c`](https://github.com/NixOS/nixpkgs/commit/5f49970c5bb5b89d0010a79f85f5c7a23a07736c) | `` vdrPlugins: fix Nix expression for vdr plugins ``                                           |
| [`b9b55234`](https://github.com/NixOS/nixpkgs/commit/b9b552346e873642814d30ea8f55401753d61352) | `` [25.05] consul: mark vulnerable ``                                                          |
| [`536ee465`](https://github.com/NixOS/nixpkgs/commit/536ee465b0926c69860f127593472f45e0e49887) | `` nixos-rebuild-ng: resolve Flake path for repl ``                                            |
| [`3b666d1b`](https://github.com/NixOS/nixpkgs/commit/3b666d1bd0737a52bcc501296f8efb9311515449) | `` nixos-rebuild-ng: fix mypy issues ``                                                        |
| [`712614b3`](https://github.com/NixOS/nixpkgs/commit/712614b34caac1f0fba45d7caf5d845c7588274a) | `` nixos-rebuild-ng: make sure mypy in CI is running with its configuration ``                 |
| [`4ce6971a`](https://github.com/NixOS/nixpkgs/commit/4ce6971acd945f8a37bd5773540b95b773e185e8) | `` nixos-rebuild-ng: do not parse the path part from Flake as a Path ``                        |
| [`2730167d`](https://github.com/NixOS/nixpkgs/commit/2730167d3227713ece70ff84e509b221762b7332) | `` nixos-rebuild-ng: make path part of Flake absolute ``                                       |
| [`575d5327`](https://github.com/NixOS/nixpkgs/commit/575d53279cb3172dce9d0a4ed9f57b87537ea770) | `` maintainers: drop pradeepchhetri ``                                                         |
| [`71cddc99`](https://github.com/NixOS/nixpkgs/commit/71cddc99daf12121d02cadc86ef7ae8ffeaf41c8) | `` gamescope: 3.16.15 -> 3.16.17 ``                                                            |
| [`2461cc4f`](https://github.com/NixOS/nixpkgs/commit/2461cc4f706fd4aa69a847bb3cc864efea3bfd71) | `` gamescope: 3.16.14.2 -> 3.16.15 ``                                                          |
| [`26b10326`](https://github.com/NixOS/nixpkgs/commit/26b10326bf7c4a5e67a7bc762783c576c6832f30) | `` gamescope-wsi: depend on libxcb independently of libx11 propagating it ``                   |
| [`5c65f1db`](https://github.com/NixOS/nixpkgs/commit/5c65f1db8ffa2edd0b3d616ef1646dd69b416b09) | `` gamescope: 3.16.14 -> 3.16.14.2 ``                                                          |
| [`d655901d`](https://github.com/NixOS/nixpkgs/commit/d655901d6b55bd38791dc04c0a20372b27935c81) | `` gamescope: correct executable only deps ``                                                  |
| [`e37d35b0`](https://github.com/NixOS/nixpkgs/commit/e37d35b007fd1bc326e86f2e34fa09b7c7398e46) | `` gamescope: use pending upstream patch for unvendoring ``                                    |
| [`4d845494`](https://github.com/NixOS/nixpkgs/commit/4d84549407f6506fd4f1258b5963ceda08c7380e) | `` gamescope: 3.16.12 -> 3.16.14 ``                                                            |
| [`229d38b8`](https://github.com/NixOS/nixpkgs/commit/229d38b8cb19870737943ee3dd2ddf61370cb5fa) | `` gamescope: 3.16.11 -> 3.16.12 ``                                                            |
| [`3f202f3d`](https://github.com/NixOS/nixpkgs/commit/3f202f3d1f0fd9a4703f2d2d8c4814b1985f08c6) | `` gamescope: 3.16.10 -> 3.16.11 ``                                                            |
| [`ab07dddb`](https://github.com/NixOS/nixpkgs/commit/ab07dddb6956480adfeaa7533153e2887bc67c5a) | `` gamescope: 3.16.9 -> 3.16.10 ``                                                             |
| [`e97c02b9`](https://github.com/NixOS/nixpkgs/commit/e97c02b9dc9855b20f715876d16e89201c17c933) | `` [25.05] hiawatha: mark vulnerable ``                                                        |
| [`818421da`](https://github.com/NixOS/nixpkgs/commit/818421da67d4ec8bcd793b43503ff9f43a97ea84) | `` vivaldi: 7.6.3797.55 -> 7.6.3797.58 ``                                                      |
| [`0d102564`](https://github.com/NixOS/nixpkgs/commit/0d1025647a7b5812dc29373eedcec0a4d6da9d10) | `` redis: 7.2.10 -> 7.2.11 ``                                                                  |
| [`d0e93b45`](https://github.com/NixOS/nixpkgs/commit/d0e93b45f92dd22718c3e235f42ccd05e43d90af) | `` fetchmail_7: unstable-2022-05-26 -> 7.0.0-alpha11 ``                                        |
| [`c5f3b186`](https://github.com/NixOS/nixpkgs/commit/c5f3b1867eeffc4f2423c1742f9eece2aac15e7b) | `` fetchmail: 6.5.1 -> 6.5.6 ``                                                                |
| [`5ab02969`](https://github.com/NixOS/nixpkgs/commit/5ab02969b54fc3ba62057cb4b46cf4da001a44f8) | `` anytype: 0.49.2 -> 0.50.3 ``                                                                |
| [`ceb7db88`](https://github.com/NixOS/nixpkgs/commit/ceb7db88ed603c539ce6e6ab04e388aae4c9934d) | `` brave: 1.82.172 -> 1.83.109 ``                                                              |
| [`6dc1a11a`](https://github.com/NixOS/nixpkgs/commit/6dc1a11a84e63fdde227a8dd652ac1a8ece420f0) | `` brave: `--replace` -> `--replace-fail` ``                                                   |
| [`94a90ea6`](https://github.com/NixOS/nixpkgs/commit/94a90ea69453e0a3304545b67b11c9d339a6bbef) | `` babl: 0.1.114 -> 0.1.116 ``                                                                 |
| [`60e8c8d8`](https://github.com/NixOS/nixpkgs/commit/60e8c8d8e7a7ffbc54018c75f0dc6c4d71756d98) | `` factorio-demo: 2.0.66 -> 2.0.69 ``                                                          |
| [`366274eb`](https://github.com/NixOS/nixpkgs/commit/366274ebcd81b1e2ad941059f4f013c679dea4d9) | `` freshrss: 1.27.0 -> 1.27.1 ``                                                               |
| [`067b6df0`](https://github.com/NixOS/nixpkgs/commit/067b6df09513efdfc3d6ca00bae5b41f4ff28c76) | `` freshrss: 1.26.3 -> 1.27.0 ``                                                               |
| [`01d47c12`](https://github.com/NixOS/nixpkgs/commit/01d47c128626dd0ce5c4465d2c451b94ca9c4c3b) | `` freshrss: 1.26.2 -> 1.26.3 ``                                                               |
| [`605cbde5`](https://github.com/NixOS/nixpkgs/commit/605cbde50894ef5d452f0c6e22b131fc22ea7ba0) | `` microsoft-edge: 140.0.3485.94 -> 141.0.3537.57 ``                                           |
| [`3f6fbe5e`](https://github.com/NixOS/nixpkgs/commit/3f6fbe5ef7673ea3886a6283b3987f37b657871d) | `` firefox-bin-unwrapped: 143.0.3 -> 143.0.4 ``                                                |
| [`1c9ae121`](https://github.com/NixOS/nixpkgs/commit/1c9ae1217432451069b1bae9940993ce6eb1bb0b) | `` firefox-unwrapped: 143.0.3 -> 143.0.4 ``                                                    |
| [`71605929`](https://github.com/NixOS/nixpkgs/commit/7160592986dfbf7153a66af78646e6bcc9056ad2) | `` thunderbird-latest-bin-unwrapped: 143.0 -> 143.0.1 ``                                       |
| [`6b4d3921`](https://github.com/NixOS/nixpkgs/commit/6b4d3921fde278731ad96aa34178146df59d44e1) | `` gfn-electron: pin electron_35 ``                                                            |
| [`96eec2cd`](https://github.com/NixOS/nixpkgs/commit/96eec2cd4577ea0f1a5abdc31b674232546e1c49) | `` podman-desktop: 1.18.1 -> 1.19.1 ``                                                         |
| [`631db5d2`](https://github.com/NixOS/nixpkgs/commit/631db5d2611cc58cba7af16da282fa0c9b62a72c) | `` lmstudio: 0.3.26.6 -> 0.3.27.4 ``                                                           |
| [`56bdf11e`](https://github.com/NixOS/nixpkgs/commit/56bdf11e035edaef15630f54eeece69274fe5d14) | `` docker_28: 28.3.3 -> 28.4.0 ``                                                              |
| [`ab83330e`](https://github.com/NixOS/nixpkgs/commit/ab83330e086e5898ba2fe2eaf37925bb5ced0cc7) | `` docker_25: 25.0.12 -> 25.0.13 ``                                                            |
| [`3934c379`](https://github.com/NixOS/nixpkgs/commit/3934c379948c755e75ef8797499451aa43dac57e) | `` docker: use `env` ``                                                                        |
| [`e44455b9`](https://github.com/NixOS/nixpkgs/commit/e44455b9c38f6d55fb8096b8e77f72ce48516295) | `` docker: remove unused parameters ``                                                         |
| [`8c308ea0`](https://github.com/NixOS/nixpkgs/commit/8c308ea04c61c19e582a9c4baf2414403e3ea43a) | `` docker: use `optionals` when dealing with list attributes ``                                |
| [`3a0bfd8a`](https://github.com/NixOS/nixpkgs/commit/3a0bfd8abed66ba36da8a06f82339373dbad4e1d) | `` docker: remove obsolete `rec` ``                                                            |
| [`6d0be295`](https://github.com/NixOS/nixpkgs/commit/6d0be2951ce64fdda539b42627699a47147f4a28) | `` docker: add missing phase hooks ``                                                          |
| [`673e10cc`](https://github.com/NixOS/nixpkgs/commit/673e10cc89afc3f7d4ecbe234f661a3984891a65) | `` docker: use `tag` ``                                                                        |
| [`a4a7162f`](https://github.com/NixOS/nixpkgs/commit/a4a7162fa6df02b5429cb2d54ff6705a37291444) | `` docker: use `makeBinaryWrapper` ``                                                          |
| [`955575c0`](https://github.com/NixOS/nixpkgs/commit/955575c03a476da928ce445ae65c2f6a08beee95) | `` docker: use `versionCheckHook` ``                                                           |
| [`1266c6cf`](https://github.com/NixOS/nixpkgs/commit/1266c6cf972de96523965deed5b0fcdea558b4bd) | `` docker: replace `util-linux` with `util-linuxMinimal` ``                                    |
| [`d8b0c67b`](https://github.com/NixOS/nixpkgs/commit/d8b0c67b9248ff811172311f01b5f75872e16891) | `` electron{,-bin,-chromedriver}: 35 -> 37 ``                                                  |
| [`8fa869e3`](https://github.com/NixOS/nixpkgs/commit/8fa869e38bf874f8123e1a266be3849a8bcda847) | `` lixPackageSets.git: 2.94.0-pre-20250807_8bbd5e1d0df9 -> 2.94.0-pre-20250912_d90e4a65812c `` |
| [`8d0de7bb`](https://github.com/NixOS/nixpkgs/commit/8d0de7bb17834338a0cdf7053ddee216e3a1b676) | `` factorio-demo: 2.0.42 -> 2.0.66 ``                                                          |