### PR TITLE
chore(flake/nur): `4297c3bb` -> `2d273891`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759816313,
-        "narHash": "sha256-+HZJZxVs168Iv75hYE7dHIZ7C0hJvbLDqMlIAEBxG50=",
+        "lastModified": 1759828485,
+        "narHash": "sha256-6WQ6PPMwgMwBUDx2tKf6JbePPwppEjPBfVPh9BSLZcY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4297c3bba38f5d5ee8fc764ab99809242cafbc9b",
+        "rev": "2d273891353c4483aed7c64c3d35068f05b80e1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d273891`](https://github.com/nix-community/NUR/commit/2d273891353c4483aed7c64c3d35068f05b80e1b) | `` automatic update `` |
| [`b00c0499`](https://github.com/nix-community/NUR/commit/b00c049942376a2d227dd88dbe7dcf7853f1099b) | `` automatic update `` |
| [`cc6815db`](https://github.com/nix-community/NUR/commit/cc6815dbb1e37008ffe45c7ca3f01cbec757f4fa) | `` automatic update `` |
| [`4271cb3d`](https://github.com/nix-community/NUR/commit/4271cb3d00251ff6a51bf05c68a8bbb80677a0e6) | `` automatic update `` |
| [`ef5b3efd`](https://github.com/nix-community/NUR/commit/ef5b3efd3e09a2ea896fa3ba5f98864d35eaf1ad) | `` automatic update `` |