### PR TITLE
chore(flake/nur): `7100dfe6` -> `638ddaad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1759921619,
-        "narHash": "sha256-pPV5sLXlEAGwyyj51B5RCXhySYvKocf79I+ug1dKPXI=",
+        "lastModified": 1759931405,
+        "narHash": "sha256-3XsDN9/DRbbE+JNnIm0QtDvCU0RH9jfPVc/JjMAqxlE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7100dfe6826fffc198a21b96244fa24bedd8ad97",
+        "rev": "638ddaad78523064b49f6b7f64cd79a50be7bfb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`638ddaad`](https://github.com/nix-community/NUR/commit/638ddaad78523064b49f6b7f64cd79a50be7bfb3) | `` automatic update `` |
| [`d7642d96`](https://github.com/nix-community/NUR/commit/d7642d9653c2c8e1becd1fd1b3c9386298aba6bc) | `` automatic update `` |