### PR TITLE
chore(flake/nixpkgs): `daf6dc47` -> `ac62194c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1761597516,
-        "narHash": "sha256-wxX7u6D2rpkJLWkZ2E932SIvDJW8+ON/0Yy8+a5vsDU=",
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "daf6dc47aa4b44791372d6139ab7b25269184d55",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                  |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
| [`6c62d013`](https://github.com/NixOS/nixpkgs/commit/6c62d013b36c589618eec5a8d450506e15b9cb31) | `` maintainers/github-teams.json: Automated sync ``                                                      |
| [`272930fe`](https://github.com/NixOS/nixpkgs/commit/272930fec6b63348fa8a7dc3e863b6b4b79ca728) | `` treewide: fix or-as-identifier ``                                                                     |
| [`0329ebce`](https://github.com/NixOS/nixpkgs/commit/0329ebce8250ec178780b4750fc9395cb0ccb874) | `` microsoft-edge: 143.0.3650.80 -> 143.0.3650.96 ``                                                     |
| [`84c56b7f`](https://github.com/NixOS/nixpkgs/commit/84c56b7f2a51093b8c9cc4d1fa33e780953d277d) | `` microsoft-edge: 143.0.3650.66 -> 143.0.3650.80 ``                                                     |
| [`7f477e54`](https://github.com/NixOS/nixpkgs/commit/7f477e545190c773d7da9c87a87f292a54ec096f) | `` php82: 8.2.29 -> 8.2.30, fixes CVE-2025-14177, CVE-2025-14178, CVE-2025-14180, GHSA-www2-q4fc-65wf `` |
| [`1285997e`](https://github.com/NixOS/nixpkgs/commit/1285997ef199692690a40f94962b8c4349bca54c) | `` php83: 8.3.28 -> 8.3.29, fixes CVE-2025-14177, CVE-2025-14178, CVE-2025-14180, GHSA-www2-q4fc-65wf `` |
| [`0a87413d`](https://github.com/NixOS/nixpkgs/commit/0a87413d48128d0dc071087d446710744d75321d) | `` php84: 8.4.15 -> 8.4.16, fixes CVE-2025-14177, CVE-2025-14178, CVE-2025-14180, GHSA-www2-q4fc-65wf `` |
| [`25d4a74c`](https://github.com/NixOS/nixpkgs/commit/25d4a74c93028f53e540e413f753984a7f555301) | `` perlPackages.YAMLSyck: 1.34 -> 1.36 ``                                                                |
| [`acc69cb6`](https://github.com/NixOS/nixpkgs/commit/acc69cb6b28908d52f73459d39abc15533cf2c4c) | `` maintainers/github-teams.json: Automated sync ``                                                      |
| [`83b3d3df`](https://github.com/NixOS/nixpkgs/commit/83b3d3dfe256984753dd7082a7d32ea234c7bd30) | `` treewide: fix broken-string-escape ``                                                                 |
| [`b0a9c473`](https://github.com/NixOS/nixpkgs/commit/b0a9c4730b4856f80beb1d83f00caf50c5ddf15a) | `` microsoft-edge: 142.0.3595.65 -> 143.0.3650.66 ``                                                     |
| [`dc5fbdb5`](https://github.com/NixOS/nixpkgs/commit/dc5fbdb5ca7f41a2dde746f2263f3491c2325f7a) | `` linux_6_17: remove ``                                                                                 |
| [`1536ff59`](https://github.com/NixOS/nixpkgs/commit/1536ff59f72cc3cc4ea3dd42a3bbad3bd2ca2e7a) | `` yarn2nix-moretea: update dependencies for yarn2nix ``                                                 |
| [`e8f7dd8b`](https://github.com/NixOS/nixpkgs/commit/e8f7dd8baedf8f7e9b4a934bf91082d6370e36f3) | `` postfix-tlspol: 1.8.23 -> 1.8.24 ``                                                                   |
| [`2c9f6d1c`](https://github.com/NixOS/nixpkgs/commit/2c9f6d1c1dbffd9fe193fbc88a0b8df98cac9664) | `` protoc-gen-grpc-java: 1.77.0 -> 1.78.0 ``                                                             |
| [`33cdc0bd`](https://github.com/NixOS/nixpkgs/commit/33cdc0bd81b34e05febb71eaeeb4b1251e688724) | `` moodle: 5.0.2 -> 5.0.4 ``                                                                             |
| [`57aa0f7b`](https://github.com/NixOS/nixpkgs/commit/57aa0f7b24840238af6b9fe3ebd37d7a8de014ca) | `` moodle: 5.0.1 -> 5.0.2 ``                                                                             |
| [`b8e3f3db`](https://github.com/NixOS/nixpkgs/commit/b8e3f3dbb2cf26e678870eba9a01182bbc8d8ab8) | `` moodle: 5.0 -> 5.0.1 ``                                                                               |
| [`2f32d5a3`](https://github.com/NixOS/nixpkgs/commit/2f32d5a325c92cb1d92c92959b602c8005dc92e6) | `` linuxKernel.kernels.linux_lqx: 6.17.13 -> 6.18.2 ``                                                   |
| [`efdd8d3d`](https://github.com/NixOS/nixpkgs/commit/efdd8d3d58758e2dde7da182fda690bfa2da7c53) | `` pgbouncer: 1.24.1 -> 1.25.1 ``                                                                        |
| [`50ae0728`](https://github.com/NixOS/nixpkgs/commit/50ae072874da06034405ae995046e53c3b6d927e) | `` mongodb*: mark vulnerable to 25.05 ``                                                                 |
| [`1a3fba18`](https://github.com/NixOS/nixpkgs/commit/1a3fba183dec9010ed2d02e3c0ad7e40c3436ed2) | `` linux/hardened/patches/6.12: v6.12.56-hardened1 -> v6.12.61-hardened1 ``                              |
| [`9cb5cce7`](https://github.com/NixOS/nixpkgs/commit/9cb5cce7e1f64bbad2c25c39d1ff488f2146fc12) | `` linuxKernel.kernels.linux_zen: 6.18.1 -> 6.18.2 ``                                                    |
| [`f10dc5b5`](https://github.com/NixOS/nixpkgs/commit/f10dc5b53761a66e2caf6df4e3aca2b51207cf4c) | `` workflows/labels: add "6.topic: tree-sitter" label ``                                                 |
| [`d4c94fd9`](https://github.com/NixOS/nixpkgs/commit/d4c94fd9ccd3834b363c1fc8caa38e9d2d51f9a2) | `` signal-desktop: 7.82.0 -> 7.83.0 ``                                                                   |
| [`74a058bf`](https://github.com/NixOS/nixpkgs/commit/74a058bfd7ffa8ab2ff890ab1764aebff51280f2) | `` librewolf-bin: mark with `knownVulnerabilities` due to lack of maintenance in nixpkgs ``              |
| [`899410ac`](https://github.com/NixOS/nixpkgs/commit/899410acb17fb828073be810d4968549364a0db1) | `` thunderbird-latest-bin-unwrapped: 146.0 -> 146.0.1 ``                                                 |
| [`8b9aedd3`](https://github.com/NixOS/nixpkgs/commit/8b9aedd3162ecd088a1855ddbda178520211ee8d) | `` signal-desktop: 7.81.0 -> 7.82.0 ``                                                                   |
| [`a467cae1`](https://github.com/NixOS/nixpkgs/commit/a467cae174a0bbc104b30f8867b6cc610fac565e) | `` n8n: mark vulnerable to CVE-2025-68613 ``                                                             |
| [`358c5f36`](https://github.com/NixOS/nixpkgs/commit/358c5f365079d75eddbdadeef85dc26556614d57) | `` anubis: 1.23.1 -> 1.24.0 ``                                                                           |
| [`7c85b4de`](https://github.com/NixOS/nixpkgs/commit/7c85b4de98514e0ca13a340144ffcf4547267425) | `` nixos/nvidia: blacklistedKernelModules add `nova_core` ``                                             |
| [`b5a7ebaa`](https://github.com/NixOS/nixpkgs/commit/b5a7ebaa259b5abe9bce28b3a82c73ffecc0a730) | `` signal-desktop-bin(darwin): 7.80.0 -> 7.83.0 ``                                                       |
| [`8603891d`](https://github.com/NixOS/nixpkgs/commit/8603891d2516c9a89a2412a2606b66de2c78a17f) | `` signal-desktop-bin(aarch64): 7.80.0 -> 7.83.0 ``                                                      |
| [`0596d4c1`](https://github.com/NixOS/nixpkgs/commit/0596d4c1fce3a31c8fa63d5641ebcd4423b7c23e) | `` signal-desktop-bin: 7.80.0 -> 7.83.0 ``                                                               |
| [`cc370acc`](https://github.com/NixOS/nixpkgs/commit/cc370acc9a7c3606f9101ba24bcc439541d968cc) | `` osmtogeojson: regnerate lockfile, run tests ``                                                        |
| [`e80b8301`](https://github.com/NixOS/nixpkgs/commit/e80b83014e66e6eaf14b7cc7672862bfca7a54be) | `` sharedown: 5.3.6 -> 5.3.6-unstable-2025-12-06 ``                                                      |
| [`7110de8d`](https://github.com/NixOS/nixpkgs/commit/7110de8dea983f97c10d51aaed35675c567a65ea) | `` sharedown: use latest commits, refactor for updateScript ``                                           |
| [`800c4d9b`](https://github.com/NixOS/nixpkgs/commit/800c4d9b85b2fbdf644502dab589c68c69004d93) | `` nginxMainline: 1.29.3 -> 1.29.4 ``                                                                    |
| [`255d9f64`](https://github.com/NixOS/nixpkgs/commit/255d9f645ad1f4fd7f41af1899b2aa4aee1937eb) | `` airgorah: fix typo `dessktopItems` ``                                                                 |
| [`ac969581`](https://github.com/NixOS/nixpkgs/commit/ac9695810f2f4bb402f3d7dc7dc5087c3bc915f8) | `` crabfit-api: regenerate lockfile, mark vulnerable ``                                                  |
| [`7f444fc2`](https://github.com/NixOS/nixpkgs/commit/7f444fc2e511e9159f439f62ebc28e16da4d4775) | `` postfix-tlspol: 1.8.22 -> 1.8.23 ``                                                                   |
| [`c8c34851`](https://github.com/NixOS/nixpkgs/commit/c8c34851bc9723fae2d5bb8c706fc8ca807cc32f) | `` build(deps): bump korthout/backport-action from 4.0.0 to 4.0.1 ``                                     |
| [`2ed3611d`](https://github.com/NixOS/nixpkgs/commit/2ed3611d614c5f4a913a57546865f0e7e7e5e78b) | `` linuxKernel.kernels.linux_lqx: 6.17.12 -> 6.17.13 ``                                                  |
| [`8dfef0dc`](https://github.com/NixOS/nixpkgs/commit/8dfef0dc344a521e5332d0fbb18616d0a613477a) | `` victoriametrics:  fix vendor/modules.txt patching ``                                                  |
| [`40dfe763`](https://github.com/NixOS/nixpkgs/commit/40dfe763e428afc457f567209bc6be738d429ee7) | `` brave: 1.85.117 -> 1.85.118 ``                                                                        |
| [`e30cceeb`](https://github.com/NixOS/nixpkgs/commit/e30cceeb03ac500dab15dd5d995c60094e4ea9d0) | `` thunderbird-latest-unwrapped: 145.0 -> 146.0.1 ``                                                     |
| [`d936f8aa`](https://github.com/NixOS/nixpkgs/commit/d936f8aa9dcf93ed50553090fd0166f667f7e685) | `` webkitgtk_6_0: 2.50.3 → 2.50.4 ``                                                                     |
| [`d58c596a`](https://github.com/NixOS/nixpkgs/commit/d58c596a11d09b2733fdfaba5c2b42cb98a0317b) | `` ungoogled-chromium: 143.0.7499.146-1 -> 143.0.7499.169-1 ``                                           |
| [`4a0cca13`](https://github.com/NixOS/nixpkgs/commit/4a0cca13e02027ac24f6e377b16e63818d0e1ace) | `` chromium,chromedriver: 143.0.7499.146 -> 143.0.7499.169 ``                                            |
| [`74bc9faf`](https://github.com/NixOS/nixpkgs/commit/74bc9faf17f5fb6997dcc5ce122c19c4b6a2c6ab) | `` surrealdb: 2.3.8 -> 2.3.10 ``                                                                         |
| [`20f44f48`](https://github.com/NixOS/nixpkgs/commit/20f44f485e2d073178a6e9f9d1c0aaca6dd19b74) | `` surrealdb: 2.3.7 -> 2.3.8 ``                                                                          |
| [`d3281515`](https://github.com/NixOS/nixpkgs/commit/d3281515b8b6d716ab9b472db5e948942f3f99de) | `` surrealdb: modernize ``                                                                               |
| [`366a68f2`](https://github.com/NixOS/nixpkgs/commit/366a68f20454855f9640eac3a0745720449d1f57) | `` surrealdb: 2.3.5 -> 2.3.7 ``                                                                          |
| [`e92ef394`](https://github.com/NixOS/nixpkgs/commit/e92ef394e1289010b3da3c13435b63062575c064) | `` surrealdb: 2.3.4 -> 2.3.5 ``                                                                          |
| [`41b7dbfc`](https://github.com/NixOS/nixpkgs/commit/41b7dbfc0a70e6fd923586e4ba39b77e661810d0) | `` surrealdb: 2.3.3 -> 2.3.4 ``                                                                          |
| [`e2e6078c`](https://github.com/NixOS/nixpkgs/commit/e2e6078c6267fee14de0b9a4c187ad06898f1938) | `` surrealdb: 2.3.2 -> 2.3.3 ``                                                                          |
| [`5e90d1ff`](https://github.com/NixOS/nixpkgs/commit/5e90d1ff10fc39e0eae61348e1e8eec9bed7cd23) | `` firefox-bin-unwrapped: 146.0 -> 146.0.1 ``                                                            |
| [`f0b85aac`](https://github.com/NixOS/nixpkgs/commit/f0b85aacbc35ffc016bb61477d41bd63abb322ec) | `` firefox-unwrapped: 146.0 -> 146.0.1 ``                                                                |
| [`d49c8cfe`](https://github.com/NixOS/nixpkgs/commit/d49c8cfe6c2442e040ee6ff261db2cc5fe52550f) | `` google-chrome: 143.0.7499.146 -> 143.0.7499.169 ``                                                    |
| [`d1b86054`](https://github.com/NixOS/nixpkgs/commit/d1b86054fecb971b933dbbf8631a4c2628801c60) | `` deploy-rs: 0-unstable-2024-06-05 -> 0-unstable-2025-12-18 ``                                          |
| [`b9bafb45`](https://github.com/NixOS/nixpkgs/commit/b9bafb4540a27f059e99851ab863a75ef25da3b2) | `` workflows/lint: fully skip the `commits` job in Merge Queues ``                                       |
| [`9825c934`](https://github.com/NixOS/nixpkgs/commit/9825c9340fa06d59d9feea0fbf7b7a636a0df4f3) | `` linux_6_12: 6.12.62 -> 6.12.63 ``                                                                     |
| [`2921be78`](https://github.com/NixOS/nixpkgs/commit/2921be787655838bee3ea403933480af0da93731) | `` linux_6_17: 6.17.12 -> 6.17.13 ``                                                                     |
| [`c4eeca46`](https://github.com/NixOS/nixpkgs/commit/c4eeca46d228aed1fa096d7282927734923b2f9c) | `` linux_6_18: 6.18.1 -> 6.18.2 ``                                                                       |
| [`b1844d09`](https://github.com/NixOS/nixpkgs/commit/b1844d09d876d7f7a8cce2104e01725bfac8cd6b) | `` linux_testing: 6.18-rc7 -> 6.19-rc1 ``                                                                |
| [`3bea4d1c`](https://github.com/NixOS/nixpkgs/commit/3bea4d1c8a29ace6fa066b20e8ccc09cbcdc5791) | `` linux/common-config: explicitly select RUST_FW_LOADER_ABSTRACTIONS for now ``                         |
| [`fde57d8b`](https://github.com/NixOS/nixpkgs/commit/fde57d8b9933362edb2417ccbcbe331c9118ee0e) | `` {workflows/lint,ci/github-script}: lint commit messages ``                                            |
| [`b68ab241`](https://github.com/NixOS/nixpkgs/commit/b68ab24112f636613a92db053060e9c44b00cdac) | `` brave: 1.85.116 -> 1.85.117 ``                                                                        |
| [`ae8ebfbd`](https://github.com/NixOS/nixpkgs/commit/ae8ebfbd4242edd71dfe8daa8f3da8d30328772e) | `` buildPythonPackage: chore: remove unnecessary set update ``                                           |
| [`f4c81353`](https://github.com/NixOS/nixpkgs/commit/f4c813531c3d1b6e6ad34cfa2898e380d3a173ac) | `` zipline: 4.3.2 -> 4.4.0 ``                                                                            |
| [`c22f46e6`](https://github.com/NixOS/nixpkgs/commit/c22f46e67fd175d8f6d1c06374476e32d5faa21f) | `` aspell: stop using `or` identifier unquoted ``                                                        |
| [`b9f17786`](https://github.com/NixOS/nixpkgs/commit/b9f177865fc72aa012211880f51a8ecd0b04969d) | `` roundcube: 1.6.11 -> 1.6.12 ``                                                                        |
| [`94a1772f`](https://github.com/NixOS/nixpkgs/commit/94a1772f4b2c0f29efdb4cebe282a5e31d3e7f6e) | `` dropbear: 2025.88 -> 2025.89 ``                                                                       |
| [`6cc0fe26`](https://github.com/NixOS/nixpkgs/commit/6cc0fe268e3d89d7461a0acb1db10068b6758739) | `` ungoogled-chromium: 143.0.7499.109-1 -> 143.0.7499.146-1 ``                                           |
| [`8a1ac8e4`](https://github.com/NixOS/nixpkgs/commit/8a1ac8e4c892536492c817511a58c3e5c1a0dbaf) | `` v4l2loopback: 0.15.1 -> 0.15.3 ``                                                                     |
| [`d8f74f88`](https://github.com/NixOS/nixpkgs/commit/d8f74f88963cdfec0d7e1cd9f2e1ff2279f8b411) | `` v4l2loopback: Add nix update script ``                                                                |
| [`67adc519`](https://github.com/NixOS/nixpkgs/commit/67adc5198ba485993410142bedec626c859f0c0a) | `` matrix-authentication-service: 1.7.0 -> 1.8.0 ``                                                      |
| [`5b8aaa7d`](https://github.com/NixOS/nixpkgs/commit/5b8aaa7d0f3158f3c478e54d3cd7be4ddfa1e085) | `` maintainers: Rename name of Mynacol ``                                                                |
| [`2ae8d3ea`](https://github.com/NixOS/nixpkgs/commit/2ae8d3ea62e87d9c60f695b69e97dcf56b63a84d) | `` slack: 4.47.59 -> 4.47.72 ``                                                                          |
| [`7b3133cd`](https://github.com/NixOS/nixpkgs/commit/7b3133cddba9f220c3ba1db8135bfffa72fc18d2) | `` build(deps): bump cachix/install-nix-action from 31.8.4 to 31.9.0 ``                                  |
| [`2efa8bab`](https://github.com/NixOS/nixpkgs/commit/2efa8bab0e8018b30f227ccb5b101775ba27fe8b) | `` google-chrome: 143.0.7499.109 -> 143.0.7499.146 ``                                                    |
| [`03582367`](https://github.com/NixOS/nixpkgs/commit/0358236791bb769ed9e005a9b0d0378b6893c34a) | `` chromium,chromedriver: 143.0.7499.109 -> 143.0.7499.146 ``                                            |
| [`12c06021`](https://github.com/NixOS/nixpkgs/commit/12c060212fb1c85d290bc66c7e26a8b4ca486677) | `` build(deps): bump actions/download-artifact from 6.0.0 to 7.0.0 ``                                    |
| [`d628d622`](https://github.com/NixOS/nixpkgs/commit/d628d622fb20ce79ce083224cd27bc3c3ce29c9d) | `` build(deps): bump korthout/backport-action from 3.4.1 to 4.0.0 ``                                     |
| [`2b2cedc0`](https://github.com/NixOS/nixpkgs/commit/2b2cedc0153cd3aacc92af8e007372cd8bae5f77) | `` build(deps): bump peter-evans/create-pull-request from 7.0.11 to 8.0.0 ``                             |
| [`ce704ef0`](https://github.com/NixOS/nixpkgs/commit/ce704ef0db79bf58070ad18a397fbb5abfba2207) | `` servo: 0.0.2 -> 0.0.3 ``                                                                              |
| [`d84bf725`](https://github.com/NixOS/nixpkgs/commit/d84bf7256f860f484182f6055378f3feabfdfca2) | `` linuxKernel.kernels.linux_zen: 6.18 -> 6.18.1 ``                                                      |
| [`cdee795e`](https://github.com/NixOS/nixpkgs/commit/cdee795ecf40d05c5ce2032ce3b1943819811ec2) | `` gimp: 3.0.4 -> 3.0.6 ``                                                                               |
| [`4843fd53`](https://github.com/NixOS/nixpkgs/commit/4843fd5379a1856a233145207c5cae16d23b6d3e) | `` maintainers/github-teams.json: Automated sync ``                                                      |
| [`7d79444c`](https://github.com/NixOS/nixpkgs/commit/7d79444cbcac6c1d67ba7ac9d338a17c9f09e58a) | `` build(deps): bump actions/upload-artifact from 5.0.0 to 6.0.0 ``                                      |
| [`e07088a3`](https://github.com/NixOS/nixpkgs/commit/e07088a305234ba7fa61345fa680da70c26a889c) | `` ci/github-script/bot: skip mergeability checks temporarily ``                                         |
| [`d5a32d4c`](https://github.com/NixOS/nixpkgs/commit/d5a32d4cbc2dcd1d403a40d0613d9da56b41d62e) | `` erlang_27: 27.3.4.5 -> 27.3.4.6 ``                                                                    |
| [`bc32bda8`](https://github.com/NixOS/nixpkgs/commit/bc32bda87920c58d7f5d65cf61416c30769eca4b) | `` erlang_27: 27.3.4.4 -> 27.3.4.5 ``                                                                    |
| [`484f446d`](https://github.com/NixOS/nixpkgs/commit/484f446dbae5cb1f8e286047f7b5822d9d959423) | `` erlang_26: 26.2.5.15 -> 26.2.5.16 ``                                                                  |
| [`69503cbd`](https://github.com/NixOS/nixpkgs/commit/69503cbdad314ed40c3802984f8b95f629f4c538) | `` vencord: 1.13.8 -> 1.13.9 ``                                                                          |
| [`7111de19`](https://github.com/NixOS/nixpkgs/commit/7111de19337613a6b821dec26eeb609af351c025) | `` linuxKernel.kernels.linux_lqx: 6.17.11 -> 6.17.12 ``                                                  |
| [`ae50965a`](https://github.com/NixOS/nixpkgs/commit/ae50965a47db91912d9e90edc0d8848492806437) | `` dim: 0-unstable-2023-12-29 -> 0-unstable-2025-09-21 ``                                                |
| [`dc552fc4`](https://github.com/NixOS/nixpkgs/commit/dc552fc4e56fcba97860070701b19ae62f29d275) | `` brave: 1.85.111 -> 1.85.116 ``                                                                        |
| [`20c8f6b3`](https://github.com/NixOS/nixpkgs/commit/20c8f6b34b1be4d9c6147341018a2387735e0ae1) | `` istat-menus: 7.10.4 -> 7.20 ``                                                                        |
| [`74c5de57`](https://github.com/NixOS/nixpkgs/commit/74c5de576549f0623cbd464e35b601322b6fb86b) | `` istat-menus: remove iedame ``                                                                         |
| [`6c59a6a4`](https://github.com/NixOS/nixpkgs/commit/6c59a6a4094d87b53ee9ebd7610e77555c793025) | `` istat-menus: conform descriptions to the standards ``                                                 |
| [`98ccdc99`](https://github.com/NixOS/nixpkgs/commit/98ccdc9919165bf1c0163ee8c6147e39c07951e0) | `` linux_xanmod_latest: 6.17.11 -> 6.17.12 ``                                                            |
| [`fe189b94`](https://github.com/NixOS/nixpkgs/commit/fe189b94111263e34a2d6908e7455f99c35178bb) | `` linux_xanmod: 6.12.61 -> 6.12.62 ``                                                                   |
| [`69c8b15e`](https://github.com/NixOS/nixpkgs/commit/69c8b15e36bfc586995f5ca01dff20f468bcbf8e) | `` vencord: 1.13.6 -> 1.13.8 ``                                                                          |
| [`4d43f356`](https://github.com/NixOS/nixpkgs/commit/4d43f3563011f2f1cf3022c288b2dfb054de0247) | `` google-chrome: 143.0.7499.40 -> 143.0.7499.109 ``                                                     |
| [`f3b9ebb1`](https://github.com/NixOS/nixpkgs/commit/f3b9ebb18ebd9f5842130280fe0234b79400bfa5) | `` google-chrome: add mdaniels5757 as co-maintainer ``                                                   |
| [`1dc8d954`](https://github.com/NixOS/nixpkgs/commit/1dc8d954521b6d5a73bc26a8165299b32bd43fda) | `` nextcloud-talk-desktop: actually use the patchelf that is passed as an argument ``                    |
| [`3cf0863c`](https://github.com/NixOS/nixpkgs/commit/3cf0863cff8c10f813bac9eb07a042d2489d17c3) | `` networkmanager: 1.52.1 -> 1.52.2 ``                                                                   |
| [`a4233c76`](https://github.com/NixOS/nixpkgs/commit/a4233c76834b22bb20ac4450da98e190bb86391c) | `` nixos/k3s: make auto-deploy-charts test standalone ``                                                 |
| [`b68cf95a`](https://github.com/NixOS/nixpkgs/commit/b68cf95a632df176bdc6ca72266c721d9908ef05) | `` networkmanager_strongswan: apply patch for CVE-2025-9615 ``                                           |
| [`74dfd787`](https://github.com/NixOS/nixpkgs/commit/74dfd78702cc288228eaf017936309ab47c859a1) | `` strongswan: apply patch for CVE-2025-9615 ``                                                          |
| [`63f003d8`](https://github.com/NixOS/nixpkgs/commit/63f003d89293bf9540f512c6809be2afbed5661a) | `` ci/treefmt: remove K3s test exclusion from yamlfmt ``                                                 |
| [`2b053443`](https://github.com/NixOS/nixpkgs/commit/2b053443b2b58d59f03046990d3a4b361e97c637) | `` linux_6_12: 6.12.61 -> 6.12.62 ``                                                                     |
| [`d8aa0efd`](https://github.com/NixOS/nixpkgs/commit/d8aa0efd81a3a98032e8555acc8f5a34b66e2bb1) | `` linux_6_17: 6.17.11 -> 6.17.12 ``                                                                     |
| [`b7787c10`](https://github.com/NixOS/nixpkgs/commit/b7787c109de8b5884d7e4d195ca07befea53e8b1) | `` linux_6_18: 6.18 -> 6.18.1 ``                                                                         |
| [`578f7d9c`](https://github.com/NixOS/nixpkgs/commit/578f7d9cdf90f30a9d3d9c8bfb3211a167a10a1f) | `` ungoogled-chromium: 143.0.7499.40-1 -> 143.0.7499.109-1 ``                                            |
| [`21f28f14`](https://github.com/NixOS/nixpkgs/commit/21f28f14616d51ce870806cef7dad855b663cb7b) | `` thunderbird-140-unwrapped: 140.5.0esr -> 140.6.0esr ``                                                |
| [`dd383416`](https://github.com/NixOS/nixpkgs/commit/dd38341641f91e7242384d12462a29bef187f7ed) | `` thunderbird-latest-bin-unwrapped: 145.0 -> 146.0 ``                                                   |
| [`45f02897`](https://github.com/NixOS/nixpkgs/commit/45f0289768624791a13c83e42d9cb8483af40ef4) | `` jenkins: 2.528.2 -> 2.528.3 ``                                                                        |
| [`2eb91a13`](https://github.com/NixOS/nixpkgs/commit/2eb91a133a95e274ba25bc12f6cf37048112a256) | `` nextcloudPackages: update ``                                                                          |
| [`da82fb8b`](https://github.com/NixOS/nixpkgs/commit/da82fb8b57c6d167405cdad3193f51c9a2db3dac) | `` nextcloud32: 32.0.2 -> 32.0.3 ``                                                                      |
| [`a2eeb296`](https://github.com/NixOS/nixpkgs/commit/a2eeb29665f31d684c6d8b1166ab2ead9d1c9f34) | `` nextcloud31: 31.0.11 -> 31.0.12 ``                                                                    |
| [`b78a12f9`](https://github.com/NixOS/nixpkgs/commit/b78a12f99f7f34db28d6025c404274eba90e7b6c) | `` chromium,chromedriver: 143.0.7499.40 -> 143.0.7499.109 ``                                             |
| [`c2dcb3a5`](https://github.com/NixOS/nixpkgs/commit/c2dcb3a50542fb0b4102f9b63909f596122151c0) | `` jenkins: 2.528.1 -> 2.528.2 ``                                                                        |
| [`3ac84a4a`](https://github.com/NixOS/nixpkgs/commit/3ac84a4a1f4b082b7e32ebafd47e3b1a0a4da81a) | `` gemstash: regenerate lockfile ``                                                                      |
| [`e3203ade`](https://github.com/NixOS/nixpkgs/commit/e3203ade1d2cfb10d2ec3c3e0145832a64a8f8dd) | `` vscode-extensions.leonardssh.vscord: 5.3.5 -> 5.3.8 ``                                                |
| [`5b438b6a`](https://github.com/NixOS/nixpkgs/commit/5b438b6a8607291268b5cd20d1fe8a350028b1da) | `` gitlab: 18.6.1 -> 18.6.2 ``                                                                           |
| [`b8bfbda0`](https://github.com/NixOS/nixpkgs/commit/b8bfbda0751f6b52f9370e54bd98b85b0e4b2c9b) | `` hue-cli: update json dependency ``                                                                    |
| [`139e9fd6`](https://github.com/NixOS/nixpkgs/commit/139e9fd6388ae137bba142dbb944aa3e95ebd5f7) | `` nss_latest: 3.119 -> 3.119.1 ``                                                                       |
| [`8b2c37f6`](https://github.com/NixOS/nixpkgs/commit/8b2c37f61d50f7ca9d6e0b632144c3ae1470fdaf) | `` frigate: mark vulnerable due to GHSA-vg28-83rp-8xx4 ``                                                |
| [`700a5b82`](https://github.com/NixOS/nixpkgs/commit/700a5b8289620bcb32f0ebece2d0e789d2a722de) | `` teams.ci: remove wolfgangwalther ``                                                                   |
| [`91228fb4`](https://github.com/NixOS/nixpkgs/commit/91228fb409e112dccb5f427dcf960ab5314cfec4) | `` red: mark rebol unfree ``                                                                             |
| [`caa39036`](https://github.com/NixOS/nixpkgs/commit/caa39036c063b31637b82f7cd9d98c660b1c4878) | `` linuxKernel.kernels.linux_lqx: 6.17.9 -> 6.17.11 ``                                                   |
| [`bc082fa9`](https://github.com/NixOS/nixpkgs/commit/bc082fa91b09641655b018c5575362a1ebbff158) | `` tutanota-desktop: 315.251202.0 -> 315.251204.0 ``                                                     |
| [`07261b53`](https://github.com/NixOS/nixpkgs/commit/07261b536d158a0e224394b550a70cbf58739da5) | `` mullvad-browser: 15.0.2 -> 15.0.3 ``                                                                  |