### PR TITLE
chore(flake/nur): `3d167c03` -> `c941a2f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759855519,
-        "narHash": "sha256-I0TOcz4I7Uz2Dj3byA+dGYWxE0GVnW9QLfBX0kXl+eE=",
+        "lastModified": 1759870005,
+        "narHash": "sha256-0JUKp2FJCtCg+nr63+IdOuoZPCZfCLiF8SfB8jYu3wI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3d167c0368882f02490e6c09f4cc2501c33d5fce",
+        "rev": "c941a2f92788e7fa1530496d18087202e994bd43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c941a2f9`](https://github.com/nix-community/NUR/commit/c941a2f92788e7fa1530496d18087202e994bd43) | `` automatic update `` |
| [`eb7a5245`](https://github.com/nix-community/NUR/commit/eb7a5245ee418ba6a9f386fa3bab72ff5d87388e) | `` automatic update `` |
| [`5a4344ae`](https://github.com/nix-community/NUR/commit/5a4344ae57c97ec93c40aeb4adad31aebfc9b923) | `` automatic update `` |