### PR TITLE
chore(flake/nixpkgs-unstable): `7df7ff7d` -> `8913c168`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1759381078,
-        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
+        "lastModified": 1759733170,
+        "narHash": "sha256-TXnlsVb5Z8HXZ6mZoeOAIwxmvGHp1g4Dw89eLvIwKVI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
+        "rev": "8913c168d1c56dc49a7718685968f38752171c3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`a725e6bb`](https://github.com/NixOS/nixpkgs/commit/a725e6bbe8954da01abc7939924bb7ab206ef055) | `` touchegg: patch build with cmake 4 ``                                                     |
| [`3efd73e3`](https://github.com/NixOS/nixpkgs/commit/3efd73e3428d1967b7d51cafd1790bd6714755f7) | `` jna: 5.18.0 -> 5.18.1 ``                                                                  |
| [`03fd6c71`](https://github.com/NixOS/nixpkgs/commit/03fd6c71c77a710e9b74ea8a14c6d95c113acd57) | `` terraform-providers.aws: 6.14.1 -> 6.15.0 ``                                              |
| [`0815ad33`](https://github.com/NixOS/nixpkgs/commit/0815ad332bb756585957f0ce516571db02176cdf) | `` terraform-providers.rootly: 4.1.0 -> 4.2.0 ``                                             |
| [`a7a9ed60`](https://github.com/NixOS/nixpkgs/commit/a7a9ed60f1532b97a13187fa4acd2ca9071358b1) | `` terraform-providers.azuread: 3.5.0 -> 3.6.0 ``                                            |
| [`61e61749`](https://github.com/NixOS/nixpkgs/commit/61e617498bc95a5b4e717e04e8e06851896daa12) | `` steam-devices-udev-rules: 1.0.0.61-unstable-2024-05-22 -> 1.0.0.61-unstable-2025-09-26 `` |
| [`e958f7d8`](https://github.com/NixOS/nixpkgs/commit/e958f7d8ed46436ab97e7d42e3ba3dcc424ec551) | `` files-cli: 2.15.104 -> 2.15.111 ``                                                        |
| [`d8a9b1dc`](https://github.com/NixOS/nixpkgs/commit/d8a9b1dca86c388f7d96f75d7de08752a31085d4) | `` limine: 10.0.1 -> 10.1.0 ``                                                               |
| [`e7b87f3a`](https://github.com/NixOS/nixpkgs/commit/e7b87f3a8a4b0838c5eea9a630f7d299903c120e) | `` sbt: 1.11.6 -> 1.11.7 ``                                                                  |
| [`1cfea965`](https://github.com/NixOS/nixpkgs/commit/1cfea9657a3101a8ee7e794e268b3c52d11c1020) | `` warpinator: fix "Connect manually" not working ``                                         |
| [`05a468e5`](https://github.com/NixOS/nixpkgs/commit/05a468e57405cf934d342fc1125490ff0f200982) | `` terraform-providers.google: 7.4.0 -> 7.5.0 ``                                             |
| [`aca4cec7`](https://github.com/NixOS/nixpkgs/commit/aca4cec72c03e562e99f81879dad442eef48402b) | `` terraform-providers.buildkite: 1.24.0 -> 1.26.0 ``                                        |
| [`9f95c2ac`](https://github.com/NixOS/nixpkgs/commit/9f95c2ace2ba533a6d8072753b164d8d8ffc29b0) | `` linux: new workflow for kernel changes ``                                                 |
| [`89ec0816`](https://github.com/NixOS/nixpkgs/commit/89ec0816f9a4aaaebaee81fba5957924c5a3530c) | `` nfpm: 2.43.1 -> 2.43.2 ``                                                                 |
| [`f4183650`](https://github.com/NixOS/nixpkgs/commit/f41836506718662fc4b50a99a7d49bf3f04c9013) | `` maintainers: drop evils ``                                                                |
| [`e0d5027e`](https://github.com/NixOS/nixpkgs/commit/e0d5027e8873eaa5e8f74fba39072fcb231f4b4b) | `` treewide: migrate to by-name ``                                                           |
| [`20193847`](https://github.com/NixOS/nixpkgs/commit/20193847cc1b8be0fb0e2fe900fe813752be8c29) | `` python3Packages.ducc0: 0.38.0 -> 0.39.0 ``                                                |
| [`2bd3163e`](https://github.com/NixOS/nixpkgs/commit/2bd3163e83beb417107125ecdf9290d008f77948) | `` steam-rom-manager: 2.5.29 -> 2.5.30 ``                                                    |
| [`df5c36fb`](https://github.com/NixOS/nixpkgs/commit/df5c36fbc7965904e176deacb2d79d1f9f797b6c) | `` cargo-nextest: 0.9.104 -> 0.9.105 ``                                                      |
| [`2b7df7b2`](https://github.com/NixOS/nixpkgs/commit/2b7df7b2f3c310282da2501e31efc4a8c1bccb9a) | `` tweeny: 3.2.0 -> 3.2.1 ``                                                                 |
| [`b26d919c`](https://github.com/NixOS/nixpkgs/commit/b26d919c4a5b19695f2dd768cd9f2925f567b0f1) | `` various: migrate to by-name ``                                                            |
| [`fad0512b`](https://github.com/NixOS/nixpkgs/commit/fad0512ba5d30c4c27e7e4f8f80e66a22f809826) | `` jameica: 2.10.4 -> 2.10.5 ``                                                              |
| [`58471c61`](https://github.com/NixOS/nixpkgs/commit/58471c61c0db6f39ce5afc913018738c29041288) | `` python3Packages.twscrape: fix build ``                                                    |
| [`a536b2a1`](https://github.com/NixOS/nixpkgs/commit/a536b2a1d66627c3abf476aea31ee894d443a581) | `` firezone-server: 0-unstable-2025-03-15 -> 0-unstable-2025-08-10 ``                        |
| [`8d4e97cd`](https://github.com/NixOS/nixpkgs/commit/8d4e97cd35f6a9375c727c51ed48049f9e271958) | `` gh-dash: 4.16.2 -> 4.17.0 ``                                                              |
| [`59dfbb04`](https://github.com/NixOS/nixpkgs/commit/59dfbb0400b5783c26e9d0277ca02d9cde341b0f) | `` vault-bin: 1.20.3 -> 1.20.4 ``                                                            |
| [`440580bc`](https://github.com/NixOS/nixpkgs/commit/440580bcb0b7c770954a454cc6f36ddc898499b5) | `` ruffle: 0.2-nightly-2025-09-24 -> 0.2-nightly-2025-10-05 ``                               |
| [`4e5b7d0d`](https://github.com/NixOS/nixpkgs/commit/4e5b7d0d28af0e42cac379404f51b6e03e7f6d39) | `` firefoxpwa: 2.16.0 -> 2.17.0 ``                                                           |
| [`0c454fbe`](https://github.com/NixOS/nixpkgs/commit/0c454fbe5bc6448338aad5f68af99b52c19aed93) | `` backintime-common: 1.5.5 -> 1.5.6 ``                                                      |
| [`e5835339`](https://github.com/NixOS/nixpkgs/commit/e58353399bcbc966379f4e59f87f191ed65d7d7c) | `` cuneiform: soft-deprecate ``                                                              |
| [`d5ace73b`](https://github.com/NixOS/nixpkgs/commit/d5ace73b50a87b14d7de4e48727a43e96241a0a3) | `` cuneiform: fix building with CMake 4 ``                                                   |
| [`f36d0db5`](https://github.com/NixOS/nixpkgs/commit/f36d0db5e3b6a5c5a817b4ce6f9e50af99e2e49e) | `` python3Packages.pyocr: disable cuneiform support ``                                       |
| [`a7be6c46`](https://github.com/NixOS/nixpkgs/commit/a7be6c460e22bc2415b452787f1e3f20f5186c86) | `` taterclient-ddnet: 10.5.3 -> 10.6.0 ``                                                    |
| [`5483b5b9`](https://github.com/NixOS/nixpkgs/commit/5483b5b9dadd28ac2ef2cb884a072834f9920371) | `` velocity: 3.4.0-unstable-2025-09-24 -> 3.4.0-unstable-2025-09-29 ``                       |
| [`ce7a9902`](https://github.com/NixOS/nixpkgs/commit/ce7a9902c3c9adea3572acbb46dbc142dfea32d4) | `` stats: 2.11.55 -> 2.11.56 ``                                                              |
| [`30786ff6`](https://github.com/NixOS/nixpkgs/commit/30786ff6131f82ea8bc90b7437cb9d358e6359d5) | `` gql: 0.40.0 -> 0.41.0 ``                                                                  |
| [`7a786a5d`](https://github.com/NixOS/nixpkgs/commit/7a786a5de3db4df502d76b13c3891f4ccf9dfd51) | `` ironbar: 0.17.0 -> 0.17.1 ``                                                              |
| [`f6620e26`](https://github.com/NixOS/nixpkgs/commit/f6620e26a4e1a1e8774b8a367a8d848518d9e216) | `` cbc: 2.10.4 -> 2.10.12 ``                                                                 |
| [`feddca15`](https://github.com/NixOS/nixpkgs/commit/feddca15ba00c7881f22d3c509116dd8b8197c36) | `` moonlight: 1.3.28 -> 1.3.30 ``                                                            |
| [`df7680b3`](https://github.com/NixOS/nixpkgs/commit/df7680b3b564e08d87956ed20df3f971c2fdfb49) | `` vscode: bind /etc/xdg/ ``                                                                 |
| [`dc7cba24`](https://github.com/NixOS/nixpkgs/commit/dc7cba2444674198cd413578706150947c95b672) | `` cosmic-protocols: 0-unstable-2025-09-17 -> 0-unstable-2025-09-26 ``                       |
| [`611c7791`](https://github.com/NixOS/nixpkgs/commit/611c77912492f7195223da1cd52835d4abf02b33) | `` hyprshell: wrap program ``                                                                |
| [`9b9cace1`](https://github.com/NixOS/nixpkgs/commit/9b9cace1c5b9be5f6e9a56f778c309a03e031442) | `` industrializer: fix build ``                                                              |
| [`b474395b`](https://github.com/NixOS/nixpkgs/commit/b474395bdf7a2501dfddc2d87a35ccdce31d0690) | `` bitmeter: add alternative to alias ``                                                     |
| [`75ce7cc1`](https://github.com/NixOS/nixpkgs/commit/75ce7cc1f7489bba2beee16f2102afddb0183df9) | `` python3Packages.opower: 0.15.5 -> 0.15.6 ``                                               |
| [`40a9edda`](https://github.com/NixOS/nixpkgs/commit/40a9edda8f4695d01f05fed3d37a6dffd7f2272b) | `` libretro.bluemsx: 0-unstable-2025-09-19 -> 0-unstable-2025-09-27 ``                       |
| [`3193a4d3`](https://github.com/NixOS/nixpkgs/commit/3193a4d3f63e80e2db1f16d1103e4f926d1c09bd) | `` qlementine: 1.2.2 -> 1.3.0 ``                                                             |
| [`984a52ef`](https://github.com/NixOS/nixpkgs/commit/984a52ef56d1d0d1840460b90747f4832387c5ee) | `` fblog: 4.15.0 -> 4.16.0 ``                                                                |
| [`32c357f0`](https://github.com/NixOS/nixpkgs/commit/32c357f0bf013bf1c5e989b021a31483044e7c95) | `` nom: 2.15.0 -> 2.16.2 ``                                                                  |
| [`9f35dc73`](https://github.com/NixOS/nixpkgs/commit/9f35dc735b0a5d5a403eae6be3579d2d6cba89fd) | `` bruno: 2.11.0 -> 2.12.0 ``                                                                |
| [`65d2c0d8`](https://github.com/NixOS/nixpkgs/commit/65d2c0d8f5e8d55902d84d1dbfb635171cb96f8a) | `` elixir_1_19: 1.19.0-rc.0 -> 1.19.0-rc.1 ``                                                |
| [`ac35cd7f`](https://github.com/NixOS/nixpkgs/commit/ac35cd7fd519cda6e780076b95848de4908bfb2e) | `` python3Packages.metaflow: 2.18.9 -> 2.18.10 ``                                            |
| [`5131b610`](https://github.com/NixOS/nixpkgs/commit/5131b6102f9b2bf9b50a3f2f2ffef5f840deaaf5) | `` bitcoin-knots: fix bitcoin-qt build ``                                                    |
| [`98e468ae`](https://github.com/NixOS/nixpkgs/commit/98e468ae62658b0511e825e5ea3bd4efe2f0ca45) | `` sing-box: 1.12.8 -> 1.12.9 ``                                                             |
| [`5a6cda10`](https://github.com/NixOS/nixpkgs/commit/5a6cda10231e7651c65bcd9f0bac2156d067ef4a) | `` python3Packages.pycoolmasternet-async: 0.2.3 -> 0.2.4 ``                                  |
| [`b7ad7e0c`](https://github.com/NixOS/nixpkgs/commit/b7ad7e0c85cbb604fd5e7d3c90bbcdb29430648d) | `` mapproxy: 5.0.0 -> 5.1.1 ``                                                               |
| [`cff42bd4`](https://github.com/NixOS/nixpkgs/commit/cff42bd46003045425ee59b0531c1bfc90ebe802) | `` mdserve: Add myself as maintainer ``                                                      |
| [`8eab1f08`](https://github.com/NixOS/nixpkgs/commit/8eab1f0891e79d0f7b252866528500a023858657) | `` mdserve: 0.4.0 -> 0.4.1 ``                                                                |
| [`307a5cff`](https://github.com/NixOS/nixpkgs/commit/307a5cffc59e6354d6f378d810ac41f4e51d09a9) | `` evcc: 0.208.1 -> 0.209.0 ``                                                               |
| [`838fd4ea`](https://github.com/NixOS/nixpkgs/commit/838fd4ea2a97404fc53bc2ab5f72b9ab081e4c5e) | `` portfolio: 0.80.2 -> 0.80.3 ``                                                            |
| [`b733671f`](https://github.com/NixOS/nixpkgs/commit/b733671f7b8ac789395809cc61cb0244dca26e43) | `` iosevka: 33.3.0 -> 33.3.1 ``                                                              |
| [`333ee272`](https://github.com/NixOS/nixpkgs/commit/333ee272ed874da33a6301bcf57dcedef57ba4f6) | `` python313Packages.django-tables2: 2.7.1 -> 2.7.5 ``                                       |
| [`acb84975`](https://github.com/NixOS/nixpkgs/commit/acb84975ee057a11fba02add6c6c0c7c67707c67) | `` python313Packages.django-phonenumber-field: 8.1.0 -> 8.2.0 ``                             |
| [`5259defc`](https://github.com/NixOS/nixpkgs/commit/5259defc039269a658d1b569aa2e5fb23ba1cd4f) | `` python313Packages.django-cms: 5.0.2 -> 5.0.4 ``                                           |
| [`f300319a`](https://github.com/NixOS/nixpkgs/commit/f300319a389893390b845da1266b70dab36c0297) | `` python313Packages.cvelib: 1.7.1 -> 1.8.0 ``                                               |
| [`0cb69ce5`](https://github.com/NixOS/nixpkgs/commit/0cb69ce56dd288e4e37bec852cbb2a09abda1cff) | `` fasttext: fix build with cmake 4 ``                                                       |
| [`4bdb7828`](https://github.com/NixOS/nixpkgs/commit/4bdb782846236443d7790d2f4609f6205b7b393d) | `` python313Packages.bump-my-version: 1.2.3 -> 1.2.4 ``                                      |