### PR TITLE
chore(flake/nixpkgs-unstable): `8913c168` -> `c9b6fb79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1759733170,
-        "narHash": "sha256-TXnlsVb5Z8HXZ6mZoeOAIwxmvGHp1g4Dw89eLvIwKVI=",
+        "lastModified": 1759831965,
+        "narHash": "sha256-vgPm2xjOmKdZ0xKA6yLXPJpjOtQPHfaZDRtH+47XEBo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8913c168d1c56dc49a7718685968f38752171c3b",
+        "rev": "c9b6fb798541223bbb396d287d16f43520250518",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`4af05f91`](https://github.com/NixOS/nixpkgs/commit/4af05f918e6ca929dbce6d588e722d3045ce2a93) | `` bitwarden-cli: 2025.5.0 -> 2025.9.0 ``                                         |
| [`29920237`](https://github.com/NixOS/nixpkgs/commit/299202371c1b84c86ac6e57c9bcc5a75b572af1b) | `` bitwarden-cli: add xiaoxiangmoe as maintainer ``                               |
| [`f7f81c00`](https://github.com/NixOS/nixpkgs/commit/f7f81c00785c7a2ab543199d56a1f4f57219791b) | `` libdivsufsort: fix build with recent cmake ``                                  |
| [`313c4db3`](https://github.com/NixOS/nixpkgs/commit/313c4db3799d0b18bc1c4a33dcdfb22215d8d6db) | `` kubectl-ai: 0.0.25 -> 0.0.26 ``                                                |
| [`d3d81934`](https://github.com/NixOS/nixpkgs/commit/d3d81934a095d30879ba92163a3cbdac2ae42748) | `` cmake-language-server: skip failing tests ``                                   |
| [`375da09b`](https://github.com/NixOS/nixpkgs/commit/375da09b236f6056cdfb96570ba46a927ad5b53b) | `` allegro: fix build with cmake4 ``                                              |
| [`aa338e33`](https://github.com/NixOS/nixpkgs/commit/aa338e337bebbee21f86586b64cdd6b41d041ac8) | `` ipu6-camera-hal: fix build with cmake4 ``                                      |
| [`340af775`](https://github.com/NixOS/nixpkgs/commit/340af77569d0ac4fa8f7f2093d3c477254a110f3) | `` vfox: 0.6.10 -> 0.8.0 ``                                                       |
| [`6f8d77e4`](https://github.com/NixOS/nixpkgs/commit/6f8d77e46d77461719114d3cc977109403982d3a) | `` luau: 0.693 -> 0.694 ``                                                        |
| [`a014d728`](https://github.com/NixOS/nixpkgs/commit/a014d7287073c04c25d469eb22ab9e4756e22a5c) | `` python313Packages.boto3-stubs: 1.40.45 -> 1.40.46 ``                           |
| [`988169be`](https://github.com/NixOS/nixpkgs/commit/988169bed4281b4e77659293a97499b360c08c5b) | `` python312Packages.mypy-boto3-resource-explorer-2: 1.40.0 -> 1.40.46 ``         |
| [`5df176e2`](https://github.com/NixOS/nixpkgs/commit/5df176e2ece5a513818e143e821a1a6c9785a1e1) | `` python312Packages.mypy-boto3-rds: 1.40.42 -> 1.40.46 ``                        |
| [`1a04455d`](https://github.com/NixOS/nixpkgs/commit/1a04455d8320c5d6396df221a5865f699341e931) | `` python312Packages.mypy-boto3-quicksight: 1.40.42 -> 1.40.46 ``                 |
| [`c7ae5ab3`](https://github.com/NixOS/nixpkgs/commit/c7ae5ab32edbd63b5bcff3b6e07925b2aca85012) | `` python312Packages.mypy-boto3-memorydb: 1.40.16 -> 1.40.46 ``                   |
| [`42520927`](https://github.com/NixOS/nixpkgs/commit/42520927a6b2447146eb468fae198db659595360) | `` python312Packages.mypy-boto3-mediaconnect: 1.40.0 -> 1.40.46 ``                |
| [`123bcc34`](https://github.com/NixOS/nixpkgs/commit/123bcc34203711e94eb4ca189f39ee216383edc9) | `` python312Packages.mypy-boto3-glue: 1.40.39 -> 1.40.46 ``                       |
| [`b0c0e251`](https://github.com/NixOS/nixpkgs/commit/b0c0e2518308df5a779fd13de57a95d54ef9fc1c) | `` python312Packages.mypy-boto3-backup: 1.40.0 -> 1.40.46 ``                      |
| [`131fc59d`](https://github.com/NixOS/nixpkgs/commit/131fc59df2836e4ef9da67af3a0b43d33002c95c) | `` python313Packages.iamdata: 0.1.202510061 -> 0.1.202510071 ``                   |
| [`c5514322`](https://github.com/NixOS/nixpkgs/commit/c55143227e90adda5918e4f7e33e852a4131ece0) | `` python313Packages.llama-index-readers-json: 0.4.1 -> 0.4.2 ``                  |
| [`ef62ff76`](https://github.com/NixOS/nixpkgs/commit/ef62ff76b444e60b3c862e1523ce25f1219a6d6f) | `` superTux: fix build with cmake 4 ``                                            |
| [`5302f52d`](https://github.com/NixOS/nixpkgs/commit/5302f52d51df6536a2b10894de994ca95896d21d) | `` rundeck: 5.15.0 -> 5.16.0 ``                                                   |
| [`552bc0da`](https://github.com/NixOS/nixpkgs/commit/552bc0da3492d14706cbfa5a0ed12503c3aa9cbf) | `` rusty-bash: 0.8.5 -> 1.2.2 ``                                                  |
| [`45823f82`](https://github.com/NixOS/nixpkgs/commit/45823f82d277efce18c08fa7cabc4b3b17f9bc9f) | `` libretro.dosbox-pure: 0-unstable-2025-09-27 -> 0-unstable-2025-09-28 ``        |
| [`d4713d59`](https://github.com/NixOS/nixpkgs/commit/d4713d595d05b3c6db31fb874b7478f9e7f59253) | `` saga: 9.9.2 -> 9.9.3 ``                                                        |
| [`f9db11fa`](https://github.com/NixOS/nixpkgs/commit/f9db11fac23cb4138f97de68007b32c8818f58a3) | `` home-assistant-custom-components.polaris-mqtt: init at 1.0.10 ``               |
| [`f87fe90c`](https://github.com/NixOS/nixpkgs/commit/f87fe90c176987e18b9e9d1c570cf0707eeaee17) | `` snx-rs: 4.8.1 -> 4.8.2 ``                                                      |
| [`e1057732`](https://github.com/NixOS/nixpkgs/commit/e10577327c050f4f604bfc06492d3f13a51efe34) | `` haproxy: remove cve patch ``                                                   |
| [`88e1ce68`](https://github.com/NixOS/nixpkgs/commit/88e1ce68199e27e234fff339c1d0363a2c12b757) | `` README: update NixOS logo ``                                                   |
| [`83b2f4f9`](https://github.com/NixOS/nixpkgs/commit/83b2f4f94969909978409e39651b46b360566fbb) | `` rqlite: 9.1.0 -> 9.1.2 ``                                                      |
| [`c0b1530c`](https://github.com/NixOS/nixpkgs/commit/c0b1530c7cb24d128e51530b2d31b4e18d7aabf4) | `` omnom: 0.6.0 -> 0.7.0 ``                                                       |
| [`6cd93803`](https://github.com/NixOS/nixpkgs/commit/6cd93803310e7e4fe65323cfd93a1c83c5c71468) | `` syncthingtray: 2.0.1 -> 2.0.2 ``                                               |
| [`2991a8f5`](https://github.com/NixOS/nixpkgs/commit/2991a8f5201084720ae49f0eaaf1554b4e2d6bb8) | `` tile38: 1.36.3 -> 1.36.5 ``                                                    |
| [`ca1ce624`](https://github.com/NixOS/nixpkgs/commit/ca1ce624dd197f5c4941e403ae33a588dd5e983f) | `` reth: 1.7.0 -> 1.8.2 ``                                                        |
| [`060d8806`](https://github.com/NixOS/nixpkgs/commit/060d880630830e97991953f99a7971b5811707d1) | `` findup: 1.1.3 -> 2.0.0 ``                                                      |
| [`1e3e3271`](https://github.com/NixOS/nixpkgs/commit/1e3e32716170ef435ac3cfbcded147712d2c8b28) | `` net-snmp: update homepage to https ``                                          |
| [`dd52227a`](https://github.com/NixOS/nixpkgs/commit/dd52227aa5d9ebebd4eb7bab6195406662732e2b) | `` lldpd: fix cross compilation ``                                                |
| [`57185b06`](https://github.com/NixOS/nixpkgs/commit/57185b06afe3cc799316beb13b9177b2d5920d51) | `` qpwgraph: 0.9.5 -> 0.9.6 ``                                                    |
| [`abf7fd77`](https://github.com/NixOS/nixpkgs/commit/abf7fd777c3281b977fd50e2d55952ffbbae95c5) | `` postgresqlPackages.pgroonga: 4.0.2 -> 4.0.4 ``                                 |
| [`0d35ffb7`](https://github.com/NixOS/nixpkgs/commit/0d35ffb70e19892b27151abe06b3ac415f1478d3) | `` prometheus-bitcoin-exporter: 0.8.0 -> 0.9.0 ``                                 |
| [`bfbec2ce`](https://github.com/NixOS/nixpkgs/commit/bfbec2cef75cf86ca6678a1cac00ab6440e825ba) | `` python3Packages.django-phonenumber-field: 8.2.0 -> 8.3.0 ``                    |
| [`779dfc35`](https://github.com/NixOS/nixpkgs/commit/779dfc354c42952b375c0cb0e5a2e29206e272ca) | `` cargo-llvm-cov: 0.6.17 -> 0.6.20 ``                                            |
| [`28e2bf38`](https://github.com/NixOS/nixpkgs/commit/28e2bf389fae8d2213776dd882e0c0e9f1785bfc) | `` python3Packages.types-lxml: 2025.03.30 -> 2025.08.25 ``                        |
| [`c3eac21c`](https://github.com/NixOS/nixpkgs/commit/c3eac21ca4b789c3467724b27bbf1ef3d8a7f172) | `` cargo-rdme: 1.4.8 -> 1.4.9 ``                                                  |
| [`7d50b827`](https://github.com/NixOS/nixpkgs/commit/7d50b827d5d1b0c941e53af2e091d7af2b83e77d) | `` clapboard: 1.1.0 -> 1.1.1 ``                                                   |
| [`8d3793de`](https://github.com/NixOS/nixpkgs/commit/8d3793dea975e6b46f053ae2c33c02e40a8f53ee) | `` imagemagick: 7.1.2-4 -> 7.1.2-5 ``                                             |
| [`8b5f6fd9`](https://github.com/NixOS/nixpkgs/commit/8b5f6fd9d028b67253b9a9048fbc5fd2eeeb97fa) | `` python3Packages.notobuilder: 0-unstable-2025-08-20 -> 0-unstable-2025-09-29 `` |
| [`3e9bbb6e`](https://github.com/NixOS/nixpkgs/commit/3e9bbb6e9e2495974cfe17dc168fbc13ae2adadf) | `` perlPackages.AppFatPackerSimple: init at 0.20 ``                               |
| [`624360da`](https://github.com/NixOS/nixpkgs/commit/624360da9365bb5170f601bf128f39c13cdbc666) | `` mxnet: fix build with CMake 4.0 ``                                             |
| [`f1e52abf`](https://github.com/NixOS/nixpkgs/commit/f1e52abf0d364f44d6351dc824d29271a29ae254) | `` nixos/immich: fix eval with `settings == null` ``                              |
| [`8f2f7371`](https://github.com/NixOS/nixpkgs/commit/8f2f7371fdb16250b5371cf4b17a85fd45a27200) | `` libversion: 3.0.3 -> 3.0.4 ``                                                  |
| [`6c3c3951`](https://github.com/NixOS/nixpkgs/commit/6c3c3951fb76343e5f8589db3ab0f82cea1d8f30) | `` ocamlPackages.synchronizer: init at 0.1 ``                                     |
| [`65daf172`](https://github.com/NixOS/nixpkgs/commit/65daf17219a9467b758c56a7c8516ea22935ba33) | `` pattypan: unbreak ``                                                           |
| [`1fca9aa4`](https://github.com/NixOS/nixpkgs/commit/1fca9aa4c2a6b63c19acaea26d147587f32774de) | `` ashell: 0.5.0 -> 0.6.0 ``                                                      |
| [`5e06b226`](https://github.com/NixOS/nixpkgs/commit/5e06b226b67c7628233e4c0aababa2ff5bbb740f) | `` python3Packages.moyopy: 0.5.0 -> 0.6.0 ``                                      |
| [`8c7bf59d`](https://github.com/NixOS/nixpkgs/commit/8c7bf59d8fe653a8c3759f3283febcd0950cf96b) | `` python3Packages.sagemaker: 2.251.1 -> 2.252.0 ``                               |
| [`eb685514`](https://github.com/NixOS/nixpkgs/commit/eb685514f21a564e016bea0d185c4a73d51ffc55) | `` stevenblack-blocklist: 3.16.20 -> 3.16.23 ``                                   |
| [`86a7a6a1`](https://github.com/NixOS/nixpkgs/commit/86a7a6a1380784cd28766b5ad7741fe7a4fcea3f) | `` home-assistant-custom-components.sensi: 1.3.15 -> 1.4.2 ``                     |
| [`22857a9b`](https://github.com/NixOS/nixpkgs/commit/22857a9b216fb171ce15856ae7dbc040622e6bd2) | `` python3Packages.enaml: 0.18.0 -> 0.19.0 ``                                     |
| [`d64cf501`](https://github.com/NixOS/nixpkgs/commit/d64cf501848833a047e006183df676ac27dbb2d8) | `` nixos/gpu-screen-recorder: Use getExe instead of building paths ``             |
| [`8da3d93c`](https://github.com/NixOS/nixpkgs/commit/8da3d93c67353810e309bac1816d7aef8f8afa71) | `` kirsch: 0.7.0 -> 0.7.1 ``                                                      |
| [`ffa78849`](https://github.com/NixOS/nixpkgs/commit/ffa78849978380ffe3cec3499d7c7f74344f3d8c) | `` wasm-language-tools: 0.6.0 -> 0.6.1 ``                                         |
| [`6127ad46`](https://github.com/NixOS/nixpkgs/commit/6127ad465517e9933ff0bbbfc6fbe27b261924ad) | `` sudo-rs: add adamcstephens as maintainer ``                                    |
| [`b7a35640`](https://github.com/NixOS/nixpkgs/commit/b7a356405480482658118ac629a32de0ff95211c) | `` python3Packages.adafruit-platformdetect: 3.83.2 -> 3.84.0 ``                   |
| [`8d665b5b`](https://github.com/NixOS/nixpkgs/commit/8d665b5b7aa29cd7a0235e9b129529a4090bd3d3) | `` pluginval: init at 1.0.4 ``                                                    |
| [`c6f08e70`](https://github.com/NixOS/nixpkgs/commit/c6f08e70358f4a6039e411225f989f1585fe9cfe) | `` gitlab-ci-ls: 1.2.1 -> 1.2.2 ``                                                |
| [`26c9934e`](https://github.com/NixOS/nixpkgs/commit/26c9934eb78a676d21b8c27c51266dcb75c96982) | `` maintainers: drop l-as ``                                                      |
| [`2dc3a425`](https://github.com/NixOS/nixpkgs/commit/2dc3a4251e308b8135de5e39012638810765251f) | `` zigfetch: init at 0.23.0 ``                                                    |
| [`e859ed8e`](https://github.com/NixOS/nixpkgs/commit/e859ed8edead2ecd8832ab81bd19f595502dbd07) | `` vscodium: 1.104.16282 -> 1.104.36664 ``                                        |
| [`6efc7c29`](https://github.com/NixOS/nixpkgs/commit/6efc7c29a932ad679f560ad49292fd5ee1374288) | `` python3Packages.binsync: 5.5.1 -> 5.7.10 ``                                    |
| [`d20cfa8f`](https://github.com/NixOS/nixpkgs/commit/d20cfa8f5f4bfd576c6da5fca8b2b0c3ec4cb454) | `` ctagdrc: init at 0.1.1 ``                                                      |
| [`7452601e`](https://github.com/NixOS/nixpkgs/commit/7452601ef61228a77d96182a324dbb3218bb8f25) | `` python3Packages.jupyterhub: 5.3.0 -> 5.4.0 ``                                  |
| [`fc2d4833`](https://github.com/NixOS/nixpkgs/commit/fc2d48332bc622c09f8ed8dae90cc621e7272acb) | `` cloudflare-warp: add meta.changelog ``                                         |
| [`7f434211`](https://github.com/NixOS/nixpkgs/commit/7f434211a192bd9850a1981d1fc9dedc0e484a2f) | `` cloudflare-warp: modernize ``                                                  |
| [`88f68585`](https://github.com/NixOS/nixpkgs/commit/88f68585d417ee2cc69178d92dd3dc6b45721446) | `` ghostty-bin: 1.2.0 -> 1.2.1 ``                                                 |
| [`1d0c315a`](https://github.com/NixOS/nixpkgs/commit/1d0c315ad25618828807f5bd0c14d44685bdee73) | `` ghostty: 1.2.0 -> 1.2.1 ``                                                     |
| [`3040fe8f`](https://github.com/NixOS/nixpkgs/commit/3040fe8f76947e22addd0ab9c1085be51554c99a) | `` astal.source: 0-unstable-2025-09-10 -> 0-unstable-2025-10-05 ``                |
| [`d984a414`](https://github.com/NixOS/nixpkgs/commit/d984a414f77014452f4bc1065cc8ef44f87e9bf1) | `` podman-tui: add maintainer iedame ``                                           |
| [`83977c63`](https://github.com/NixOS/nixpkgs/commit/83977c6327955be474628d59f98a08f21d493c48) | `` podman-tui: 1.8.1 -> 1.9.0 ``                                                  |
| [`f0d1b551`](https://github.com/NixOS/nixpkgs/commit/f0d1b55145675a2b0e1727726331d4755ce7710c) | `` llvmPackages_git: 22.0.0-unstable-2025-09-28 -> 22.0.0-unstable-2025-10-05 ``  |
| [`2bdc27c4`](https://github.com/NixOS/nixpkgs/commit/2bdc27c4ab4a4c00645d76d7bf5287ef9d170650) | `` issue2md: 1.3.0 -> 1.3.1 ``                                                    |
| [`4aaf875e`](https://github.com/NixOS/nixpkgs/commit/4aaf875e25d353a47c5f9e93b19545b5a79bf5e5) | `` terraform-providers.yandex: 0.159.0 -> 0.162.0 ``                              |
| [`3aaa1879`](https://github.com/NixOS/nixpkgs/commit/3aaa1879b5e4ba16be14ae4e005ff2fa3bec544b) | `` terraform-providers.pagerduty: 3.29.0 -> 3.30.1 ``                             |
| [`b1aa7a55`](https://github.com/NixOS/nixpkgs/commit/b1aa7a5521060ee03d73dad91ba719930a85e008) | `` gildas: 20250901_a -> 20251001_a ``                                            |
| [`8a8f9604`](https://github.com/NixOS/nixpkgs/commit/8a8f9604698f5219dbfb6fa95d3f37db743c3afe) | `` terraform-providers.mongodbatlas: 2.0.0 -> 2.0.1 ``                            |
| [`3a64062d`](https://github.com/NixOS/nixpkgs/commit/3a64062d66a28d45f62ca6fdf792f25a7aaeafad) | `` just-lsp: 0.2.6 -> 0.2.7 ``                                                    |
| [`df85e6ef`](https://github.com/NixOS/nixpkgs/commit/df85e6efe6e643372190793fe1b8afc7e523e55c) | `` ed-odyssey-materials-helper: 3.0.1 -> 3.0.6 ``                                 |
| [`47513a19`](https://github.com/NixOS/nixpkgs/commit/47513a1990cb919b476b73215025606f7a5d498b) | `` temurin-{,jre-}bin-24: drop, open{jdk,jfx}24: drop ``                          |
| [`a6dae01d`](https://github.com/NixOS/nixpkgs/commit/a6dae01d158ffadfcec8f1c35420ee8a83f56dc9) | `` python3Packages.pymupdf: disable test requiring network access ``              |
| [`4c2316f5`](https://github.com/NixOS/nixpkgs/commit/4c2316f556099ae37cc751801c2d3170962a2e86) | `` mupdf: fix build with enableCxx against Clang >= 20 ``                         |
| [`0645bd7a`](https://github.com/NixOS/nixpkgs/commit/0645bd7a1f8209fd2473a2a96d6d43c08a8f5f0a) | `` vintagestory: 1.21.2 -> 1.21.4 ``                                              |
| [`ab2deeb8`](https://github.com/NixOS/nixpkgs/commit/ab2deeb8085f4d6a801c011ffa56cdbcfd148247) | `` alertmanager-ntfy: 1.0.1 -> 1.0.2 ``                                           |
| [`df06ff92`](https://github.com/NixOS/nixpkgs/commit/df06ff92950d64c08d1c64417e6d2560782b2553) | `` vimPlugins.rainbow-delimiters-nvim: 0.9.1 -> 0.10.0 ``                         |
| [`b5125315`](https://github.com/NixOS/nixpkgs/commit/b5125315ff9b87f7bb052f736ce5cf7fe6ba06d3) | `` imagemagick: 7.1.2-3 -> 7.1.2-4 ``                                             |
| [`920ff505`](https://github.com/NixOS/nixpkgs/commit/920ff50584689fe574a72ece2be73cf85dd11790) | `` vsce: fix gyp build error of keytar ``                                         |
| [`3e722106`](https://github.com/NixOS/nixpkgs/commit/3e7221064004eb2e83a83e53b067c1ad40edd57f) | `` hyprls: 0.8.0 -> 0.9.1 ``                                                      |