### PR TITLE
chore(flake/disko): `ec8eabe0` -> `ff8702b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1764017209,
-        "narHash": "sha256-RoJGCtKExXXkNCZUmmxezG3eOczEOTBw38DaZGSYJC0=",
+        "lastModified": 1781152676,
+        "narHash": "sha256-RxWs5ND31KzTG7wvMM+PMfUjyNpmIEr999lqNARaM5o=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "ec8eabe00c4ee9a2ddc50162c125f0ec2a7099e1",
+        "rev": "ff8702b4de27f72b4c78573dfb89ec74e36abdf1",
         "type": "github"
       },
       "original": {
@@ -398,11 +398,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1752596105,
-        "narHash": "sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k=",
+        "lastModified": 1780930886,
+        "narHash": "sha256-rppURzHviaQN131F+nLiLdGfcb0uCd9gGP0E5+iw9MI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dab3a6e781554f965bde3def0aa2fda4eb8f1708",
+        "rev": "8c3cede7ddc26bd659d2d383b5610efbd2c7a16e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                         |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`bb8b1838`](https://github.com/nix-community/disko/commit/bb8b1838a7a9142a05f5e368c8f5811158834513) | `` [create-pull-request] automated change ``                                    |
| [`85d7f921`](https://github.com/nix-community/disko/commit/85d7f921cd7bfb0a1fe02a711d4eb396d2e05f3b) | `` [create-pull-request] automated change ``                                    |
| [`0a3481ad`](https://github.com/nix-community/disko/commit/0a3481adf8d7b51110fd26e3928fc56ffe976ee3) | `` [create-pull-request] automated change ``                                    |
| [`8ff2716d`](https://github.com/nix-community/disko/commit/8ff2716d01dd00c25abff97da485dca4282e5ff1) | `` Fix(test); Add idempotent unmounting to tests of example configuration ``    |
| [`2c40806b`](https://github.com/nix-community/disko/commit/2c40806b9370ffbbfcf15487cd714173c7ac8811) | `` feat(mdadm); start mdadm before mounting datasets ``                         |
| [`5c7406ec`](https://github.com/nix-community/disko/commit/5c7406ecc5dd63816f0d8c30bef0339f8d680390) | `` Fix(zfs_volume); Volume mount/unmount with encryption ``                     |
| [`03e19b4f`](https://github.com/nix-community/disko/commit/03e19b4f67f1f28ee5fff660ea7cdb2489b03597) | `` Feature(zfs_volume); Add internal option for fully qualified zfs path ``     |
| [`85e79db1`](https://github.com/nix-community/disko/commit/85e79db1bd8e615ccfd265c57624a39d3a18927d) | `` [create-pull-request] automated change ``                                    |
| [`a1b9822f`](https://github.com/nix-community/disko/commit/a1b9822f032747189a83688253043f563619d7ce) | `` luks: add test for FIDO2 ``                                                  |
| [`640d1dd8`](https://github.com/nix-community/disko/commit/640d1dd8e00f1522b4f34cdddfcce199d0159c07) | `` tests: fix enabling Canokey ``                                               |
| [`7da3d737`](https://github.com/nix-community/disko/commit/7da3d737f71783d224c94096d517d51632002c93) | `` luks: fix not asking for password in format script ``                        |
| [`0d15976f`](https://github.com/nix-community/disko/commit/0d15976fce51cac59449ebf663070055bb809fcc) | `` luks: don't depend on autogenerated password ``                              |
| [`d60b2b5e`](https://github.com/nix-community/disko/commit/d60b2b5e001f7f476acba9ec2eeceb70bc9e759d) | `` luks: improve idempotency for enrolling FIDO2 ``                             |
| [`6795806d`](https://github.com/nix-community/disko/commit/6795806dbc34b14235736b19bee78f97c1f4f044) | `` tests/zfs-with-vdevs: fix not all vdevs detected ``                          |
| [`e40d944d`](https://github.com/nix-community/disko/commit/e40d944decb3681687534f25fe7e841d5b7cb98b) | `` tests/bcachefs: read filesystem metadata from sysfs ``                       |
| [`40318644`](https://github.com/nix-community/disko/commit/403186440c93f52878768bca4602f35e3cafbc5b) | `` lib/types/bcachefs_filesystem: tolerate already-unlocked filesystem ``       |
| [`21d9daf2`](https://github.com/nix-community/disko/commit/21d9daf2552f32c531a6c9fbbc21a9fdfdf82df0) | `` tests/disko-install: drop default value for oldmachine ``                    |
| [`baf057aa`](https://github.com/nix-community/disko/commit/baf057aa5b861c549b9ee92807e43ae49ab50cf6) | `` lib/tests: stage the test password file under systemd initrd ``              |
| [`8ebce632`](https://github.com/nix-community/disko/commit/8ebce63228c7fe1b622d4256dbf579ae17482054) | `` tests: register dynamically-created machines with the driver ``              |
| [`17e2eee8`](https://github.com/nix-community/disko/commit/17e2eee82276dc631aef465e799d01a1b1421649) | `` flake: bump nixpkgs ``                                                       |
| [`a6a0a068`](https://github.com/nix-community/disko/commit/a6a0a068c27441441c9fb556a79e87b0e3b7fe08) | `` devShells: expose disko CLI ``                                               |
| [`4c810916`](https://github.com/nix-community/disko/commit/4c81091646eca9d27d8545df9aa992b73f39eac0) | `` make-disk-image: don't build native `/etc`. ``                               |
| [`1be7610e`](https://github.com/nix-community/disko/commit/1be7610ee9df28d1c4b0a0effad17792c6d94e3d) | `` Remove alias usage ``                                                        |
| [`b02541f2`](https://github.com/nix-community/disko/commit/b02541f2d0767361b855be341b4b1349c88d4b17) | `` feat: add FIDO2 & recovery support for LUKS ``                               |
| [`47deadb7`](https://github.com/nix-community/disko/commit/47deadb7c169e70794262d2cb6de5f51d010d386) | `` Fix failing ShellCheck for LUKS partitions ``                                |
| [`dffa2001`](https://github.com/nix-community/disko/commit/dffa2001ceebdc570f49d4e4a70f38636568458d) | `` add canary test for btrfs on mdadm wipes ``                                  |
| [`669ca49a`](https://github.com/nix-community/disko/commit/669ca49ae4b1355e569db99dd3182d48c98979d9) | `` disk-deactivate: wipe raid arrays before stopping them ``                    |
| [`c3b6033c`](https://github.com/nix-community/disko/commit/c3b6033c65084538bb9e5f9001d26fcf7ba5a848) | `` [create-pull-request] automated change ``                                    |
| [`0fce0ab2`](https://github.com/nix-community/disko/commit/0fce0ab2bdbc02a4587a0ccfc395365d25da0e8d) | `` [create-pull-request] automated change ``                                    |
| [`0597c926`](https://github.com/nix-community/disko/commit/0597c9262ed91d1e8359fc06dd48afc6fb457f7c) | `` Mount file-systems in the correct order ``                                   |
| [`089cf54f`](https://github.com/nix-community/disko/commit/089cf54ff388fe00f99485159894197fd1bc8077) | `` fix: correct uncommitted spelling in release script ``                       |
| [`29d01f42`](https://github.com/nix-community/disko/commit/29d01f42458ab925439e7ec10f2b9c17cbd3526c) | `` test: fix typo in mkOverride comment ``                                      |
| [`6be22290`](https://github.com/nix-community/disko/commit/6be2229087cdb3c3decbfb9c2513219f57fc1c3e) | `` fix: correct typo in disk image help text ``                                 |
| [`8b94abcd`](https://github.com/nix-community/disko/commit/8b94abcd238d33dc7020b3be96b3dccf97c252e3) | `` fix: correct deprecation typo in lib default ``                              |
| [`f1bcd070`](https://github.com/nix-community/disko/commit/f1bcd0707b02c333526b54d2aa88981c6a8df7e6) | `` docs: fix typo in table to gpt guide ``                                      |
| [`bc23e2e8`](https://github.com/nix-community/disko/commit/bc23e2e89c9b49f8cebc54c3e3615bd1a57eaa5d) | `` docs: fix typo in interactive vm guide ``                                    |
| [`d17b956f`](https://github.com/nix-community/disko/commit/d17b956f9426d18578c4fa3fb5ca8d8f9d98cef3) | `` docs: fix typos in disko-images ``                                           |
| [`dff80bbc`](https://github.com/nix-community/disko/commit/dff80bbcd953b1bbfcddea598ce513cfc66eb51c) | `` Escape ZFS args ``                                                           |
| [`c0e77ffb`](https://github.com/nix-community/disko/commit/c0e77ffb5218dc9d6d8db6b39732c54fe400dbe9) | `` [create-pull-request] automated change ``                                    |
| [`5abb5af1`](https://github.com/nix-community/disko/commit/5abb5af1de3b82ab321b48ec2e21e8c3e92f68b7) | `` build(deps): bump peter-evans/create-pull-request from 7 to 8 ``             |
| [`061761ee`](https://github.com/nix-community/disko/commit/061761eef45bca115a750c5afe8c58faed9f8bc7) | `` [create-pull-request] automated change ``                                    |
| [`8383dadd`](https://github.com/nix-community/disko/commit/8383dadd063d1009d5d7eb2db9f62449d123a207) | `` [create-pull-request] automated change ``                                    |
| [`04d390e4`](https://github.com/nix-community/disko/commit/04d390e4ff1f1ab6cc454f92beaafea4509bbc48) | `` ci: fix PRs not merged automatically redux ``                                |
| [`cd3861a0`](https://github.com/nix-community/disko/commit/cd3861a0f37ab5e56f983baf9aea8901a0fd90e8) | `` mergify: drop ``                                                             |
| [`ed94610e`](https://github.com/nix-community/disko/commit/ed94610e221197b5fad1eda71cccc7456783db9d) | `` flake.lock: Update ``                                                        |
| [`41fd3909`](https://github.com/nix-community/disko/commit/41fd3909e25cc4cc600db52b979e1171455c138c) | `` ci: fix PRs not getting merged automatically ``                              |
| [`01a4a362`](https://github.com/nix-community/disko/commit/01a4a3621f420036f0494eb7f52b240768af6231) | `` flake.lock: Update ``                                                        |
| [`00395d18`](https://github.com/nix-community/disko/commit/00395d188e3594a1507f214a2f15d4ce5c07cb28) | `` create-release: don't require SSH auth ``                                    |
| [`d3b70396`](https://github.com/nix-community/disko/commit/d3b7039649dd33418f7c6844b9c1440632e0676b) | `` create-release: make all changes go through a PR ``                          |
| [`4a334b87`](https://github.com/nix-community/disko/commit/4a334b87cab2b920cf107dd7b67e687dafffae64) | `` create-release: fix version not updated correctly ``                         |
| [`9c1eaf1e`](https://github.com/nix-community/disko/commit/9c1eaf1e0943c00812d67b21679e8969ff80a910) | `` release: reset released flag ``                                              |
| [`de570873`](https://github.com/nix-community/disko/commit/de5708739256238fb912c62f03988815db89ec9a) | `` release: v1.13.0 ``                                                          |
| [`ea8eec39`](https://github.com/nix-community/disko/commit/ea8eec3908cac790acfa31f5492044fc74132002) | `` treefmt: stop using old attr ``                                              |
| [`6fcb8c60`](https://github.com/nix-community/disko/commit/6fcb8c602b0589759b0fde15c627c8d2ceb2d5a8) | `` scripts: avoid running `create-release` directly ``                          |
| [`e0bbbb88`](https://github.com/nix-community/disko/commit/e0bbbb8886d0630402e1a5882134a1a772c91fed) | `` tests/bcachefs: unlock before running `show-super` ``                        |
| [`8d2eb19e`](https://github.com/nix-community/disko/commit/8d2eb19e35d8b96bad20767c93a9823d3afaa617) | `` tests/bcachefs: fix invalid syntax warning ``                                |
| [`28254e49`](https://github.com/nix-community/disko/commit/28254e49c4d3fa7e9e32c445a9fff9f902555680) | `` tests/bcachefs: switch to `linuxPackages_latest` ``                          |
| [`ec90d55f`](https://github.com/nix-community/disko/commit/ec90d55ff3bc330759d3bfbfc254985e08c96b1f) | `` lib: pass `stdenv` to `qemu-common` not `pkgs` ``                            |
| [`5ae05d98`](https://github.com/nix-community/disko/commit/5ae05d98d2bebc0a9521c9fc89bd2e5cffa05926) | `` treewide: reformat ``                                                        |
| [`0062b1a1`](https://github.com/nix-community/disko/commit/0062b1a1de100e2fb38353b8aff690b1a591d34e) | `` flake.lock: Update ``                                                        |
| [`558e8465`](https://github.com/nix-community/disko/commit/558e84658d0eafc812497542ad6ca0d9654b3b0f) | `` example: add comments as warning about legacy table type ``                  |
| [`91650644`](https://github.com/nix-community/disko/commit/916506443ecd0d0b4a0f4cf9d40a3c22ce39b378) | `` make-disk-image: quote $rootMountPoint for consistency ``                    |
| [`6b172212`](https://github.com/nix-community/disko/commit/6b172212b632093b7b04397f55a4365f3712ecca) | `` disko-install: resolve symlinks in mount point path ``                       |
| [`7194cfe5`](https://github.com/nix-community/disko/commit/7194cfe5b7a3660726b0fe7296070eaef601cae9) | `` downgrade the priority of kernelPackages set from imageBuilder ``            |
| [`be1a6b8a`](https://github.com/nix-community/disko/commit/be1a6b8a05afdd5d5fa69fcaf3c4ead7014c9fd8) | `` bcachefs: fix subvolume mounting ``                                          |
| [`4250f1ce`](https://github.com/nix-community/disko/commit/4250f1ce5ff7837cdb465f0e270415f9cc41cfc4) | `` tests/disko-install: fix `drvPath` missing from dependencies ``              |
| [`f2bba803`](https://github.com/nix-community/disko/commit/f2bba803a7669cf38591c351ee77009ea55f31ef) | `` treewide: reformat ``                                                        |
| [`386f070c`](https://github.com/nix-community/disko/commit/386f070c74568b707a4765a27080201111e7b6b3) | `` flake: bump Nixpkgs ``                                                       |
| [`d64e5cdc`](https://github.com/nix-community/disko/commit/d64e5cdca35b5fad7c504f615357a7afe6d9c49e) | `` feat(mdadm): add test for mdadm with extraArgs ``                            |
| [`e65362ce`](https://github.com/nix-community/disko/commit/e65362ceef7861ff3e9eb507ff3a1af56b0673cf) | `` feat(mdadm): add extraArgs option ``                                         |
| [`d307bf82`](https://github.com/nix-community/disko/commit/d307bf82e1ca4cd4aca8f48ef181245256b5fb62) | `` docs: typo in testing ``                                                     |
| [`8e68aa81`](https://github.com/nix-community/disko/commit/8e68aa819d6a9964c8ac45172e68b943b597c52a) | `` disko-images: add copyNixStoreThreads option for configurable parallelism `` |
| [`10cdd632`](https://github.com/nix-community/disko/commit/10cdd63203395fe9a9e83b5e9e73e99459f0c10b) | `` disko-images: switch back from xcp to cp for improved stability ``           |
| [`5a88a6ec`](https://github.com/nix-community/disko/commit/5a88a6eceb8fd732b983e72b732f6f4b8269bef3) | `` build(deps): bump DeterminateSystems/update-flake-lock from 27 to 28 ``      |
| [`2055a08f`](https://github.com/nix-community/disko/commit/2055a08fd0e2fd41318279a5355eb8a161accf26) | `` flake: export lib with references to nixpkgs input ``                        |
| [`aecba248`](https://github.com/nix-community/disko/commit/aecba248f9a7d68c5d1ed15de2d1c8a4c994a3c5) | `` Correct npins import example ``                                              |
| [`590de6c2`](https://github.com/nix-community/disko/commit/590de6c248a61dbbb317ea42dd1e7e418a3f3430) | `` Better handling of bind mounts in make-disk-image ``                         |