### PR TITLE
chore(flake/nur): `1c7dbdd3` -> `b3d7d8cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1759733170,
-        "narHash": "sha256-TXnlsVb5Z8HXZ6mZoeOAIwxmvGHp1g4Dw89eLvIwKVI=",
+        "lastModified": 1759831965,
+        "narHash": "sha256-vgPm2xjOmKdZ0xKA6yLXPJpjOtQPHfaZDRtH+47XEBo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8913c168d1c56dc49a7718685968f38752171c3b",
+        "rev": "c9b6fb798541223bbb396d287d16f43520250518",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759893655,
-        "narHash": "sha256-O89o1x4hawH+7vi3zgnlNiFpzhcfpPD/6nOOB+m4e+c=",
+        "lastModified": 1759905023,
+        "narHash": "sha256-2aGGMzvLzGV1cr55uWpGvBbg1cCs512w3h7r3+Bx0wY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1c7dbdd3c897955e858f092008f300b5d7e2acc3",
+        "rev": "b3d7d8cb84e4c1b59d1c66f77c0b53c8915045e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b3d7d8cb`](https://github.com/nix-community/NUR/commit/b3d7d8cb84e4c1b59d1c66f77c0b53c8915045e9) | `` automatic update `` |
| [`403444b4`](https://github.com/nix-community/NUR/commit/403444b4810a974cecdf34307fb30f2ae7aed48e) | `` automatic update `` |
| [`088ba7a7`](https://github.com/nix-community/NUR/commit/088ba7a7aa1391540301ab728e667f1648845c46) | `` automatic update `` |
| [`571facee`](https://github.com/nix-community/NUR/commit/571facee77c447a0ca649ddca6d50c645f1e877d) | `` automatic update `` |
| [`5c1958c9`](https://github.com/nix-community/NUR/commit/5c1958c9146d5b7f0a7fd683fbce9073f2433c93) | `` automatic update `` |
| [`cd308601`](https://github.com/nix-community/NUR/commit/cd308601119e1f833cf4ac319aa19972c15386e8) | `` automatic update `` |