### PR TITLE
chore(flake/nur): `c941a2f9` -> `2b6c093f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759870005,
-        "narHash": "sha256-0JUKp2FJCtCg+nr63+IdOuoZPCZfCLiF8SfB8jYu3wI=",
+        "lastModified": 1759884798,
+        "narHash": "sha256-HGM3bB0GRBg6rVHsU026jIHhIgpPhZbOkwR7P0dpBls=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c941a2f92788e7fa1530496d18087202e994bd43",
+        "rev": "2b6c093f1ce99e2bce40c1578dfd8e6e257b6b26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2b6c093f`](https://github.com/nix-community/NUR/commit/2b6c093f1ce99e2bce40c1578dfd8e6e257b6b26) | `` automatic update `` |
| [`84a5a792`](https://github.com/nix-community/NUR/commit/84a5a7921fc9c2246eb251e38b967dfd4db88dbc) | `` automatic update `` |
| [`a9b46f89`](https://github.com/nix-community/NUR/commit/a9b46f898b7d0a6a2818bedbc0898a1ccccd2e85) | `` automatic update `` |