### PR TITLE
chore(flake/nur): `0a01f5c9` -> `4297c3bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1759381078,
-        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
+        "lastModified": 1759733170,
+        "narHash": "sha256-TXnlsVb5Z8HXZ6mZoeOAIwxmvGHp1g4Dw89eLvIwKVI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
+        "rev": "8913c168d1c56dc49a7718685968f38752171c3b",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759807990,
-        "narHash": "sha256-GqDpfKu3+xSD3S1iW4p71lZLGwde3E6rXcAoJg6JSp4=",
+        "lastModified": 1759816313,
+        "narHash": "sha256-+HZJZxVs168Iv75hYE7dHIZ7C0hJvbLDqMlIAEBxG50=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0a01f5c97f5ec1d3166530772dd1966b599f0982",
+        "rev": "4297c3bba38f5d5ee8fc764ab99809242cafbc9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4297c3bb`](https://github.com/nix-community/NUR/commit/4297c3bba38f5d5ee8fc764ab99809242cafbc9b) | `` automatic update `` |
| [`55d07564`](https://github.com/nix-community/NUR/commit/55d07564056e8be7f127c9a8a4036efce892cef9) | `` automatic update `` |
| [`9639ac78`](https://github.com/nix-community/NUR/commit/9639ac7856f034f9c5466a99b6e7dc448f4c09d2) | `` automatic update `` |